### PR TITLE
fix: Eprint detail page validation and field label resolution

### DIFF
--- a/lexicons/pub/chive/eprint/getSubmission.json
+++ b/lexicons/pub/chive/eprint/getSubmission.json
@@ -36,8 +36,8 @@
               "format": "cid"
             },
             "value": {
-              "type": "ref",
-              "ref": "pub.chive.eprint.submission"
+              "type": "unknown",
+              "description": "The eprint submission record. Must contain $type field."
             },
             "indexedAt": {
               "type": "string",

--- a/src/index.ts
+++ b/src/index.ts
@@ -378,6 +378,7 @@ function createServices(
     identity: identityResolver,
     logger,
     tagManager, // Auto-generate tags from eprint keywords
+    graph: graphAdapter, // Resolve field labels from knowledge graph
   });
 
   const searchService = new SearchService({

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -326,6 +326,7 @@ async function main(): Promise<void> {
       identity: identityResolver,
       logger,
       tagManager, // Auto-generate tags from eprint keywords
+      graph: graphAdapter, // Resolve field labels from knowledge graph
     });
 
     const reviewService = new ReviewService({

--- a/src/types/interfaces/graph.interface.ts
+++ b/src/types/interfaces/graph.interface.ts
@@ -148,6 +148,15 @@ export interface IGraphDatabase {
   getNode(id: string, subkind?: string): Promise<GraphNode | null>;
 
   /**
+   * Gets multiple nodes by IDs in a single query.
+   *
+   * @param ids - Node identifiers to fetch
+   * @param subkind - Optional subkind filter
+   * @returns Map of id to GraphNode (missing nodes are not included)
+   */
+  getNodesByIds(ids: readonly string[], subkind?: string): Promise<Map<string, GraphNode>>;
+
+  /**
    * Lists nodes with filtering.
    */
   listNodes(options: NodeSearchOptions): Promise<NodeSearchResult>;

--- a/tests/compliance/api-layer-compliance.test.ts
+++ b/tests/compliance/api-layer-compliance.test.ts
@@ -830,7 +830,7 @@ describe('API Layer ATProto Compliance', () => {
 
       // CRITICAL: Document MUST be BlobRef structure in value.document
       expect(body.value.document).toBeDefined();
-      const document = body.value.document as unknown as Record<string, unknown>;
+      const document = body.value.document as Record<string, unknown>;
       expect(document.$type).toBe('blob');
       expect(document.ref).toBeDefined();
       expect(document.mimeType).toBe('application/pdf');
@@ -852,7 +852,7 @@ describe('API Layer ATProto Compliance', () => {
       const body = (await res.json()) as EprintResponse;
 
       // CRITICAL: No inline blob data fields (these properties should not exist on BlobRef)
-      const document = body.value.document as unknown as Record<string, unknown>;
+      const document = body.value.document as Record<string, unknown>;
       expect(document.data).toBeUndefined();
       expect(document.content).toBeUndefined();
       expect(document.buffer).toBeUndefined();
@@ -1098,7 +1098,7 @@ describe('API Layer ATProto Compliance', () => {
 
       // User should be able to fetch blob from PDS using CID in value.document
       // ATProto BlobRef format: { $type: 'blob', ref: { $link: string }, mimeType, size }
-      const document = body.value.document as unknown as Record<string, unknown>;
+      const document = body.value.document as Record<string, unknown>;
       expect(document.ref).toBeDefined();
       // ref is a $link object in ATProto format
       const refObj = document.ref as { $link?: string } | string;

--- a/tests/integration/api/rest/v1/eprints.test.ts
+++ b/tests/integration/api/rest/v1/eprints.test.ts
@@ -446,7 +446,7 @@ describe('REST v1/eprints Endpoints Integration', () => {
 
       // Verify BlobRef structure in value.document
       expect(body.value.document).toBeDefined();
-      const document = body.value.document as unknown as Record<string, unknown>;
+      const document = body.value.document as Record<string, unknown>;
       expect(document.$type).toBe('blob');
       expect(document.ref).toBeDefined();
 

--- a/tests/integration/api/xrpc/eprint.test.ts
+++ b/tests/integration/api/xrpc/eprint.test.ts
@@ -456,7 +456,7 @@ describe('XRPC Eprint Endpoints Integration', () => {
 
       // Verify BlobRef structure in value.document
       expect(body.value.document).toBeDefined();
-      const document = body.value.document as unknown as Record<string, unknown>;
+      const document = body.value.document as Record<string, unknown>;
       expect(document.$type).toBe('blob');
       expect(document.ref).toBeDefined();
       expect(document.mimeType).toBe('application/pdf');

--- a/tests/unit/api/handlers/xrpc/eprint.test.ts
+++ b/tests/unit/api/handlers/xrpc/eprint.test.ts
@@ -160,7 +160,9 @@ describe('XRPC Eprint Handlers', () => {
       });
 
       expect(result.body.uri).toBe(eprint.uri);
-      expect(result.body.value.title).toBe(eprint.title);
+      // value is unknown type per ATProto pattern (like com.atproto.repo.getRecord)
+      const value = result.body.value as { title: string };
+      expect(value.title).toBe(eprint.title);
 
       // Verify ATProto compliance: pdsUrl field
       expect(result.body.pdsUrl).toBeDefined();
@@ -179,11 +181,13 @@ describe('XRPC Eprint Handlers', () => {
         c: mockContext as never,
       });
 
+      // value is unknown type per ATProto pattern (like com.atproto.repo.getRecord)
+      const value = result.body.value as { document: { mimeType: string; size: number } };
       // Verify document blob - it's now a BlobRef instance which has cid, mimeType, size
-      expect(result.body.value.document).toBeDefined();
+      expect(value.document).toBeDefined();
       // BlobRef from @atproto/lexicon stores cid as CID type
-      expect(result.body.value.document.mimeType).toBe('application/pdf');
-      expect(result.body.value.document.size).toBe(1024000);
+      expect(value.document.mimeType).toBe('application/pdf');
+      expect(value.document.size).toBe(1024000);
     });
 
     it('includes version history', async () => {

--- a/tests/unit/services/eprint/eprint-service.test.ts
+++ b/tests/unit/services/eprint/eprint-service.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Unit tests for EprintService.
+ *
+ * @remarks
+ * Tests eprint indexing, retrieval, and field label resolution functionality.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { EprintService, type RecordMetadata } from '@/services/eprint/eprint-service.js';
+import type { AtUri, CID, DID, Timestamp } from '@/types/atproto.js';
+import type { IGraphDatabase, GraphNode } from '@/types/interfaces/graph.interface.js';
+import type { IIdentityResolver } from '@/types/interfaces/identity.interface.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+import type { IRepository } from '@/types/interfaces/repository.interface.js';
+import type { ISearchEngine } from '@/types/interfaces/search.interface.js';
+import type { IStorageBackend } from '@/types/interfaces/storage.interface.js';
+import type { Eprint } from '@/types/models/eprint.js';
+
+const createMockLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+const createMockStorage = () => ({
+  storeEprint: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+  getEprint: vi.fn(),
+  getEprintsByAuthor: vi.fn(),
+  countEprintsByAuthor: vi.fn(),
+  trackPDSSource: vi.fn().mockResolvedValue(undefined),
+  getRecordsNotSyncedSince: vi.fn(),
+  isStale: vi.fn(),
+  listEprintUris: vi.fn(),
+  findByExternalIds: vi.fn(),
+});
+
+const createMockSearch = () => ({
+  indexEprint: vi.fn().mockResolvedValue(undefined),
+  deleteDocument: vi.fn().mockResolvedValue(undefined),
+  search: vi.fn(),
+});
+
+const createMockRepository = () => ({
+  getRecord: vi.fn(),
+  listRecords: vi.fn(),
+  getBlob: vi.fn(),
+});
+
+const createMockIdentity = () => ({
+  resolveDID: vi.fn().mockResolvedValue(undefined),
+  resolveHandle: vi.fn(),
+  getPDSEndpoint: vi.fn(),
+});
+
+const createMockGraph = () => ({
+  getNodesByIds: vi.fn(),
+  getNodeByUri: vi.fn(),
+  getNode: vi.fn(),
+  upsertNode: vi.fn(),
+  listNodes: vi.fn(),
+  searchNodes: vi.fn(),
+  createEdge: vi.fn(),
+  getEdges: vi.fn(),
+  findRelatedNodes: vi.fn(),
+  getHierarchy: vi.fn(),
+  queryByFacets: vi.fn(),
+  aggregateFacets: vi.fn(),
+  getProposalsForNode: vi.fn(),
+  listProposals: vi.fn(),
+  getProposal: vi.fn(),
+  createVote: vi.fn(),
+  getVotesForProposal: vi.fn(),
+  calculateConsensus: vi.fn(),
+  createProposal: vi.fn(),
+  deleteNode: vi.fn(),
+});
+
+const createMockEprint = (overrides?: Partial<Eprint>): Eprint => ({
+  uri: 'at://did:plc:author123/pub.chive.eprint.submission/abc123' as AtUri,
+  cid: 'bafyreigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi' as CID,
+  title: 'Test Eprint Title',
+  abstract: {
+    type: 'RichText',
+    items: [{ type: 'text', content: 'This is the abstract.' }],
+    format: 'application/x-chive-gloss+json',
+  },
+  abstractPlainText: 'This is the abstract.',
+  documentBlobRef: {
+    $type: 'blob',
+    ref: 'bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku' as CID,
+    mimeType: 'application/pdf',
+    size: 1024000,
+  },
+  documentFormat: 'pdf',
+  authors: [
+    {
+      did: 'did:plc:author123' as DID,
+      name: 'Test Author',
+      order: 1,
+      affiliations: [],
+      contributions: [],
+      isCorrespondingAuthor: true,
+      isHighlighted: false,
+    },
+  ],
+  submittedBy: 'did:plc:author123' as DID,
+  createdAt: Date.now() as Timestamp,
+  license: 'CC-BY-4.0',
+  keywords: ['test', 'eprint'],
+  facets: [],
+  fields: undefined,
+  version: 1,
+  publicationStatus: 'eprint',
+  ...overrides,
+});
+
+const createMockMetadata = (overrides?: Partial<RecordMetadata>): RecordMetadata => ({
+  uri: 'at://did:plc:author123/pub.chive.eprint.submission/abc123' as AtUri,
+  cid: 'bafyreigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi' as CID,
+  pdsUrl: 'https://pds.example.com',
+  indexedAt: new Date('2024-01-15T10:00:00Z'),
+  ...overrides,
+});
+
+describe('EprintService', () => {
+  let storage: ReturnType<typeof createMockStorage>;
+  let search: ReturnType<typeof createMockSearch>;
+  let repository: ReturnType<typeof createMockRepository>;
+  let identity: ReturnType<typeof createMockIdentity>;
+  let graph: ReturnType<typeof createMockGraph>;
+  let logger: ILogger;
+  let service: EprintService;
+
+  beforeEach(() => {
+    storage = createMockStorage();
+    search = createMockSearch();
+    repository = createMockRepository();
+    identity = createMockIdentity();
+    graph = createMockGraph();
+    logger = createMockLogger();
+
+    service = new EprintService({
+      storage: storage as unknown as IStorageBackend,
+      search: search as unknown as ISearchEngine,
+      repository: repository as unknown as IRepository,
+      identity: identity as unknown as IIdentityResolver,
+      logger,
+      graph: graph as unknown as IGraphDatabase,
+    });
+  });
+
+  describe('indexEprint', () => {
+    it('indexes an eprint without fields', async () => {
+      const eprint = createMockEprint();
+      const metadata = createMockMetadata();
+
+      const result = await service.indexEprint(eprint, metadata);
+
+      expect(result.ok).toBe(true);
+      expect(storage.storeEprint).toHaveBeenCalledTimes(1);
+      expect(search.indexEprint).toHaveBeenCalledTimes(1);
+      expect(graph.getNodesByIds).not.toHaveBeenCalled();
+    });
+
+    it('resolves field labels from knowledge graph when fields are present', async () => {
+      const fields = [
+        { uri: 'field-uuid-1', label: 'field-uuid-1', id: 'field-uuid-1' },
+        { uri: 'field-uuid-2', label: 'field-uuid-2', id: 'field-uuid-2' },
+      ];
+      const eprint = createMockEprint({ fields });
+      const metadata = createMockMetadata();
+
+      // Mock graph to return resolved labels
+      const nodeMap = new Map<string, GraphNode>();
+      nodeMap.set('field-uuid-1', {
+        id: 'field-uuid-1',
+        uri: 'at://graph/field/1' as AtUri,
+        kind: 'type',
+        subkind: 'field',
+        label: 'Computational Linguistics',
+        status: 'established',
+        createdAt: new Date(),
+      });
+      nodeMap.set('field-uuid-2', {
+        id: 'field-uuid-2',
+        uri: 'at://graph/field/2' as AtUri,
+        kind: 'type',
+        subkind: 'field',
+        label: 'Natural Language Processing',
+        status: 'established',
+        createdAt: new Date(),
+      });
+      graph.getNodesByIds.mockResolvedValue(nodeMap);
+
+      const result = await service.indexEprint(eprint, metadata);
+
+      expect(result.ok).toBe(true);
+      expect(graph.getNodesByIds).toHaveBeenCalledWith(['field-uuid-1', 'field-uuid-2'], 'field');
+
+      // Verify storeEprint was called with resolved labels
+      expect(storage.storeEprint).toHaveBeenCalledTimes(1);
+      const storeCall = storage.storeEprint.mock.calls[0]?.[0] as { fields: unknown };
+      expect(storeCall.fields).toEqual([
+        { uri: 'field-uuid-1', label: 'Computational Linguistics', id: 'field-uuid-1' },
+        { uri: 'field-uuid-2', label: 'Natural Language Processing', id: 'field-uuid-2' },
+      ]);
+    });
+
+    it('falls back to URI as label when field not found in graph', async () => {
+      const fields = [
+        { uri: 'field-uuid-1', label: 'field-uuid-1', id: 'field-uuid-1' },
+        { uri: 'field-uuid-unknown', label: 'field-uuid-unknown', id: 'field-uuid-unknown' },
+      ];
+      const eprint = createMockEprint({ fields });
+      const metadata = createMockMetadata();
+
+      // Mock graph to return only one field
+      const nodeMap = new Map<string, GraphNode>();
+      nodeMap.set('field-uuid-1', {
+        id: 'field-uuid-1',
+        uri: 'at://graph/field/1' as AtUri,
+        kind: 'type',
+        subkind: 'field',
+        label: 'Computational Linguistics',
+        status: 'established',
+        createdAt: new Date(),
+      });
+      // field-uuid-unknown is NOT in the map
+      graph.getNodesByIds.mockResolvedValue(nodeMap);
+
+      const result = await service.indexEprint(eprint, metadata);
+
+      expect(result.ok).toBe(true);
+
+      // Verify storeEprint was called - found field gets resolved, unknown keeps URI
+      expect(storage.storeEprint).toHaveBeenCalledTimes(1);
+      const storeCall = storage.storeEprint.mock.calls[0]?.[0] as { fields: unknown };
+      expect(storeCall.fields).toEqual([
+        { uri: 'field-uuid-1', label: 'Computational Linguistics', id: 'field-uuid-1' },
+        { uri: 'field-uuid-unknown', label: 'field-uuid-unknown', id: 'field-uuid-unknown' },
+      ]);
+    });
+
+    it('handles graph errors gracefully and falls back to URIs', async () => {
+      const fields = [{ uri: 'field-uuid-1', label: 'field-uuid-1', id: 'field-uuid-1' }];
+      const eprint = createMockEprint({ fields });
+      const metadata = createMockMetadata();
+
+      // Mock graph to throw error
+      graph.getNodesByIds.mockRejectedValue(new Error('Graph connection failed'));
+
+      const result = await service.indexEprint(eprint, metadata);
+
+      expect(result.ok).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to resolve field labels, using URIs as fallback',
+        expect.objectContaining({ fieldCount: 1 })
+      );
+
+      // Verify storeEprint was still called with original fields
+      expect(storage.storeEprint).toHaveBeenCalledTimes(1);
+      const storeCall = storage.storeEprint.mock.calls[0]?.[0] as { fields: unknown };
+      expect(storeCall.fields).toEqual(fields);
+    });
+
+    it('works without graph service configured', async () => {
+      // Create service without graph
+      const serviceWithoutGraph = new EprintService({
+        storage: storage as unknown as IStorageBackend,
+        search: search as unknown as ISearchEngine,
+        repository: repository as unknown as IRepository,
+        identity: identity as unknown as IIdentityResolver,
+        logger,
+        // no graph
+      });
+
+      const fields = [{ uri: 'field-uuid-1', label: 'field-uuid-1', id: 'field-uuid-1' }];
+      const eprint = createMockEprint({ fields });
+      const metadata = createMockMetadata();
+
+      const result = await serviceWithoutGraph.indexEprint(eprint, metadata);
+
+      expect(result.ok).toBe(true);
+      expect(graph.getNodesByIds).not.toHaveBeenCalled();
+
+      // Fields should be stored as-is (no label resolution)
+      expect(storage.storeEprint).toHaveBeenCalledTimes(1);
+      const storeCall = storage.storeEprint.mock.calls[0]?.[0] as { fields: unknown };
+      expect(storeCall.fields).toEqual(fields);
+    });
+
+    it('handles storage errors', async () => {
+      const eprint = createMockEprint();
+      const metadata = createMockMetadata();
+
+      storage.storeEprint.mockResolvedValue({
+        ok: false,
+        error: { message: 'Database connection failed' },
+      });
+
+      const result = await service.indexEprint(eprint, metadata);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error?.message).toContain('Database connection failed');
+      }
+    });
+  });
+
+  describe('getEprint', () => {
+    it('returns null when eprint not found', async () => {
+      storage.getEprint.mockResolvedValue(null);
+
+      const result = await service.getEprint(
+        'at://did:plc:notfound/pub.chive.eprint.submission/xyz' as AtUri
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns eprint with versions and metrics', async () => {
+      const createdAt = new Date('2024-01-15T10:00:00Z');
+      const storedEprint = {
+        uri: 'at://did:plc:author123/pub.chive.eprint.submission/abc123' as AtUri,
+        cid: 'bafyrei123' as CID,
+        title: 'Test Eprint',
+        abstract: { type: 'RichText', items: [], format: 'application/x-chive-gloss+json' },
+        abstractPlainText: '',
+        authors: [],
+        submittedBy: 'did:plc:author123' as DID,
+        license: 'CC-BY-4.0',
+        documentBlobRef: {
+          $type: 'blob',
+          ref: 'bafkrei123',
+          mimeType: 'application/pdf',
+          size: 1000,
+        },
+        documentFormat: 'pdf',
+        pdsUrl: 'https://pds.example.com',
+        indexedAt: new Date(),
+        createdAt,
+        version: 1,
+      };
+      storage.getEprint.mockResolvedValue(storedEprint);
+
+      const result = await service.getEprint(storedEprint.uri);
+
+      expect(result).not.toBeNull();
+      expect(result?.uri).toBe(storedEprint.uri);
+      // Version manager generates a version entry from the stored eprint
+      expect(result?.versions).toHaveLength(1);
+      expect(result?.versions[0]).toMatchObject({
+        uri: storedEprint.uri,
+        cid: storedEprint.cid,
+        versionNumber: 1,
+      });
+      expect(result?.metrics).toEqual({ views: 0, downloads: 0, endorsements: 0 });
+    });
+  });
+
+  describe('getEprintsByAuthor', () => {
+    it('returns eprints for author', async () => {
+      const storedEprints = [
+        {
+          uri: 'at://did:plc:author123/pub.chive.eprint.submission/abc123' as AtUri,
+          cid: 'bafyrei123' as CID,
+          title: 'Test Eprint 1',
+          authors: [],
+          submittedBy: 'did:plc:author123' as DID,
+          indexedAt: new Date(),
+          createdAt: new Date(),
+        },
+        {
+          uri: 'at://did:plc:author123/pub.chive.eprint.submission/def456' as AtUri,
+          cid: 'bafyrei456' as CID,
+          title: 'Test Eprint 2',
+          authors: [],
+          submittedBy: 'did:plc:author123' as DID,
+          indexedAt: new Date(),
+          createdAt: new Date(),
+        },
+      ];
+      storage.getEprintsByAuthor.mockResolvedValue(storedEprints);
+
+      const result = await service.getEprintsByAuthor('did:plc:author123' as DID);
+
+      expect(result.eprints).toHaveLength(2);
+      expect(result.total).toBe(2);
+    });
+  });
+});

--- a/web/app/eprints/[...uri]/page.tsx
+++ b/web/app/eprints/[...uri]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { EprintDetailContent } from './eprint-content';
 import { EprintDetailSkeleton } from './loading';
 import { createServerClient } from '@/lib/api/client';
+import type { Record as SubmissionRecord } from '@/lib/api/generated/types/pub/chive/eprint/submission';
 
 /**
  * Eprint detail page route parameters.
@@ -27,8 +28,8 @@ export async function generateMetadata({ params }: EprintPageProps): Promise<Met
     const response = await serverApi.pub.chive.eprint.getSubmission({ uri: fullUri });
     const data = response.data;
 
-    // Access the record value - the actual eprint content
-    const value = data.value;
+    // Cast value to SubmissionRecord type (value is unknown per ATProto pattern)
+    const value = data.value as SubmissionRecord;
     const firstAuthor = value.authors[0];
     const authorName = firstAuthor?.name ?? 'Unknown';
 

--- a/web/lib/hooks/use-eprint.ts
+++ b/web/lib/hooks/use-eprint.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api/client';
+import type { Record as SubmissionRecord } from '@/lib/api/generated/types/pub/chive/eprint/submission';
 import { APIError } from '@/lib/errors';
 import type { Eprint, EprintSummary, EprintAuthorView } from '@/lib/api/schema';
 
@@ -146,7 +147,10 @@ export function useEprint(uri: string, options: UseEprintOptions = {}) {
     queryFn: async (): Promise<Eprint> => {
       try {
         const response = await api.pub.chive.eprint.getSubmission({ uri });
-        const { value, ...metadata } = response.data;
+        const { value: rawValue, ...metadata } = response.data;
+
+        // Cast value to SubmissionRecord type (value is unknown per ATProto pattern)
+        const value = rawValue as SubmissionRecord;
 
         // Transform raw record to enriched Eprint view
         const abstractItems = value.abstract as Array<{
@@ -370,7 +374,10 @@ export function usePrefetchEprint() {
       queryFn: async (): Promise<Eprint | undefined> => {
         try {
           const response = await api.pub.chive.eprint.getSubmission({ uri });
-          const { value, ...metadata } = response.data;
+          const { value: rawValue, ...metadata } = response.data;
+
+          // Cast value to SubmissionRecord type (value is unknown per ATProto pattern)
+          const value = rawValue as SubmissionRecord;
 
           // Transform raw record to enriched Eprint view
           const abstractItems = value.abstract as Array<{


### PR DESCRIPTION
## Summary

- Fix eprint detail page failing with "The server gave an invalid response" by changing `getSubmission` lexicon `value` type from `ref` to `unknown` (following ATProto's `com.atproto.repo.getRecord` pattern)
- Add field label resolution from knowledge graph during eprint indexing so dashboard displays human-readable field names instead of UUIDs
- Add batch `getNodesByIds` method to graph interface for efficient field lookup

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

- All 2616 unit tests pass
- New eprint service tests verify field label resolution (9 tests)
- TypeScript type checks pass
- Manual testing: verify eprint detail page loads without error
- Manual testing: verify dashboard shows field labels instead of UUIDs (requires reindexing)

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [ ] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented