### PR TITLE
fix: Author profile page crash from cache key collision

### DIFF
--- a/web/app/authors/[did]/author-content.tsx
+++ b/web/app/authors/[did]/author-content.tsx
@@ -112,7 +112,7 @@ export function AuthorPageContent({ did }: AuthorPageContentProps) {
     );
   }
 
-  if (!data) {
+  if (!data?.profile) {
     notFound();
   }
 

--- a/web/lib/hooks/use-author.ts
+++ b/web/lib/hooks/use-author.ts
@@ -173,10 +173,10 @@ export function useAuthor(did: string, options: UseAuthorOptions = {}) {
 export function useAuthorProfile(did: string) {
   return useQuery({
     queryKey: authorKeys.profile(did),
-    queryFn: async (): Promise<AuthorProfile> => {
+    queryFn: async (): Promise<AuthorProfileResponse> => {
       try {
         const response = await api.pub.chive.author.getProfile({ did });
-        return response.data.profile;
+        return response.data;
       } catch (error) {
         if (error instanceof APIError) throw error;
         throw new APIError(
@@ -188,7 +188,7 @@ export function useAuthorProfile(did: string) {
     },
     enabled: !!did,
     staleTime: 5 * 60 * 1000, // 5 minutes
-    select: (data) => data as unknown as AuthorProfile,
+    select: (data) => data.profile,
   });
 }
 


### PR DESCRIPTION
## Summary

`useAuthorProfile` and `useAuthor` shared the same TanStack Query cache key (`authorKeys.profile(did)`) but cached different data shapes: `useAuthorProfile` cached just `AuthorProfile`, while `useAuthor` cached the full `{profile, metrics}` response. When a user visited the dashboard first (which calls `useAuthorProfile`), the bare `AuthorProfile` was cached. Navigating to the author profile page then read that cached value, making `data.profile` undefined and crashing with `Cannot read properties of undefined (reading 'displayName')`.

Fix: `useAuthorProfile` now caches the full response (matching `useAuthor`) and uses `select` to extract just the profile for subscribers. Added defensive `!data?.profile` guard in author page content.

## Related Issues

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

- All 2979 unit tests pass
- Typecheck passes
- Manual: verify Aaron's profile page loads (`/authors/did:plc:34mbm5v3umztwvvgnttvcz6e`)
- Manual: verify Julian's profile page still works (`/authors/did:plc:mgcfy7hmflw4zuvc27caz2wn`)
- Manual: verify dashboard still loads author profile correctly

## Screenshots

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [ ] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [ ] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [ ] Compliance tests pass (`npm run test:compliance` — 100% required)
- [ ] No writes to user PDSes
- [ ] BlobRef storage only (never blob data)
- [ ] Indexes can be rebuilt from firehose
- [ ] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented