### PR TITLE
fix: Resolve UUID field labels and force re-index after schema migration

### DIFF
--- a/src/api/handlers/xrpc/eprint/listByAuthor.ts
+++ b/src/api/handlers/xrpc/eprint/listByAuthor.ts
@@ -110,6 +110,31 @@ export const listByAuthor: XRPCMethod<QueryParams, void, OutputSchema> = {
       }
     }
 
+    // Resolve UUID field labels from Neo4j at response time.
+    // During indexing, labels may fall back to UUIDs if Neo4j was unavailable.
+    const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const uuidFieldIds = new Set<string>();
+    for (const p of results.eprints) {
+      for (const f of p.fields ?? []) {
+        if (UUID_PATTERN.test(f.label)) {
+          uuidFieldIds.add(f.id ?? f.label);
+        }
+      }
+    }
+
+    let nodeMap = new Map<string, { label: string }>();
+    if (uuidFieldIds.size > 0) {
+      try {
+        const { nodeRepository } = c.get('services');
+        nodeMap = await nodeRepository.getNodesByIds([...uuidFieldIds]);
+      } catch (err) {
+        logger.warn('Failed to resolve UUID field labels from Neo4j', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          uuidCount: uuidFieldIds.size,
+        });
+      }
+    }
+
     const response: OutputSchema = {
       eprints: results.eprints.map((p) => ({
         uri: p.uri,
@@ -126,11 +151,17 @@ export const listByAuthor: XRPCMethod<QueryParams, void, OutputSchema> = {
             avatarUrl: author.avatarUrl ?? profile?.avatar,
           };
         }),
-        fields: p.fields?.map((f) => ({
-          uri: normalizeFieldUri(f.uri),
-          label: f.label,
-          id: f.id,
-        })),
+        fields: p.fields?.map((f) => {
+          const fieldId = f.id ?? f.label;
+          const label = UUID_PATTERN.test(f.label)
+            ? (nodeMap.get(fieldId)?.label ?? f.label)
+            : f.label;
+          return {
+            uri: normalizeFieldUri(f.uri),
+            label,
+            id: f.id,
+          };
+        }),
         indexedAt: p.indexedAt.toISOString(),
         publishedAt: p.createdAt.toISOString(),
       })),

--- a/src/storage/neo4j/node-repository.ts
+++ b/src/storage/neo4j/node-repository.ts
@@ -187,6 +187,34 @@ export class NodeRepository {
   }
 
   /**
+   * Get multiple nodes by IDs in a single query.
+   *
+   * @param ids - Node IDs (UUIDs)
+   * @returns Map of id to GraphNode (missing nodes are omitted)
+   */
+  async getNodesByIds(ids: readonly string[]): Promise<Map<string, GraphNode>> {
+    if (ids.length === 0) {
+      return new Map();
+    }
+
+    const query = `
+      MATCH (n:Node)
+      WHERE n.id IN $ids
+      RETURN n
+    `;
+
+    const result = await this.connection.executeQuery<{ n: GraphNode }>(query, { ids: [...ids] });
+    const map = new Map<string, GraphNode>();
+
+    for (const record of result.records) {
+      const node = this.mapRecordToNode(record.get('n'));
+      map.set(node.id, node);
+    }
+
+    return map;
+  }
+
+  /**
    * Update a node.
    *
    * @param uri - Node AT-URI


### PR DESCRIPTION
## Summary

Two fixes:

1. **Field labels rendering as UUIDs**: During indexing, field labels are resolved from Neo4j. If Neo4j is unavailable or the node doesn't exist yet, the label falls back to the UUID. These UUID labels get stored in PostgreSQL and served as-is. Fix: detect UUID-like labels at API response time and batch-resolve them from Neo4j via a new `NodeRepository.getNodesByIds()` method.

2. **Migration banner reappearing after successful update**: After the user clicks "Update Now", the PDS record is updated but the frontend immediately refetches from the backend, which reads from the stale PostgreSQL index (not yet re-indexed by the firehose). Fix: call `pub.chive.sync.indexRecord` after the PDS update to force immediate re-indexing, matching the pattern already used in `use-schema-migration.ts`, `use-review.ts`, and `use-endorsement.ts`.

## Related Issues

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

- All 2979 unit tests pass (`pnpm vitest run --config vitest.unit.config.ts`)
- Typecheck passes (`pnpm typecheck`)
- Manual: verify field labels render as names instead of UUIDs on affected eprints
- Manual: verify migration banner does not reappear after successful "Update Now"

## Screenshots

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [ ] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [ ] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [ ] Compliance tests pass (`npm run test:compliance` — 100% required)
- [ ] No writes to user PDSes
- [ ] BlobRef storage only (never blob data)
- [ ] Indexes can be rebuilt from firehose
- [ ] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented