### PR TITLE
fix: Auto-add fields as discipline facets and fix facet search

### DIFF
--- a/web/components/submit/submission-wizard.test.ts
+++ b/web/components/submit/submission-wizard.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { mergeFieldsIntoFacets } from './submission-wizard';
+
+describe('mergeFieldsIntoFacets', () => {
+  const field1 = { uri: 'at://did:plc:gov/pub.chive.graph.node/cs', label: 'Computer Science' };
+  const field2 = { uri: 'at://did:plc:gov/pub.chive.graph.node/phys', label: 'Physics' };
+
+  it('adds fields as personality facets when no facets exist', () => {
+    const result = mergeFieldsIntoFacets([], [field1, field2]);
+
+    expect(result).toEqual([
+      { slug: 'personality', value: field1.uri, label: field1.label },
+      { slug: 'personality', value: field2.uri, label: field2.label },
+    ]);
+  });
+
+  it('preserves existing non-personality facets', () => {
+    const existing = [{ slug: 'space', value: 'europe', label: 'Europe' }];
+
+    const result = mergeFieldsIntoFacets(existing, [field1]);
+
+    expect(result).toEqual([
+      { slug: 'space', value: 'europe', label: 'Europe' },
+      { slug: 'personality', value: field1.uri, label: field1.label },
+    ]);
+  });
+
+  it('deduplicates fields already present as personality facets', () => {
+    const existing = [{ slug: 'personality', value: field1.uri, label: field1.label }];
+
+    const result = mergeFieldsIntoFacets(existing, [field1, field2]);
+
+    expect(result).toEqual([
+      { slug: 'personality', value: field1.uri, label: field1.label },
+      { slug: 'personality', value: field2.uri, label: field2.label },
+    ]);
+  });
+
+  it('returns existing facets unchanged when no fields are provided', () => {
+    const existing = [
+      { slug: 'space', value: 'asia', label: 'Asia' },
+      { slug: 'energy', value: 'meta-analysis', label: 'Meta-analysis' },
+    ];
+
+    const result = mergeFieldsIntoFacets(existing, []);
+
+    expect(result).toEqual(existing);
+  });
+
+  it('does not mutate the input array', () => {
+    const existing = [{ slug: 'space', value: 'europe', label: 'Europe' }];
+    const copy = [...existing];
+
+    mergeFieldsIntoFacets(existing, [field1]);
+
+    expect(existing).toEqual(copy);
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-populate personality (discipline) facets from selected field nodes during eprint submission, so users don't have to manually re-select their fields in the Facets step
- Pre-populate the Discipline facet UI on the Facets step when navigating from the Fields step
- Fix facet value search returning "No results found" due to cmdk's built-in filter matching against AT-URIs instead of labels

## Related Issues

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

- Unit tests for `mergeFieldsIntoFacets` covering: fields added as personality facets, deduplication of manually-added facets, preservation of other facet types, empty inputs, and input immutability
- Manual testing via dev server in tunnel mode: verified fields auto-populate in the Discipline facet on the Facets step, verified facet search now returns results when typing

## Screenshots

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [ ] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [ ] Compliance tests pass (`npm run test:compliance` — 100% required)
- [ ] No writes to user PDSes
- [ ] BlobRef storage only (never blob data)
- [ ] Indexes can be rebuilt from firehose
- [ ] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented