### PR TITLE
Integrate with all new Semble features and Margin annotations

### DIFF
--- a/lexicons/pub/chive/collection/getFollowStatus.json
+++ b/lexicons/pub/chive/collection/getFollowStatus.json
@@ -1,0 +1,38 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.collection.getFollowStatus",
+  "revision": 1,
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Check if a user follows a collection (via network.cosmik.follow records)",
+      "parameters": {
+        "type": "params",
+        "required": ["followerDid", "subject"],
+        "properties": {
+          "followerDid": {
+            "type": "string",
+            "description": "DID of the potential follower"
+          },
+          "subject": {
+            "type": "string",
+            "description": "AT-URI of the collection"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["followUri"],
+          "properties": {
+            "followUri": {
+              "type": "string",
+              "description": "AT-URI of the follow record, or empty string if not following"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/pub/chive/collection/getFollowerCount.json
+++ b/lexicons/pub/chive/collection/getFollowerCount.json
@@ -1,0 +1,34 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.collection.getFollowerCount",
+  "revision": 1,
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get the follower count for a collection (via network.cosmik.follow records)",
+      "parameters": {
+        "type": "params",
+        "required": ["uri"],
+        "properties": {
+          "uri": {
+            "type": "string",
+            "description": "AT-URI of the collection"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["count"],
+          "properties": {
+            "count": {
+              "type": "integer",
+              "description": "Number of followers"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/pub/chive/collection/getMarginAnnotations.json
+++ b/lexicons/pub/chive/collection/getMarginAnnotations.json
@@ -1,0 +1,105 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.collection.getMarginAnnotations",
+  "revision": 1,
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get Margin annotations (at.margin.annotation, at.margin.highlight) targeting a Chive eprint",
+      "parameters": {
+        "type": "params",
+        "required": ["eprintUri"],
+        "properties": {
+          "eprintUri": {
+            "type": "string",
+            "description": "AT-URI of the eprint to get annotations for"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50,
+            "description": "Maximum results to return"
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Pagination cursor"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["annotations"],
+          "properties": {
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#annotationView"
+              }
+            },
+            "cursor": {
+              "type": "string"
+            },
+            "hasMore": {
+              "type": "boolean"
+            },
+            "total": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "annotationView": {
+      "type": "object",
+      "required": ["uri", "authorDid", "recordType", "createdAt"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "AT-URI of the annotation record"
+        },
+        "authorDid": {
+          "type": "string",
+          "description": "DID of the annotation author"
+        },
+        "recordType": {
+          "type": "string",
+          "description": "Record type: annotation or highlight"
+        },
+        "motivation": {
+          "type": "string",
+          "description": "W3C annotation motivation"
+        },
+        "body": {
+          "type": "string",
+          "description": "Annotation body text"
+        },
+        "bodyFormat": {
+          "type": "string",
+          "description": "Body MIME type"
+        },
+        "pageTitle": {
+          "type": "string",
+          "description": "Page title at annotation time"
+        },
+        "color": {
+          "type": "string",
+          "description": "Highlight color"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    }
+  }
+}

--- a/src/api/handlers/xrpc/collection/getFollowStatus.ts
+++ b/src/api/handlers/xrpc/collection/getFollowStatus.ts
@@ -1,0 +1,61 @@
+/**
+ * XRPC handler for pub.chive.collection.getFollowStatus.
+ *
+ * @remarks
+ * Checks if a user follows a collection via network.cosmik.follow.
+ * Returns the follow record URI if following, empty string otherwise.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type {
+  QueryParams,
+  OutputSchema,
+} from '../../../../lexicons/generated/types/pub/chive/collection/getFollowStatus.js';
+import type { DID } from '../../../../types/atproto.js';
+import { ValidationError } from '../../../../types/errors.js';
+import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/** Re-exported query parameters. */
+export type GetFollowStatusParams = QueryParams;
+
+/** Re-exported output schema. */
+export type GetFollowStatusOutput = OutputSchema;
+
+/**
+ * XRPC method for pub.chive.collection.getFollowStatus query.
+ *
+ * @public
+ */
+export const getFollowStatus: XRPCMethod<QueryParams, void, OutputSchema> = {
+  auth: 'optional',
+  handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
+    const { collection: collectionService } = c.get('services');
+    const logger = c.get('logger');
+
+    if (!params.followerDid || !params.subject) {
+      throw new ValidationError('Missing required parameters: followerDid, subject', 'params');
+    }
+
+    if (!collectionService) {
+      return { encoding: 'application/json', body: { followUri: '' } };
+    }
+
+    const followUri = await collectionService.getFollowStatus(
+      params.followerDid as DID,
+      params.subject
+    );
+
+    logger.debug('Follow status checked', {
+      followerDid: params.followerDid,
+      subject: params.subject,
+      isFollowing: !!followUri,
+    });
+
+    return {
+      encoding: 'application/json',
+      body: { followUri: followUri ?? '' },
+    };
+  },
+};

--- a/src/api/handlers/xrpc/collection/getFollowerCount.ts
+++ b/src/api/handlers/xrpc/collection/getFollowerCount.ts
@@ -1,0 +1,50 @@
+/**
+ * XRPC handler for pub.chive.collection.getFollowerCount.
+ *
+ * @remarks
+ * Returns the number of network.cosmik.follow records targeting a collection.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type {
+  QueryParams,
+  OutputSchema,
+} from '../../../../lexicons/generated/types/pub/chive/collection/getFollowerCount.js';
+import type { AtUri } from '../../../../types/atproto.js';
+import { ValidationError } from '../../../../types/errors.js';
+import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/** Re-exported query parameters. */
+export type GetFollowerCountParams = QueryParams;
+
+/** Re-exported output schema. */
+export type GetFollowerCountOutput = OutputSchema;
+
+/**
+ * XRPC method for pub.chive.collection.getFollowerCount query.
+ *
+ * @public
+ */
+export const getFollowerCount: XRPCMethod<QueryParams, void, OutputSchema> = {
+  auth: 'optional',
+  handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
+    const { collection: collectionService } = c.get('services');
+    const logger = c.get('logger');
+
+    if (!params.uri) {
+      throw new ValidationError('Missing required parameter: uri', 'uri');
+    }
+
+    if (!collectionService) {
+      return { encoding: 'application/json', body: { count: 0 } };
+    }
+
+    const count = await collectionService.getFollowerCount(params.uri as AtUri);
+
+    logger.debug('Follower count retrieved', { uri: params.uri, count });
+
+    return { encoding: 'application/json', body: { count } };
+  },
+};

--- a/src/api/handlers/xrpc/collection/getMarginAnnotations.ts
+++ b/src/api/handlers/xrpc/collection/getMarginAnnotations.ts
@@ -1,0 +1,81 @@
+/**
+ * XRPC handler for pub.chive.collection.getMarginAnnotations.
+ *
+ * @remarks
+ * Returns Margin annotations (at.margin.annotation, at.margin.highlight)
+ * that target a specific Chive eprint. These are indexed from the firehose
+ * by the MarginAnnotationsPlugin and MarginHighlightsPlugin.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type {
+  QueryParams,
+  OutputSchema,
+} from '../../../../lexicons/generated/types/pub/chive/collection/getMarginAnnotations.js';
+import type { AtUri } from '../../../../types/atproto.js';
+import { ValidationError } from '../../../../types/errors.js';
+import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/** Re-exported query parameters. */
+export type GetMarginAnnotationsParams = QueryParams;
+
+/** Re-exported output schema. */
+export type GetMarginAnnotationsOutput = OutputSchema;
+
+/**
+ * XRPC method for pub.chive.collection.getMarginAnnotations query.
+ *
+ * @public
+ */
+export const getMarginAnnotations: XRPCMethod<QueryParams, void, OutputSchema> = {
+  auth: 'optional',
+  handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
+    const { collection: collectionService } = c.get('services');
+    const logger = c.get('logger');
+
+    if (!params.eprintUri) {
+      throw new ValidationError('Missing required parameter: eprintUri', 'eprintUri');
+    }
+
+    if (!collectionService) {
+      return {
+        encoding: 'application/json',
+        body: { annotations: [], hasMore: false, total: 0 },
+      };
+    }
+
+    const result = await collectionService.getMarginAnnotationsForEprint(
+      params.eprintUri as AtUri,
+      { limit: params.limit, cursor: params.cursor }
+    );
+
+    logger.debug('Margin annotations retrieved', {
+      eprintUri: params.eprintUri,
+      count: result.items.length,
+      total: result.total,
+    });
+
+    return {
+      encoding: 'application/json',
+      body: {
+        annotations: result.items.map((item) => ({
+          uri: item.uri,
+          authorDid: item.authorDid,
+          recordType: item.recordType,
+          motivation: item.motivation,
+          body: item.body,
+          bodyFormat: item.bodyFormat,
+          pageTitle: item.pageTitle,
+          color: item.color,
+          tags: item.tags,
+          createdAt: item.createdAt.toISOString(),
+        })),
+        cursor: result.cursor,
+        hasMore: result.hasMore,
+        total: result.total,
+      },
+    };
+  },
+};

--- a/src/api/handlers/xrpc/collection/index.ts
+++ b/src/api/handlers/xrpc/collection/index.ts
@@ -15,6 +15,9 @@ import { findContainsEdge } from './findContainsEdge.js';
 import { get } from './get.js';
 import { getContaining } from './getContaining.js';
 import { getFeed } from './getFeed.js';
+import { getFollowStatus } from './getFollowStatus.js';
+import { getFollowerCount } from './getFollowerCount.js';
+import { getMarginAnnotations } from './getMarginAnnotations.js';
 import { getParent } from './getParent.js';
 import { getSubcollections } from './getSubcollections.js';
 import { listByOwner } from './listByOwner.js';
@@ -26,6 +29,9 @@ export { findContainsEdge } from './findContainsEdge.js';
 export { get } from './get.js';
 export { getContaining } from './getContaining.js';
 export { getFeed } from './getFeed.js';
+export { getFollowStatus } from './getFollowStatus.js';
+export { getFollowerCount } from './getFollowerCount.js';
+export { getMarginAnnotations } from './getMarginAnnotations.js';
 export { getParent } from './getParent.js';
 export { getSubcollections } from './getSubcollections.js';
 export { listByOwner } from './listByOwner.js';
@@ -41,6 +47,12 @@ export type { ListPublicParams, ListPublicOutput } from './listPublic.js';
 export type { SearchCollectionsParams, SearchCollectionsOutput } from './search.js';
 export type { FindContainsEdgeParams, FindContainsEdgeOutput } from './findContainsEdge.js';
 export type { GetContainingParams, GetContainingOutput } from './getContaining.js';
+export type { GetFollowStatusParams, GetFollowStatusOutput } from './getFollowStatus.js';
+export type { GetFollowerCountParams, GetFollowerCountOutput } from './getFollowerCount.js';
+export type {
+  GetMarginAnnotationsParams,
+  GetMarginAnnotationsOutput,
+} from './getMarginAnnotations.js';
 export type { GetParentParams, GetParentOutput } from './getParent.js';
 export type { GetSubcollectionsParams, GetSubcollectionsOutput } from './getSubcollections.js';
 
@@ -58,6 +70,9 @@ export const collectionMethods: Record<string, XRPCMethod<any, any, any>> = {
   'pub.chive.collection.listPublic': listPublic,
   'pub.chive.collection.search': search,
   'pub.chive.collection.getContaining': getContaining,
+  'pub.chive.collection.getFollowerCount': getFollowerCount,
+  'pub.chive.collection.getFollowStatus': getFollowStatus,
+  'pub.chive.collection.getMarginAnnotations': getMarginAnnotations,
   'pub.chive.collection.getParent': getParent,
   'pub.chive.collection.getSubcollections': getSubcollections,
 };

--- a/src/plugins/builtin/cosmik-connections.ts
+++ b/src/plugins/builtin/cosmik-connections.ts
@@ -1,0 +1,124 @@
+/**
+ * Cosmik connections tracking plugin.
+ *
+ * @remarks
+ * Tracks `network.cosmik.connection` records from the firehose. Connections
+ * represent edges between two entities (URLs or AT URIs) in the Semble graph.
+ *
+ * When a connection references a Chive eprint URL as either source or target,
+ * this plugin creates a backlink for aggregation and discovery.
+ *
+ * ATProto Compliance:
+ * - All backlinks indexed from firehose (rebuildable via replay)
+ * - Tracks deletions to honor record removal
+ * - Never writes to user PDSes
+ *
+ * @packageDocumentation
+ * @public
+ * @since 0.5.2
+ */
+
+import type {
+  BacklinkSourceType,
+  IPluginManifest,
+} from '../../types/interfaces/plugin.interface.js';
+import { BacklinkTrackingPlugin } from '../core/backlink-plugin.js';
+
+/**
+ * Cosmik connection record structure.
+ *
+ * @internal
+ */
+interface CosmikConnection {
+  $type: 'network.cosmik.connection';
+  source: string;
+  target: string;
+  connectionType?: string;
+  note?: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+/**
+ * Cosmik connections tracking plugin.
+ *
+ * @remarks
+ * Tracks eprint references in Cosmik connection records via firehose.
+ * Connections can reference eprints in either source or target fields.
+ *
+ * @public
+ */
+export class CosmikConnectionsPlugin extends BacklinkTrackingPlugin {
+  readonly id = 'pub.chive.plugin.cosmik-connections';
+
+  readonly trackedCollection = 'network.cosmik.connection';
+
+  readonly sourceType: BacklinkSourceType = 'cosmik.connection';
+
+  readonly manifest: IPluginManifest = {
+    id: 'pub.chive.plugin.cosmik-connections',
+    name: 'Cosmik Connections',
+    version: '0.5.2',
+    description: 'Tracks edges between entities referencing Chive eprints from Semble connections',
+    author: 'Aaron Steven White',
+    license: 'MIT',
+    permissions: {
+      hooks: ['firehose.network.cosmik.connection'],
+      storage: {
+        maxSize: 10 * 1024 * 1024,
+      },
+    },
+    entrypoint: 'cosmik-connections.js',
+  };
+
+  /**
+   * Extracts eprint AT-URIs or Chive URLs from a connection's source and target.
+   *
+   * @param record - Cosmik connection record
+   * @returns Array of eprint references found in source/target
+   */
+  extractEprintRefs(record: unknown): string[] {
+    const connection = record as CosmikConnection;
+    const refs: string[] = [];
+
+    if (this.isChiveEprintReference(connection.source)) {
+      refs.push(connection.source);
+    }
+    if (this.isChiveEprintReference(connection.target)) {
+      refs.push(connection.target);
+    }
+
+    return refs;
+  }
+
+  /**
+   * Extracts context from a connection record.
+   *
+   * @param record - Connection record
+   * @returns Connection type and note as context
+   */
+  protected override extractContext(record: unknown): string | undefined {
+    const connection = record as CosmikConnection;
+    const parts: string[] = [];
+    if (connection.connectionType) parts.push(`type: ${connection.connectionType}`);
+    if (connection.note) parts.push(connection.note);
+    return parts.length > 0 ? parts.join(' - ') : undefined;
+  }
+
+  protected override shouldProcess(_record: unknown): boolean {
+    return true;
+  }
+
+  /**
+   * Checks if a string references a Chive eprint via AT-URI or web URL.
+   */
+  private isChiveEprintReference(value: string): boolean {
+    // Check AT-URI format
+    if (value.includes('pub.chive.eprint.submission')) return true;
+    // Check for Chive web URLs: https://chive.pub/eprints/...
+    if (value.includes('chive.pub/eprints/')) return true;
+    return false;
+  }
+}
+
+export default CosmikConnectionsPlugin;

--- a/src/plugins/builtin/cosmik-follows.ts
+++ b/src/plugins/builtin/cosmik-follows.ts
@@ -1,0 +1,113 @@
+/**
+ * Cosmik follows tracking plugin.
+ *
+ * @remarks
+ * Tracks `network.cosmik.follow` records from the firehose. Follow records
+ * represent a user following another user (DID) or a collection (AT-URI).
+ *
+ * This plugin indexes follow relationships for:
+ * - Collection follower counts (when subject is a collection AT-URI)
+ * - User follow graphs (when subject is a DID)
+ *
+ * ATProto Compliance:
+ * - All data indexed from firehose (rebuildable via replay)
+ * - Tracks deletions to honor unfollows
+ * - Never writes to user PDSes
+ *
+ * @packageDocumentation
+ * @public
+ * @since 0.5.2
+ */
+
+import type { IPluginContext, IPluginManifest } from '../../types/interfaces/plugin.interface.js';
+import type { FirehoseRecord } from '../core/backlink-plugin.js';
+
+import { BasePlugin } from './base-plugin.js';
+
+/**
+ * Cosmik follow record structure.
+ *
+ * @internal
+ */
+interface CosmikFollow {
+  $type: 'network.cosmik.follow';
+  subject: string;
+  createdAt: string;
+}
+
+/**
+ * Cosmik follows tracking plugin.
+ *
+ * @public
+ */
+export class CosmikFollowsPlugin extends BasePlugin {
+  readonly id = 'pub.chive.plugin.cosmik-follows';
+
+  readonly manifest: IPluginManifest = {
+    id: 'pub.chive.plugin.cosmik-follows',
+    name: 'Cosmik Follows',
+    version: '0.5.2',
+    description: 'Tracks follow relationships from Semble for collection follower counts',
+    author: 'Aaron Steven White',
+    license: 'MIT',
+    permissions: {
+      hooks: ['firehose.network.cosmik.follow'],
+      storage: {
+        maxSize: 5 * 1024 * 1024,
+      },
+    },
+    entrypoint: 'cosmik-follows.js',
+  };
+
+  override async initialize(context: IPluginContext): Promise<void> {
+    await super.initialize(context);
+
+    this.context.eventBus.on('firehose.network.cosmik.follow', (...args: readonly unknown[]) => {
+      const record = args[0] as FirehoseRecord;
+      void this.handleFirehoseRecord(record);
+    });
+
+    this.logger.info('Cosmik follows tracking initialized');
+  }
+
+  private handleFirehoseRecord(record: FirehoseRecord): void {
+    try {
+      if (record.deleted) {
+        this.context.eventBus.emit('cosmik.follow.deleted', {
+          uri: record.uri,
+          did: record.did,
+        });
+        this.logger.debug('Follow deleted', { uri: record.uri });
+      } else if (record.record) {
+        const follow = record.record as unknown as CosmikFollow;
+        const subjectType = follow.subject.startsWith('did:') ? 'user' : 'collection';
+
+        this.context.eventBus.emit('cosmik.follow.created', {
+          uri: record.uri,
+          followerDid: record.did,
+          subject: follow.subject,
+          subjectType,
+          createdAt: follow.createdAt,
+        });
+
+        this.logger.debug('Follow indexed', {
+          uri: record.uri,
+          followerDid: record.did,
+          subject: follow.subject,
+          subjectType,
+        });
+      }
+    } catch (err) {
+      this.logger.warn('Failed to process follow record', {
+        error: (err as Error).message,
+        uri: record.uri,
+      });
+    }
+  }
+
+  protected onInitialize(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export default CosmikFollowsPlugin;

--- a/src/plugins/builtin/cosmik-link-removals.ts
+++ b/src/plugins/builtin/cosmik-link-removals.ts
@@ -1,0 +1,113 @@
+/**
+ * Cosmik collectionLinkRemoval tracking plugin.
+ *
+ * @remarks
+ * Tracks `network.cosmik.collectionLinkRemoval` records from the firehose.
+ * These are tombstone records created when a collection owner removes a
+ * collaborator's link from their collection (since the owner cannot delete
+ * records in another user's PDS).
+ *
+ * ATProto Compliance:
+ * - All data indexed from firehose (rebuildable via replay)
+ * - Never writes to user PDSes
+ *
+ * @packageDocumentation
+ * @public
+ * @since 0.5.2
+ */
+
+import type { IPluginContext, IPluginManifest } from '../../types/interfaces/plugin.interface.js';
+import type { FirehoseRecord } from '../core/backlink-plugin.js';
+
+import { BasePlugin } from './base-plugin.js';
+
+/**
+ * Cosmik collectionLinkRemoval record structure.
+ *
+ * @internal
+ */
+interface CosmikCollectionLinkRemoval {
+  $type: 'network.cosmik.collectionLinkRemoval';
+  collection: { uri: string; cid: string };
+  removedLink: { uri: string; cid: string };
+  removedAt: string;
+}
+
+/**
+ * Cosmik link removals tracking plugin.
+ *
+ * @public
+ */
+export class CosmikLinkRemovalsPlugin extends BasePlugin {
+  readonly id = 'pub.chive.plugin.cosmik-link-removals';
+
+  readonly manifest: IPluginManifest = {
+    id: 'pub.chive.plugin.cosmik-link-removals',
+    name: 'Cosmik Link Removals',
+    version: '0.5.2',
+    description: 'Tracks tombstone records for collaborative collection link removals',
+    author: 'Aaron Steven White',
+    license: 'MIT',
+    permissions: {
+      hooks: ['firehose.network.cosmik.collectionLinkRemoval'],
+      storage: {
+        maxSize: 5 * 1024 * 1024,
+      },
+    },
+    entrypoint: 'cosmik-link-removals.js',
+  };
+
+  override async initialize(context: IPluginContext): Promise<void> {
+    await super.initialize(context);
+
+    this.context.eventBus.on(
+      'firehose.network.cosmik.collectionLinkRemoval',
+      (...args: readonly unknown[]) => {
+        const record = args[0] as FirehoseRecord;
+        void this.handleFirehoseRecord(record);
+      }
+    );
+
+    this.logger.info('Cosmik link removals tracking initialized');
+  }
+
+  private handleFirehoseRecord(record: FirehoseRecord): void {
+    try {
+      if (record.deleted) {
+        // A deleted removal record means the link was re-added
+        this.context.eventBus.emit('cosmik.linkRemoval.reverted', {
+          uri: record.uri,
+          did: record.did,
+        });
+        this.logger.debug('Link removal tombstone deleted (re-added)', { uri: record.uri });
+      } else if (record.record) {
+        const removal = record.record as unknown as CosmikCollectionLinkRemoval;
+
+        this.context.eventBus.emit('cosmik.linkRemoval.created', {
+          uri: record.uri,
+          ownerDid: record.did,
+          collectionUri: removal.collection.uri,
+          removedLinkUri: removal.removedLink.uri,
+          removedAt: removal.removedAt,
+        });
+
+        this.logger.debug('Link removal tombstone indexed', {
+          uri: record.uri,
+          collectionUri: removal.collection.uri,
+          removedLinkUri: removal.removedLink.uri,
+        });
+      }
+    } catch (err) {
+      this.logger.warn('Failed to process link removal record', {
+        error: (err as Error).message,
+        uri: record.uri,
+      });
+    }
+  }
+
+  protected onInitialize(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export default CosmikLinkRemovalsPlugin;

--- a/src/plugins/builtin/margin-annotations.ts
+++ b/src/plugins/builtin/margin-annotations.ts
@@ -1,0 +1,370 @@
+/**
+ * Margin annotations tracking plugin.
+ *
+ * @remarks
+ * Tracks `at.margin.annotation`, `at.margin.highlight`, and `at.margin.bookmark`
+ * records from the firehose. When these records reference Chive eprint URLs
+ * (via `target.source` or `source`), this plugin creates backlinks for
+ * aggregation and displays annotations alongside native Chive reviews.
+ *
+ * Margin implements the W3C Web Annotation Data Model on ATProto, making it
+ * a natural complement to Chive's review system.
+ *
+ * ATProto Compliance:
+ * - All backlinks indexed from firehose (rebuildable via replay)
+ * - Tracks deletions to honor record removal
+ * - Never writes to user PDSes
+ *
+ * @packageDocumentation
+ * @public
+ * @since 0.5.2
+ */
+
+import type {
+  BacklinkSourceType,
+  IPluginContext,
+  IPluginManifest,
+} from '../../types/interfaces/plugin.interface.js';
+import { BacklinkTrackingPlugin } from '../core/backlink-plugin.js';
+import type { FirehoseRecord } from '../core/backlink-plugin.js';
+
+// =============================================================================
+// RECORD TYPES
+// =============================================================================
+
+/**
+ * Margin annotation target (W3C SpecificResource).
+ *
+ * @internal
+ */
+interface MarginTarget {
+  source: string;
+  sourceHash?: string;
+  title?: string;
+  selector?: Record<string, unknown>;
+}
+
+/**
+ * Margin annotation record structure.
+ *
+ * @internal
+ */
+interface MarginAnnotation {
+  $type: 'at.margin.annotation';
+  target: MarginTarget;
+  body?: {
+    value: string;
+    format?: string;
+  };
+  motivation?: string;
+  tags?: string[];
+  createdAt: string;
+}
+
+/**
+ * Margin highlight record structure.
+ *
+ * @internal
+ */
+interface MarginHighlight {
+  $type: 'at.margin.highlight';
+  target: MarginTarget;
+  color?: string;
+  tags?: string[];
+  createdAt: string;
+}
+
+/**
+ * Margin bookmark record structure.
+ *
+ * @internal
+ */
+interface MarginBookmark {
+  $type: 'at.margin.bookmark';
+  source: string;
+  sourceHash?: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  createdAt: string;
+}
+
+// =============================================================================
+// ANNOTATION PLUGIN (handles at.margin.annotation)
+// =============================================================================
+
+/**
+ * Margin annotations tracking plugin.
+ *
+ * @remarks
+ * Tracks W3C Web Annotations from Margin that reference Chive eprint URLs.
+ *
+ * @public
+ */
+export class MarginAnnotationsPlugin extends BacklinkTrackingPlugin {
+  readonly id = 'pub.chive.plugin.margin-annotations';
+
+  readonly trackedCollection = 'at.margin.annotation';
+
+  readonly sourceType: BacklinkSourceType = 'margin.annotation';
+
+  readonly manifest: IPluginManifest = {
+    id: 'pub.chive.plugin.margin-annotations',
+    name: 'Margin Annotations',
+    version: '0.5.2',
+    description: 'Tracks W3C Web Annotations from Margin referencing Chive eprints',
+    author: 'Aaron Steven White',
+    license: 'MIT',
+    permissions: {
+      hooks: ['firehose.at.margin.annotation'],
+      storage: {
+        maxSize: 10 * 1024 * 1024,
+      },
+    },
+    entrypoint: 'margin-annotations.js',
+  };
+
+  extractEprintRefs(record: unknown): string[] {
+    const annotation = record as MarginAnnotation;
+    const refs: string[] = [];
+
+    if (annotation.target?.source && this.isChiveReference(annotation.target.source)) {
+      refs.push(annotation.target.source);
+    }
+
+    return refs;
+  }
+
+  protected override extractContext(record: unknown): string | undefined {
+    const annotation = record as MarginAnnotation;
+    const parts: string[] = [];
+    if (annotation.motivation) parts.push(annotation.motivation);
+    if (annotation.body?.value) {
+      parts.push(annotation.body.value.slice(0, 200));
+    }
+    return parts.length > 0 ? parts.join(': ') : undefined;
+  }
+
+  protected override shouldProcess(_record: unknown): boolean {
+    return true;
+  }
+
+  private isChiveReference(url: string): boolean {
+    return url.includes('chive.pub/eprints/') || this.isEprintUri(url);
+  }
+}
+
+// =============================================================================
+// HIGHLIGHT PLUGIN (handles at.margin.highlight)
+// =============================================================================
+
+/**
+ * Margin highlights tracking plugin.
+ *
+ * @public
+ */
+export class MarginHighlightsPlugin extends BacklinkTrackingPlugin {
+  readonly id = 'pub.chive.plugin.margin-highlights';
+
+  readonly trackedCollection = 'at.margin.highlight';
+
+  readonly sourceType: BacklinkSourceType = 'margin.highlight';
+
+  readonly manifest: IPluginManifest = {
+    id: 'pub.chive.plugin.margin-highlights',
+    name: 'Margin Highlights',
+    version: '0.5.2',
+    description: 'Tracks highlights from Margin on Chive eprints',
+    author: 'Aaron Steven White',
+    license: 'MIT',
+    permissions: {
+      hooks: ['firehose.at.margin.highlight'],
+      storage: {
+        maxSize: 5 * 1024 * 1024,
+      },
+    },
+    entrypoint: 'margin-highlights.js',
+  };
+
+  extractEprintRefs(record: unknown): string[] {
+    const highlight = record as MarginHighlight;
+    const refs: string[] = [];
+
+    if (highlight.target?.source && this.isChiveReference(highlight.target.source)) {
+      refs.push(highlight.target.source);
+    }
+
+    return refs;
+  }
+
+  protected override extractContext(record: unknown): string | undefined {
+    const highlight = record as MarginHighlight;
+    if (highlight.color) return `highlight (${highlight.color})`;
+    return 'highlight';
+  }
+
+  protected override shouldProcess(_record: unknown): boolean {
+    return true;
+  }
+
+  private isChiveReference(url: string): boolean {
+    return url.includes('chive.pub/eprints/') || this.isEprintUri(url);
+  }
+}
+
+// =============================================================================
+// BOOKMARK PLUGIN (handles at.margin.bookmark)
+// =============================================================================
+
+/**
+ * Margin bookmarks tracking plugin.
+ *
+ * @public
+ */
+export class MarginBookmarksPlugin extends BacklinkTrackingPlugin {
+  readonly id = 'pub.chive.plugin.margin-bookmarks';
+
+  readonly trackedCollection = 'at.margin.bookmark';
+
+  readonly sourceType: BacklinkSourceType = 'margin.bookmark';
+
+  readonly manifest: IPluginManifest = {
+    id: 'pub.chive.plugin.margin-bookmarks',
+    name: 'Margin Bookmarks',
+    version: '0.5.2',
+    description: 'Tracks bookmarks from Margin for Chive eprints',
+    author: 'Aaron Steven White',
+    license: 'MIT',
+    permissions: {
+      hooks: ['firehose.at.margin.bookmark'],
+      storage: {
+        maxSize: 5 * 1024 * 1024,
+      },
+    },
+    entrypoint: 'margin-bookmarks.js',
+  };
+
+  extractEprintRefs(record: unknown): string[] {
+    const bookmark = record as MarginBookmark;
+    const refs: string[] = [];
+
+    if (bookmark.source && this.isChiveReference(bookmark.source)) {
+      refs.push(bookmark.source);
+    }
+
+    return refs;
+  }
+
+  protected override extractContext(record: unknown): string | undefined {
+    const bookmark = record as MarginBookmark;
+    return bookmark.title || bookmark.description || undefined; // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing -- intentionally coerces empty string
+  }
+
+  protected override shouldProcess(_record: unknown): boolean {
+    return true;
+  }
+
+  private isChiveReference(url: string): boolean {
+    return url.includes('chive.pub/eprints/') || this.isEprintUri(url);
+  }
+}
+
+// =============================================================================
+// MARGIN REPLY PLUGIN (handles at.margin.reply for threading)
+// =============================================================================
+
+/**
+ * Margin reply record structure.
+ *
+ * @internal
+ */
+interface MarginReply {
+  $type: 'at.margin.reply';
+  parent: { uri: string; cid: string };
+  root: { uri: string; cid: string };
+  text: string;
+  format?: string;
+  createdAt: string;
+}
+
+/**
+ * Margin replies tracking plugin.
+ *
+ * @remarks
+ * Tracks `at.margin.reply` records and emits events for threading.
+ * Replies reference parent and root annotations via StrongRefs.
+ *
+ * @public
+ */
+export class MarginRepliesPlugin extends BacklinkTrackingPlugin {
+  readonly id = 'pub.chive.plugin.margin-replies';
+
+  readonly trackedCollection = 'at.margin.reply';
+
+  readonly sourceType: BacklinkSourceType = 'margin.annotation';
+
+  readonly manifest: IPluginManifest = {
+    id: 'pub.chive.plugin.margin-replies',
+    name: 'Margin Replies',
+    version: '0.5.2',
+    description: 'Tracks threaded replies on Margin annotations for Chive eprints',
+    author: 'Aaron Steven White',
+    license: 'MIT',
+    permissions: {
+      hooks: ['firehose.at.margin.reply'],
+      storage: {
+        maxSize: 5 * 1024 * 1024,
+      },
+    },
+    entrypoint: 'margin-replies.js',
+  };
+
+  override async initialize(context: IPluginContext): Promise<void> {
+    await super.initialize(context);
+
+    // Also listen for reply events to build thread context
+    this.context.eventBus.on('firehose.at.margin.reply', (...args: readonly unknown[]) => {
+      const record = args[0] as FirehoseRecord;
+      void this.handleReplyRecord(record);
+    });
+  }
+
+  extractEprintRefs(_record: unknown): string[] {
+    // Replies don't directly reference eprints; they chain to annotations
+    // that may reference eprints. The backlink is on the root annotation.
+    return [];
+  }
+
+  private handleReplyRecord(record: FirehoseRecord): void {
+    try {
+      if (record.deleted) {
+        this.context.eventBus.emit('margin.reply.deleted', {
+          uri: record.uri,
+          did: record.did,
+        });
+      } else if (record.record) {
+        const reply = record.record as unknown as MarginReply;
+
+        this.context.eventBus.emit('margin.reply.created', {
+          uri: record.uri,
+          authorDid: record.did,
+          parentUri: reply.parent.uri,
+          rootUri: reply.root.uri,
+          text: reply.text,
+          createdAt: reply.createdAt,
+        });
+      }
+    } catch (err) {
+      this.logger.warn('Failed to process reply record', {
+        error: (err as Error).message,
+        uri: record.uri,
+      });
+    }
+  }
+
+  protected override shouldProcess(_record: unknown): boolean {
+    return true;
+  }
+}
+
+export { MarginAnnotationsPlugin as default };

--- a/src/services/collection/collection-service.ts
+++ b/src/services/collection/collection-service.ts
@@ -1796,6 +1796,552 @@ export class CollectionService {
     }
   }
 
+  // =========================================================================
+  // COSMIK CONNECTIONS (edges between links)
+  // =========================================================================
+
+  /**
+   * Retrieves Cosmik connections that reference items in a collection.
+   *
+   * @param collectionUri - AT URI of the collection
+   * @returns Connections where source or target is an item in the collection
+   *
+   * @public
+   */
+  async getCosmikConnections(collectionUri: AtUri): Promise<
+    {
+      uri: string;
+      sourceEntity: string;
+      targetEntity: string;
+      connectionType?: string;
+      note?: string;
+      chiveEdgeUri?: string;
+    }[]
+  > {
+    try {
+      const result = await this.pool.query<{
+        uri: string;
+        source_entity: string;
+        target_entity: string;
+        connection_type: string | null;
+        note: string | null;
+        chive_edge_uri: string | null;
+      }>(
+        `SELECT cc.uri, cc.source_entity, cc.target_entity,
+                cc.connection_type, cc.note, cc.chive_edge_uri
+         FROM cosmik_connections_index cc
+         WHERE cc.chive_edge_uri IN (
+           SELECT pge.uri FROM personal_graph_edges_index pge
+           WHERE pge.source_uri IN (
+             SELECT ce.target_uri FROM collection_edges_index ce
+             WHERE ce.source_uri = $1 AND ce.relation_slug = 'contains'
+           )
+           AND pge.target_uri IN (
+             SELECT ce.target_uri FROM collection_edges_index ce
+             WHERE ce.source_uri = $1 AND ce.relation_slug = 'contains'
+           )
+           AND pge.relation_slug NOT IN ('contains', 'subcollection-of')
+         )`,
+        [collectionUri]
+      );
+
+      return result.rows.map((row) => ({
+        uri: row.uri,
+        sourceEntity: row.source_entity,
+        targetEntity: row.target_entity,
+        connectionType: row.connection_type ?? undefined,
+        note: row.note ?? undefined,
+        chiveEdgeUri: row.chive_edge_uri ?? undefined,
+      }));
+    } catch (error) {
+      this.logger.error(
+        'Failed to get Cosmik connections',
+        error instanceof Error ? error : undefined,
+        { collectionUri }
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Indexes a Cosmik connection record from the firehose.
+   *
+   * @param record - Parsed connection record
+   * @param metadata - Record metadata
+   * @returns Result indicating success or failure
+   *
+   * @public
+   */
+  async indexCosmikConnection(
+    record: {
+      source: string;
+      target: string;
+      connectionType?: string;
+      note?: string;
+    },
+    metadata: RecordMetadata
+  ): Promise<Result<void, DatabaseError>> {
+    try {
+      const ownerDid = extractDidFromUri(metadata.uri);
+
+      await this.pool.query(
+        `INSERT INTO cosmik_connections_index (
+          uri, cid, owner_did, source_entity, target_entity,
+          connection_type, note, created_at, pds_url, indexed_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+        ON CONFLICT (uri) DO UPDATE SET
+          cid = EXCLUDED.cid,
+          source_entity = EXCLUDED.source_entity,
+          target_entity = EXCLUDED.target_entity,
+          connection_type = EXCLUDED.connection_type,
+          note = EXCLUDED.note,
+          updated_at = NOW()`,
+        [
+          metadata.uri,
+          metadata.cid,
+          ownerDid,
+          record.source,
+          record.target,
+          record.connectionType ?? null,
+          record.note ?? null,
+          metadata.indexedAt,
+          metadata.pdsUrl,
+        ]
+      );
+
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError(
+        'WRITE',
+        `Failed to index Cosmik connection: ${error instanceof Error ? error.message : String(error)}`
+      );
+      this.logger.error('Failed to index Cosmik connection', dbError, { uri: metadata.uri });
+      return Err(dbError);
+    }
+  }
+
+  /**
+   * Deletes a Cosmik connection from the index.
+   *
+   * @param uri - AT URI of the connection
+   * @returns Result indicating success or failure
+   *
+   * @public
+   */
+  async deleteCosmikConnection(uri: AtUri): Promise<Result<void, DatabaseError>> {
+    try {
+      await this.pool.query('DELETE FROM cosmik_connections_index WHERE uri = $1', [uri]);
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError(
+        'DELETE',
+        `Failed to delete Cosmik connection: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return Err(dbError);
+    }
+  }
+
+  // =========================================================================
+  // COSMIK FOLLOWS
+  // =========================================================================
+
+  /**
+   * Gets the follower count for a collection.
+   *
+   * @param collectionUri - AT URI of the collection (as a Cosmik subject)
+   * @returns Number of followers
+   *
+   * @public
+   */
+  async getFollowerCount(collectionUri: AtUri): Promise<number> {
+    try {
+      const result = await this.pool.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM cosmik_follows_index
+         WHERE subject = $1 AND subject_type = 'collection'`,
+        [collectionUri]
+      );
+      return parseInt(result.rows[0]?.count ?? '0', 10);
+    } catch (error) {
+      this.logger.error(
+        'Failed to get follower count',
+        error instanceof Error ? error : undefined,
+        { collectionUri }
+      );
+      return 0;
+    }
+  }
+
+  /**
+   * Checks if a user follows a collection.
+   *
+   * @param followerDid - DID of the follower
+   * @param subject - AT URI of the collection
+   * @returns Follow URI if following, null otherwise
+   *
+   * @public
+   */
+  async getFollowStatus(followerDid: DID, subject: string): Promise<string | null> {
+    try {
+      const result = await this.pool.query<{ uri: string }>(
+        `SELECT uri FROM cosmik_follows_index
+         WHERE follower_did = $1 AND subject = $2
+         LIMIT 1`,
+        [followerDid, subject]
+      );
+      return result.rows[0]?.uri ?? null;
+    } catch (error) {
+      this.logger.error('Failed to get follow status', error instanceof Error ? error : undefined, {
+        followerDid,
+        subject,
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Indexes a Cosmik follow record from the firehose.
+   *
+   * @param record - Parsed follow record
+   * @param metadata - Record metadata
+   * @returns Result indicating success or failure
+   *
+   * @public
+   */
+  async indexCosmikFollow(
+    record: { subject: string; createdAt: string },
+    metadata: RecordMetadata
+  ): Promise<Result<void, DatabaseError>> {
+    try {
+      const followerDid = extractDidFromUri(metadata.uri);
+      const subjectType = record.subject.startsWith('did:') ? 'user' : 'collection';
+
+      await this.pool.query(
+        `INSERT INTO cosmik_follows_index (
+          uri, cid, follower_did, subject, subject_type, created_at, pds_url, indexed_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+        ON CONFLICT (uri) DO NOTHING`,
+        [
+          metadata.uri,
+          metadata.cid,
+          followerDid,
+          record.subject,
+          subjectType,
+          new Date(record.createdAt),
+          metadata.pdsUrl,
+        ]
+      );
+
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError(
+        'WRITE',
+        `Failed to index Cosmik follow: ${error instanceof Error ? error.message : String(error)}`
+      );
+      this.logger.error('Failed to index Cosmik follow', dbError, { uri: metadata.uri });
+      return Err(dbError);
+    }
+  }
+
+  /**
+   * Deletes a Cosmik follow from the index.
+   *
+   * @param uri - AT URI of the follow record
+   * @returns Result indicating success or failure
+   *
+   * @public
+   */
+  async deleteCosmikFollow(uri: AtUri): Promise<Result<void, DatabaseError>> {
+    try {
+      await this.pool.query('DELETE FROM cosmik_follows_index WHERE uri = $1', [uri]);
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError(
+        'DELETE',
+        `Failed to delete Cosmik follow: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return Err(dbError);
+    }
+  }
+
+  // =========================================================================
+  // MARGIN ANNOTATIONS
+  // =========================================================================
+
+  /**
+   * Retrieves Margin annotations targeting a specific eprint.
+   *
+   * @param eprintUri - AT URI of the eprint
+   * @param options - Pagination options
+   * @returns Paginated list of Margin annotations
+   *
+   * @public
+   */
+  async getMarginAnnotationsForEprint(
+    eprintUri: AtUri,
+    options: PaginationOptions = {}
+  ): Promise<
+    PaginatedResult<{
+      uri: string;
+      authorDid: string;
+      recordType: string;
+      motivation?: string;
+      body?: string;
+      bodyFormat?: string;
+      pageTitle?: string;
+      selectorJson?: Record<string, unknown>;
+      color?: string;
+      tags?: string[];
+      createdAt: Date;
+    }>
+  > {
+    const limit = Math.min(options.limit ?? 50, 100);
+
+    try {
+      const countResult = await this.pool.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM margin_annotations_index WHERE eprint_uri = $1`,
+        [eprintUri]
+      );
+      const total = parseInt(countResult.rows[0]?.count ?? '0', 10);
+
+      let sql = `SELECT uri, author_did, record_type, motivation, body, body_format,
+                        page_title, selector_json, color, tags, created_at
+                 FROM margin_annotations_index
+                 WHERE eprint_uri = $1`;
+      const params: unknown[] = [eprintUri];
+
+      if (options.cursor) {
+        const parts = options.cursor.split('::');
+        const timestamp = parts[0] ?? new Date().toISOString();
+        const cursorUri = parts[1] ?? '';
+        sql += ` AND (created_at, uri) < ($2, $3)`;
+        params.push(new Date(timestamp), cursorUri);
+      }
+
+      sql += ` ORDER BY created_at DESC, uri DESC LIMIT $${params.length + 1}`;
+      params.push(limit + 1);
+
+      const result = await this.pool.query<{
+        uri: string;
+        author_did: string;
+        record_type: string;
+        motivation: string | null;
+        body: string | null;
+        body_format: string | null;
+        page_title: string | null;
+        selector_json: Record<string, unknown> | null;
+        color: string | null;
+        tags: string[] | null;
+        created_at: Date;
+      }>(sql, params);
+
+      const hasMore = result.rows.length > limit;
+      const items = result.rows.slice(0, limit);
+
+      let cursor: string | undefined;
+      const lastItem = items[items.length - 1];
+      if (hasMore && lastItem) {
+        cursor = `${lastItem.created_at.toISOString()}::${lastItem.uri}`;
+      }
+
+      return {
+        items: items.map((row) => ({
+          uri: row.uri,
+          authorDid: row.author_did,
+          recordType: row.record_type,
+          motivation: row.motivation ?? undefined,
+          body: row.body ?? undefined,
+          bodyFormat: row.body_format ?? undefined,
+          pageTitle: row.page_title ?? undefined,
+          selectorJson: row.selector_json ?? undefined,
+          color: row.color ?? undefined,
+          tags: row.tags ?? undefined,
+          createdAt: new Date(row.created_at),
+        })),
+        cursor,
+        hasMore,
+        total,
+      };
+    } catch (error) {
+      this.logger.error(
+        'Failed to get Margin annotations for eprint',
+        error instanceof Error ? error : undefined,
+        { eprintUri }
+      );
+      return { items: [], hasMore: false, total: 0 };
+    }
+  }
+
+  /**
+   * Indexes a Margin annotation or highlight record from the firehose.
+   *
+   * @param record - Parsed annotation/highlight record
+   * @param metadata - Record metadata
+   * @returns Result indicating success or failure
+   *
+   * @public
+   */
+  async indexMarginAnnotation(
+    record: {
+      recordType: 'annotation' | 'highlight';
+      sourceUrl: string;
+      sourceHash?: string;
+      motivation?: string;
+      body?: string;
+      bodyFormat?: string;
+      pageTitle?: string;
+      selectorJson?: Record<string, unknown>;
+      color?: string;
+      tags?: string[];
+      eprintUri?: string;
+    },
+    metadata: RecordMetadata
+  ): Promise<Result<void, DatabaseError>> {
+    try {
+      const authorDid = extractDidFromUri(metadata.uri);
+
+      await this.pool.query(
+        `INSERT INTO margin_annotations_index (
+          uri, cid, author_did, source_url, source_hash, record_type,
+          motivation, body, body_format, page_title, selector_json,
+          color, tags, eprint_uri, created_at, pds_url, indexed_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12, $13::jsonb, $14, $15, $16, NOW())
+        ON CONFLICT (uri) DO UPDATE SET
+          cid = EXCLUDED.cid,
+          body = EXCLUDED.body,
+          body_format = EXCLUDED.body_format,
+          tags = EXCLUDED.tags`,
+        [
+          metadata.uri,
+          metadata.cid,
+          authorDid,
+          record.sourceUrl,
+          record.sourceHash ?? null,
+          record.recordType,
+          record.motivation ?? null,
+          record.body ?? null,
+          record.bodyFormat ?? null,
+          record.pageTitle ?? null,
+          record.selectorJson ? JSON.stringify(record.selectorJson) : null,
+          record.color ?? null,
+          record.tags ? JSON.stringify(record.tags) : null,
+          record.eprintUri ?? null,
+          metadata.indexedAt,
+          metadata.pdsUrl,
+        ]
+      );
+
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError(
+        'WRITE',
+        `Failed to index Margin annotation: ${error instanceof Error ? error.message : String(error)}`
+      );
+      this.logger.error('Failed to index Margin annotation', dbError, { uri: metadata.uri });
+      return Err(dbError);
+    }
+  }
+
+  /**
+   * Deletes a Margin annotation from the index.
+   *
+   * @param uri - AT URI of the annotation
+   * @returns Result indicating success or failure
+   *
+   * @public
+   */
+  async deleteMarginAnnotation(uri: AtUri): Promise<Result<void, DatabaseError>> {
+    try {
+      await this.pool.query('DELETE FROM margin_annotations_index WHERE uri = $1', [uri]);
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError(
+        'DELETE',
+        `Failed to delete Margin annotation: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return Err(dbError);
+    }
+  }
+
+  /**
+   * Indexes a Margin bookmark record from the firehose.
+   *
+   * @param record - Parsed bookmark record
+   * @param metadata - Record metadata
+   * @returns Result indicating success or failure
+   *
+   * @public
+   */
+  async indexMarginBookmark(
+    record: {
+      sourceUrl: string;
+      sourceHash?: string;
+      title?: string;
+      description?: string;
+      tags?: string[];
+      eprintUri?: string;
+    },
+    metadata: RecordMetadata
+  ): Promise<Result<void, DatabaseError>> {
+    try {
+      const authorDid = extractDidFromUri(metadata.uri);
+
+      await this.pool.query(
+        `INSERT INTO margin_bookmarks_index (
+          uri, cid, author_did, source_url, source_hash, title,
+          description, tags, eprint_uri, created_at, pds_url, indexed_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, NOW())
+        ON CONFLICT (uri) DO UPDATE SET
+          cid = EXCLUDED.cid,
+          title = EXCLUDED.title,
+          description = EXCLUDED.description,
+          tags = EXCLUDED.tags`,
+        [
+          metadata.uri,
+          metadata.cid,
+          authorDid,
+          record.sourceUrl,
+          record.sourceHash ?? null,
+          record.title ?? null,
+          record.description ?? null,
+          record.tags ? JSON.stringify(record.tags) : null,
+          record.eprintUri ?? null,
+          metadata.indexedAt,
+          metadata.pdsUrl,
+        ]
+      );
+
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError(
+        'WRITE',
+        `Failed to index Margin bookmark: ${error instanceof Error ? error.message : String(error)}`
+      );
+      this.logger.error('Failed to index Margin bookmark', dbError, { uri: metadata.uri });
+      return Err(dbError);
+    }
+  }
+
+  /**
+   * Deletes a Margin bookmark from the index.
+   *
+   * @param uri - AT URI of the bookmark
+   * @returns Result indicating success or failure
+   *
+   * @public
+   */
+  async deleteMarginBookmark(uri: AtUri): Promise<Result<void, DatabaseError>> {
+    try {
+      await this.pool.query('DELETE FROM margin_bookmarks_index WHERE uri = $1', [uri]);
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError(
+        'DELETE',
+        `Failed to delete Margin bookmark: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return Err(dbError);
+    }
+  }
+
   /**
    * Converts a database row to an IndexedCollection.
    *

--- a/src/storage/postgresql/migrations/1741200000000_semble-integration.ts
+++ b/src/storage/postgresql/migrations/1741200000000_semble-integration.ts
@@ -42,6 +42,7 @@ export function up(pgm: MigrationBuilder): void {
     updated_at: { type: 'timestamptz' },
     pds_url: { type: 'text' },
     indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    last_synced_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
 
   pgm.createIndex('cosmik_connections_index', 'owner_did');
@@ -64,6 +65,7 @@ export function up(pgm: MigrationBuilder): void {
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
     pds_url: { type: 'text' },
     indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    last_synced_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
 
   pgm.createIndex('cosmik_follows_index', 'follower_did');
@@ -105,6 +107,7 @@ export function up(pgm: MigrationBuilder): void {
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
     pds_url: { type: 'text' },
     indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    last_synced_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
 
   pgm.createIndex('margin_annotations_index', 'author_did');
@@ -130,6 +133,7 @@ export function up(pgm: MigrationBuilder): void {
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
     pds_url: { type: 'text' },
     indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    last_synced_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
 
   pgm.createIndex('margin_bookmarks_index', 'author_did');
@@ -247,6 +251,7 @@ export function up(pgm: MigrationBuilder): void {
     removed_at: { type: 'timestamptz', notNull: true },
     pds_url: { type: 'text' },
     indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    last_synced_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
   });
 
   pgm.createIndex('cosmik_link_removals_index', 'collection_uri');

--- a/src/storage/postgresql/migrations/1741200000000_semble-integration.ts
+++ b/src/storage/postgresql/migrations/1741200000000_semble-integration.ts
@@ -230,9 +230,10 @@ export function up(pgm: MigrationBuilder): void {
   // =========================================================================
   // 8. Add collaborators column to collections_index
   // =========================================================================
-  pgm.addColumns('collections_index', {
-    collaborators: { type: 'jsonb', default: "'[]'::jsonb" },
-  });
+  pgm.sql(`
+    ALTER TABLE collections_index
+    ADD COLUMN collaborators jsonb NOT NULL DEFAULT '[]'::jsonb
+  `);
 
   // =========================================================================
   // 9. Cosmik collection link removals index (tombstones)
@@ -259,7 +260,7 @@ export function up(pgm: MigrationBuilder): void {
  */
 export function down(pgm: MigrationBuilder): void {
   pgm.dropTable('cosmik_link_removals_index');
-  pgm.dropColumns('collections_index', ['collaborators']);
+  pgm.sql('ALTER TABLE collections_index DROP COLUMN IF EXISTS collaborators');
 
   // Restore previous refresh_backlink_counts function
   pgm.sql(`

--- a/src/storage/postgresql/migrations/1741200000000_semble-integration.ts
+++ b/src/storage/postgresql/migrations/1741200000000_semble-integration.ts
@@ -1,0 +1,336 @@
+/**
+ * Semble deep integration: connections, follows, collaborators, and Margin annotations.
+ *
+ * @remarks
+ * Adds database support for:
+ * - `cosmik_connections_index`: tracks network.cosmik.connection records (edges between links)
+ * - `cosmik_follows_index`: tracks network.cosmik.follow records (user/collection follows)
+ * - `margin_annotations_index`: tracks at.margin.annotation and at.margin.highlight records
+ * - `margin_bookmarks_index`: tracks at.margin.bookmark records
+ * - New backlink source types: cosmik.connection, cosmik.follow, margin.annotation,
+ *   margin.highlight, margin.bookmark
+ * - `margin_count` column on backlink_counts
+ * - `collaborators` column on collections_index
+ *
+ * @packageDocumentation
+ */
+
+import type { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+/**
+ * Apply migration: add Semble integration tables and columns.
+ *
+ * @param pgm - PostgreSQL migration builder
+ */
+export function up(pgm: MigrationBuilder): void {
+  // =========================================================================
+  // 1. Cosmik connections index (edges between links)
+  // =========================================================================
+  pgm.createTable('cosmik_connections_index', {
+    uri: { type: 'text', primaryKey: true },
+    cid: { type: 'text', notNull: true },
+    owner_did: { type: 'text', notNull: true },
+    source_entity: { type: 'text', notNull: true },
+    target_entity: { type: 'text', notNull: true },
+    connection_type: { type: 'text' },
+    note: { type: 'text' },
+    /** AT-URI of the corresponding pub.chive.graph.edge, if dual-written */
+    chive_edge_uri: { type: 'text' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    updated_at: { type: 'timestamptz' },
+    pds_url: { type: 'text' },
+    indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('cosmik_connections_index', 'owner_did');
+  pgm.createIndex('cosmik_connections_index', 'source_entity');
+  pgm.createIndex('cosmik_connections_index', 'target_entity');
+  pgm.createIndex('cosmik_connections_index', 'connection_type');
+  pgm.createIndex('cosmik_connections_index', 'chive_edge_uri');
+
+  // =========================================================================
+  // 2. Cosmik follows index
+  // =========================================================================
+  pgm.createTable('cosmik_follows_index', {
+    uri: { type: 'text', primaryKey: true },
+    cid: { type: 'text', notNull: true },
+    follower_did: { type: 'text', notNull: true },
+    /** DID for user follows, AT-URI for collection follows */
+    subject: { type: 'text', notNull: true },
+    /** 'user' or 'collection' */
+    subject_type: { type: 'text', notNull: true },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    pds_url: { type: 'text' },
+    indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('cosmik_follows_index', 'follower_did');
+  pgm.createIndex('cosmik_follows_index', 'subject');
+  pgm.createIndex('cosmik_follows_index', 'subject_type');
+  pgm.addConstraint('cosmik_follows_index', 'cosmik_follows_unique_pair', {
+    unique: ['follower_did', 'subject'],
+  });
+
+  // =========================================================================
+  // 3. Margin annotations index
+  // =========================================================================
+  pgm.createTable('margin_annotations_index', {
+    uri: { type: 'text', primaryKey: true },
+    cid: { type: 'text', notNull: true },
+    author_did: { type: 'text', notNull: true },
+    /** URL being annotated */
+    source_url: { type: 'text', notNull: true },
+    /** SHA256 of normalized URL for fast lookup */
+    source_hash: { type: 'text' },
+    /** Record type: 'annotation', 'highlight' */
+    record_type: { type: 'text', notNull: true },
+    /** W3C motivation: commenting, highlighting, assessing, etc. */
+    motivation: { type: 'text' },
+    /** Annotation body text */
+    body: { type: 'text' },
+    /** Body format MIME type */
+    body_format: { type: 'text' },
+    /** Page title at annotation time */
+    page_title: { type: 'text' },
+    /** JSON-encoded selector for positioning */
+    selector_json: { type: 'jsonb' },
+    /** Highlight color (for highlight records) */
+    color: { type: 'text' },
+    /** JSON-encoded tags array */
+    tags: { type: 'jsonb' },
+    /** AT-URI of the Chive eprint this targets, if resolved */
+    eprint_uri: { type: 'text' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    pds_url: { type: 'text' },
+    indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('margin_annotations_index', 'author_did');
+  pgm.createIndex('margin_annotations_index', 'source_url');
+  pgm.createIndex('margin_annotations_index', 'source_hash');
+  pgm.createIndex('margin_annotations_index', 'eprint_uri');
+  pgm.createIndex('margin_annotations_index', 'record_type');
+  pgm.createIndex('margin_annotations_index', 'motivation');
+
+  // =========================================================================
+  // 4. Margin bookmarks index
+  // =========================================================================
+  pgm.createTable('margin_bookmarks_index', {
+    uri: { type: 'text', primaryKey: true },
+    cid: { type: 'text', notNull: true },
+    author_did: { type: 'text', notNull: true },
+    source_url: { type: 'text', notNull: true },
+    source_hash: { type: 'text' },
+    title: { type: 'text' },
+    description: { type: 'text' },
+    tags: { type: 'jsonb' },
+    eprint_uri: { type: 'text' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    pds_url: { type: 'text' },
+    indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('margin_bookmarks_index', 'author_did');
+  pgm.createIndex('margin_bookmarks_index', 'source_url');
+  pgm.createIndex('margin_bookmarks_index', 'source_hash');
+  pgm.createIndex('margin_bookmarks_index', 'eprint_uri');
+
+  // =========================================================================
+  // 5. Add margin_count to backlink_counts
+  // =========================================================================
+  pgm.addColumns('backlink_counts', {
+    margin_count: { type: 'integer', notNull: true, default: 0 },
+    cosmik_connection_count: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  // =========================================================================
+  // 6. Update backlinks source_type check constraint
+  // =========================================================================
+  pgm.sql(`
+    ALTER TABLE backlinks
+    DROP CONSTRAINT IF EXISTS backlinks_source_type_check
+  `);
+  pgm.sql(`
+    ALTER TABLE backlinks
+    ADD CONSTRAINT backlinks_source_type_check
+    CHECK (source_type IN (
+      'cosmik.collection',
+      'cosmik.connection',
+      'cosmik.follow',
+      'leaflet.list',
+      'whitewind.blog',
+      'bluesky.post',
+      'bluesky.embed',
+      'chive.comment',
+      'chive.endorsement',
+      'margin.annotation',
+      'margin.highlight',
+      'margin.bookmark',
+      'other'
+    ))
+  `);
+
+  // =========================================================================
+  // 7. Update refresh_backlink_counts function
+  // =========================================================================
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION refresh_backlink_counts(p_target_uri text)
+    RETURNS void AS $$
+    BEGIN
+      INSERT INTO backlink_counts (
+        target_uri,
+        cosmik_count,
+        cosmik_connection_count,
+        margin_count,
+        leaflet_count,
+        whitewind_count,
+        bluesky_post_count,
+        bluesky_embed_count,
+        comment_count,
+        endorsement_count,
+        other_count,
+        total_count,
+        last_updated_at
+      )
+      SELECT
+        p_target_uri,
+        COUNT(*) FILTER (WHERE source_type = 'cosmik.collection'),
+        COUNT(*) FILTER (WHERE source_type = 'cosmik.connection'),
+        COUNT(*) FILTER (WHERE source_type IN ('margin.annotation', 'margin.highlight', 'margin.bookmark')),
+        COUNT(*) FILTER (WHERE source_type = 'leaflet.list'),
+        COUNT(*) FILTER (WHERE source_type = 'whitewind.blog'),
+        COUNT(*) FILTER (WHERE source_type = 'bluesky.post'),
+        COUNT(*) FILTER (WHERE source_type = 'bluesky.embed'),
+        COUNT(*) FILTER (WHERE source_type = 'chive.comment'),
+        COUNT(*) FILTER (WHERE source_type = 'chive.endorsement'),
+        COUNT(*) FILTER (WHERE source_type = 'other'),
+        COUNT(*),
+        NOW()
+      FROM backlinks
+      WHERE target_uri = p_target_uri AND is_deleted = false
+      ON CONFLICT (target_uri) DO UPDATE SET
+        cosmik_count = EXCLUDED.cosmik_count,
+        cosmik_connection_count = EXCLUDED.cosmik_connection_count,
+        margin_count = EXCLUDED.margin_count,
+        leaflet_count = EXCLUDED.leaflet_count,
+        whitewind_count = EXCLUDED.whitewind_count,
+        bluesky_post_count = EXCLUDED.bluesky_post_count,
+        bluesky_embed_count = EXCLUDED.bluesky_embed_count,
+        comment_count = EXCLUDED.comment_count,
+        endorsement_count = EXCLUDED.endorsement_count,
+        other_count = EXCLUDED.other_count,
+        total_count = EXCLUDED.total_count,
+        last_updated_at = NOW();
+    END;
+    $$ LANGUAGE plpgsql
+  `);
+
+  // =========================================================================
+  // 8. Add collaborators column to collections_index
+  // =========================================================================
+  pgm.addColumns('collections_index', {
+    collaborators: { type: 'jsonb', default: "'[]'::jsonb" },
+  });
+
+  // =========================================================================
+  // 9. Cosmik collection link removals index (tombstones)
+  // =========================================================================
+  pgm.createTable('cosmik_link_removals_index', {
+    uri: { type: 'text', primaryKey: true },
+    cid: { type: 'text', notNull: true },
+    owner_did: { type: 'text', notNull: true },
+    collection_uri: { type: 'text', notNull: true },
+    removed_link_uri: { type: 'text', notNull: true },
+    removed_at: { type: 'timestamptz', notNull: true },
+    pds_url: { type: 'text' },
+    indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('cosmik_link_removals_index', 'collection_uri');
+  pgm.createIndex('cosmik_link_removals_index', 'removed_link_uri');
+}
+
+/**
+ * Rollback migration.
+ *
+ * @param pgm - PostgreSQL migration builder
+ */
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable('cosmik_link_removals_index');
+  pgm.dropColumns('collections_index', ['collaborators']);
+
+  // Restore previous refresh_backlink_counts function
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION refresh_backlink_counts(p_target_uri text)
+    RETURNS void AS $$
+    BEGIN
+      INSERT INTO backlink_counts (
+        target_uri,
+        cosmik_count,
+        leaflet_count,
+        whitewind_count,
+        bluesky_post_count,
+        bluesky_embed_count,
+        comment_count,
+        endorsement_count,
+        other_count,
+        total_count,
+        last_updated_at
+      )
+      SELECT
+        p_target_uri,
+        COUNT(*) FILTER (WHERE source_type = 'cosmik.collection'),
+        COUNT(*) FILTER (WHERE source_type = 'leaflet.list'),
+        COUNT(*) FILTER (WHERE source_type = 'whitewind.blog'),
+        COUNT(*) FILTER (WHERE source_type = 'bluesky.post'),
+        COUNT(*) FILTER (WHERE source_type = 'bluesky.embed'),
+        COUNT(*) FILTER (WHERE source_type = 'chive.comment'),
+        COUNT(*) FILTER (WHERE source_type = 'chive.endorsement'),
+        COUNT(*) FILTER (WHERE source_type = 'other'),
+        COUNT(*),
+        NOW()
+      FROM backlinks
+      WHERE target_uri = p_target_uri AND is_deleted = false
+      ON CONFLICT (target_uri) DO UPDATE SET
+        cosmik_count = EXCLUDED.cosmik_count,
+        leaflet_count = EXCLUDED.leaflet_count,
+        whitewind_count = EXCLUDED.whitewind_count,
+        bluesky_post_count = EXCLUDED.bluesky_post_count,
+        bluesky_embed_count = EXCLUDED.bluesky_embed_count,
+        comment_count = EXCLUDED.comment_count,
+        endorsement_count = EXCLUDED.endorsement_count,
+        other_count = EXCLUDED.other_count,
+        total_count = EXCLUDED.total_count,
+        last_updated_at = NOW();
+    END;
+    $$ LANGUAGE plpgsql
+  `);
+
+  // Restore source_type constraint
+  pgm.sql(`
+    ALTER TABLE backlinks
+    DROP CONSTRAINT IF EXISTS backlinks_source_type_check
+  `);
+  pgm.sql(`
+    ALTER TABLE backlinks
+    ADD CONSTRAINT backlinks_source_type_check
+    CHECK (source_type IN (
+      'cosmik.collection',
+      'leaflet.list',
+      'whitewind.blog',
+      'bluesky.post',
+      'bluesky.embed',
+      'chive.comment',
+      'chive.endorsement',
+      'other'
+    ))
+  `);
+
+  pgm.dropColumns('backlink_counts', ['margin_count', 'cosmik_connection_count']);
+  pgm.dropTable('margin_bookmarks_index');
+  pgm.dropTable('margin_annotations_index');
+  pgm.dropTable('cosmik_follows_index');
+  pgm.dropTable('cosmik_connections_index');
+}

--- a/src/types/interfaces/plugin.interface.ts
+++ b/src/types/interfaces/plugin.interface.ts
@@ -1458,10 +1458,15 @@ export function isImportingPlugin(plugin: IChivePlugin): plugin is ImportingPlug
  */
 export type BacklinkSourceType =
   | 'cosmik.collection'
+  | 'cosmik.connection'
+  | 'cosmik.follow'
   | 'leaflet.list'
   | 'whitewind.blog'
   | 'bluesky.post'
   | 'bluesky.embed'
+  | 'margin.annotation'
+  | 'margin.highlight'
+  | 'margin.bookmark'
   | 'other';
 
 /**

--- a/tests/compliance/database-compliance.test.ts
+++ b/tests/compliance/database-compliance.test.ts
@@ -601,12 +601,12 @@ describe('ATProto Database Compliance', () => {
         {
           name: 'Index semantics (_index naming)',
           query: `SELECT COUNT(*) as count FROM information_schema.tables WHERE table_schema = 'public' AND table_name LIKE '%_index'`,
-          expected: 17, // eprints, reviews, endorsements, user_tags, relevance_logs, activity_log, authors, coauthor_claims, changelogs, annotations, entity_links, user_related_works, personal_graph_nodes, personal_graph_edges, collections, collection_edges, eprint_versions
+          expected: 22, // eprints, reviews, endorsements, user_tags, relevance_logs, activity_log, authors, coauthor_claims, changelogs, annotations, entity_links, user_related_works, personal_graph_nodes, personal_graph_edges, collections, collection_edges, eprint_versions, cosmik_connections, cosmik_follows, margin_annotations, margin_bookmarks, cosmik_link_removals
         },
         {
           name: 'PDS source tracking',
           query: `SELECT COUNT(*) as count FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE '%_index' AND column_name = 'pds_url'`,
-          expected: 17, // All index tables have pds_url
+          expected: 22, // All index tables have pds_url
         },
         {
           name: 'No blob data',

--- a/tests/unit/plugins/builtin/cosmik-connections.test.ts
+++ b/tests/unit/plugins/builtin/cosmik-connections.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Unit tests for CosmikConnectionsPlugin.
+ *
+ * @remarks
+ * Tests backlink tracking from Cosmik connections to Chive eprints.
+ *
+ * @packageDocumentation
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { CosmikConnectionsPlugin } from '../../../../src/plugins/builtin/cosmik-connections.js';
+import type { FirehoseRecord } from '../../../../src/plugins/core/backlink-plugin.js';
+import type { ILogger } from '../../../../src/types/interfaces/logger.interface.js';
+import type {
+  ICacheProvider,
+  IMetrics,
+  IPluginContext,
+  IPluginEventBus,
+  IBacklinkService,
+} from '../../../../src/types/interfaces/plugin.interface.js';
+
+// ============================================================================
+// Mock Factories
+// ============================================================================
+
+const createMockLogger = (): ILogger => {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => logger),
+  };
+  return logger;
+};
+
+const createMockCache = (): ICacheProvider => ({
+  get: vi.fn().mockResolvedValue(null),
+  set: vi.fn().mockResolvedValue(undefined),
+  delete: vi.fn().mockResolvedValue(undefined),
+  exists: vi.fn().mockResolvedValue(false),
+  expire: vi.fn().mockResolvedValue(undefined),
+});
+
+const createMockMetrics = (): IMetrics => ({
+  incrementCounter: vi.fn(),
+  setGauge: vi.fn(),
+  observeHistogram: vi.fn(),
+  startTimer: vi.fn().mockReturnValue(() => {}),
+});
+
+const createMockEventBus = (): IPluginEventBus => ({
+  on: vi.fn(),
+  once: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+  emitAsync: vi.fn().mockResolvedValue(undefined),
+  listenerCount: vi.fn().mockReturnValue(0),
+  eventNames: vi.fn().mockReturnValue([]),
+  removeAllListeners: vi.fn(),
+});
+
+const createMockBacklinkService = (): IBacklinkService => ({
+  createBacklink: vi.fn().mockResolvedValue({
+    id: 1,
+    sourceUri: 'at://did:plc:user/network.cosmik.connection/abc123',
+    sourceType: 'cosmik.connection',
+    targetUri: 'at://did:plc:author/pub.chive.eprint.submission/xyz789',
+    context: 'type: cites',
+    indexedAt: new Date(),
+    deleted: false,
+  }),
+  deleteBacklink: vi.fn().mockResolvedValue(undefined),
+  getBacklinks: vi.fn().mockResolvedValue({ backlinks: [], cursor: undefined }),
+  getCounts: vi.fn().mockResolvedValue({
+    cosmikCollections: 0,
+    leafletLists: 0,
+    whitewindBlogs: 0,
+    blueskyPosts: 0,
+    blueskyEmbeds: 0,
+    total: 0,
+  }),
+  updateCounts: vi.fn().mockResolvedValue(undefined),
+});
+
+const createMockContext = (overrides?: Partial<IPluginContext>): IPluginContext => ({
+  logger: createMockLogger(),
+  cache: createMockCache(),
+  metrics: createMockMetrics(),
+  eventBus: createMockEventBus(),
+  config: {
+    backlinkService: createMockBacklinkService(),
+  },
+  ...overrides,
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('CosmikConnectionsPlugin', () => {
+  let plugin: CosmikConnectionsPlugin;
+
+  beforeEach(() => {
+    plugin = new CosmikConnectionsPlugin();
+  });
+
+  describe('extractEprintRefs', () => {
+    it('extracts eprint AT-URI from source', () => {
+      const record = {
+        $type: 'network.cosmik.connection',
+        source: 'at://did:plc:abc/pub.chive.eprint.submission/123',
+        target: 'https://example.com',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toEqual(['at://did:plc:abc/pub.chive.eprint.submission/123']);
+    });
+
+    it('extracts eprint AT-URI from target', () => {
+      const record = {
+        $type: 'network.cosmik.connection',
+        source: 'https://example.com',
+        target: 'at://did:plc:abc/pub.chive.eprint.submission/456',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toEqual(['at://did:plc:abc/pub.chive.eprint.submission/456']);
+    });
+
+    it('extracts from both source and target', () => {
+      const record = {
+        $type: 'network.cosmik.connection',
+        source: 'at://did:plc:abc/pub.chive.eprint.submission/123',
+        target:
+          'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Adef%2Fpub.chive.eprint.submission%2F456',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(2);
+    });
+
+    it('returns empty for non-Chive URLs', () => {
+      const record = {
+        $type: 'network.cosmik.connection',
+        source: 'https://example.com/paper1',
+        target: 'https://arxiv.org/abs/1234',
+        connectionType: 'cites',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(0);
+    });
+  });
+
+  describe('handleFirehoseRecord', () => {
+    it('creates backlinks for records with eprint refs', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      const firehoseRecord: FirehoseRecord = {
+        uri: 'at://did:plc:user/network.cosmik.connection/abc',
+        collection: 'network.cosmik.connection',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: {
+          $type: 'network.cosmik.connection',
+          source: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
+          target: 'https://example.com/paper',
+          connectionType: 'cites',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+        deleted: false,
+        timestamp: new Date(),
+      };
+
+      await plugin.handleFirehoseRecord(firehoseRecord);
+
+      expect(backlinkService.createBacklink).toHaveBeenCalledWith({
+        sourceUri: 'at://did:plc:user/network.cosmik.connection/abc',
+        sourceType: 'cosmik.connection',
+        targetUri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
+        context: 'type: cites',
+      });
+    });
+
+    it('handles deletions', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      const firehoseRecord: FirehoseRecord = {
+        uri: 'at://did:plc:user/network.cosmik.connection/abc',
+        collection: 'network.cosmik.connection',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: null,
+        deleted: true,
+        timestamp: new Date(),
+      };
+
+      await plugin.handleFirehoseRecord(firehoseRecord);
+
+      expect(backlinkService.deleteBacklink).toHaveBeenCalledWith(
+        'at://did:plc:user/network.cosmik.connection/abc'
+      );
+    });
+
+    it('skips records without eprint refs', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      const firehoseRecord: FirehoseRecord = {
+        uri: 'at://did:plc:user/network.cosmik.connection/abc',
+        collection: 'network.cosmik.connection',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: {
+          $type: 'network.cosmik.connection',
+          source: 'https://example.com/a',
+          target: 'https://example.com/b',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+        deleted: false,
+        timestamp: new Date(),
+      };
+
+      await plugin.handleFirehoseRecord(firehoseRecord);
+
+      expect(backlinkService.createBacklink).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/plugins/builtin/margin-annotations.test.ts
+++ b/tests/unit/plugins/builtin/margin-annotations.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for Margin annotation plugins.
+ *
+ * @remarks
+ * Tests backlink tracking from Margin annotations, highlights, and bookmarks
+ * to Chive eprints.
+ *
+ * @packageDocumentation
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  MarginAnnotationsPlugin,
+  MarginHighlightsPlugin,
+  MarginBookmarksPlugin,
+} from '../../../../src/plugins/builtin/margin-annotations.js';
+import type { FirehoseRecord } from '../../../../src/plugins/core/backlink-plugin.js';
+import type { ILogger } from '../../../../src/types/interfaces/logger.interface.js';
+import type {
+  ICacheProvider,
+  IMetrics,
+  IPluginContext,
+  IPluginEventBus,
+  IBacklinkService,
+} from '../../../../src/types/interfaces/plugin.interface.js';
+
+// ============================================================================
+// Mock Factories
+// ============================================================================
+
+const createMockLogger = (): ILogger => {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => logger),
+  };
+  return logger;
+};
+
+const createMockCache = (): ICacheProvider => ({
+  get: vi.fn().mockResolvedValue(null),
+  set: vi.fn().mockResolvedValue(undefined),
+  delete: vi.fn().mockResolvedValue(undefined),
+  exists: vi.fn().mockResolvedValue(false),
+  expire: vi.fn().mockResolvedValue(undefined),
+});
+
+const createMockMetrics = (): IMetrics => ({
+  incrementCounter: vi.fn(),
+  setGauge: vi.fn(),
+  observeHistogram: vi.fn(),
+  startTimer: vi.fn().mockReturnValue(() => {}),
+});
+
+const createMockEventBus = (): IPluginEventBus => ({
+  on: vi.fn(),
+  once: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+  emitAsync: vi.fn().mockResolvedValue(undefined),
+  listenerCount: vi.fn().mockReturnValue(0),
+  eventNames: vi.fn().mockReturnValue([]),
+  removeAllListeners: vi.fn(),
+});
+
+const createMockBacklinkService = (): IBacklinkService => ({
+  createBacklink: vi.fn().mockResolvedValue({
+    id: 1,
+    sourceUri: 'at://did:plc:user/at.margin.annotation/abc123',
+    sourceType: 'margin.annotation',
+    targetUri: 'at://did:plc:author/pub.chive.eprint.submission/xyz789',
+    context: 'commenting: Great paper!',
+    indexedAt: new Date(),
+    deleted: false,
+  }),
+  deleteBacklink: vi.fn().mockResolvedValue(undefined),
+  getBacklinks: vi.fn().mockResolvedValue({ backlinks: [], cursor: undefined }),
+  getCounts: vi.fn().mockResolvedValue({
+    cosmikCollections: 0,
+    leafletLists: 0,
+    whitewindBlogs: 0,
+    blueskyPosts: 0,
+    blueskyEmbeds: 0,
+    total: 0,
+  }),
+  updateCounts: vi.fn().mockResolvedValue(undefined),
+});
+
+const createMockContext = (overrides?: Partial<IPluginContext>): IPluginContext => ({
+  logger: createMockLogger(),
+  cache: createMockCache(),
+  metrics: createMockMetrics(),
+  eventBus: createMockEventBus(),
+  config: {
+    backlinkService: createMockBacklinkService(),
+  },
+  ...overrides,
+});
+
+// ============================================================================
+// MarginAnnotationsPlugin Tests
+// ============================================================================
+
+describe('MarginAnnotationsPlugin', () => {
+  let plugin: MarginAnnotationsPlugin;
+
+  beforeEach(() => {
+    plugin = new MarginAnnotationsPlugin();
+  });
+
+  describe('handleFirehoseRecord', () => {
+    it('creates backlinks for annotations targeting Chive eprints', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      const firehoseRecord: FirehoseRecord = {
+        uri: 'at://did:plc:user/at.margin.annotation/abc',
+        collection: 'at.margin.annotation',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: {
+          $type: 'at.margin.annotation',
+          target: {
+            source:
+              'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aauthor%2Fpub.chive.eprint.submission%2Fxyz',
+            sourceHash: 'abc123',
+            title: 'An Important Paper',
+          },
+          body: {
+            value: 'This is a well-written paper with novel results.',
+            format: 'text/plain',
+          },
+          motivation: 'commenting',
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        deleted: false,
+        timestamp: new Date(),
+      };
+
+      await plugin.handleFirehoseRecord(firehoseRecord);
+
+      expect(backlinkService.createBacklink).toHaveBeenCalledWith({
+        sourceUri: 'at://did:plc:user/at.margin.annotation/abc',
+        sourceType: 'margin.annotation',
+        targetUri: expect.stringContaining('chive.pub/eprints/'),
+        context: expect.stringContaining('commenting'),
+      });
+    });
+
+    it('handles annotation deletions', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      await plugin.handleFirehoseRecord({
+        uri: 'at://did:plc:user/at.margin.annotation/abc',
+        collection: 'at.margin.annotation',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: null,
+        deleted: true,
+        timestamp: new Date(),
+      });
+
+      expect(backlinkService.deleteBacklink).toHaveBeenCalledWith(
+        'at://did:plc:user/at.margin.annotation/abc'
+      );
+    });
+
+    it('skips annotations targeting non-Chive URLs', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      await plugin.handleFirehoseRecord({
+        uri: 'at://did:plc:user/at.margin.annotation/abc',
+        collection: 'at.margin.annotation',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: {
+          $type: 'at.margin.annotation',
+          target: {
+            source: 'https://arxiv.org/abs/1234.5678',
+          },
+          body: { value: 'Nice paper' },
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        deleted: false,
+        timestamp: new Date(),
+      });
+
+      expect(backlinkService.createBacklink).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ============================================================================
+// MarginHighlightsPlugin Tests
+// ============================================================================
+
+describe('MarginHighlightsPlugin', () => {
+  let plugin: MarginHighlightsPlugin;
+
+  beforeEach(() => {
+    plugin = new MarginHighlightsPlugin();
+  });
+
+  describe('handleFirehoseRecord', () => {
+    it('creates backlinks for highlights on Chive eprints', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      await plugin.handleFirehoseRecord({
+        uri: 'at://did:plc:user/at.margin.highlight/abc',
+        collection: 'at.margin.highlight',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: {
+          $type: 'at.margin.highlight',
+          target: {
+            source:
+              'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aauthor%2Fpub.chive.eprint.submission%2Fxyz',
+            selector: {
+              type: 'TextQuoteSelector',
+              exact: 'This is the key finding of our study.',
+              prefix: 'In conclusion, ',
+              suffix: ' We believe',
+            },
+          },
+          color: '#ffeb3b',
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        deleted: false,
+        timestamp: new Date(),
+      });
+
+      expect(backlinkService.createBacklink).toHaveBeenCalledWith({
+        sourceUri: 'at://did:plc:user/at.margin.highlight/abc',
+        sourceType: 'margin.highlight',
+        targetUri: expect.stringContaining('chive.pub/eprints/'),
+        context: 'highlight (#ffeb3b)',
+      });
+    });
+  });
+});
+
+// ============================================================================
+// MarginBookmarksPlugin Tests
+// ============================================================================
+
+describe('MarginBookmarksPlugin', () => {
+  let plugin: MarginBookmarksPlugin;
+
+  beforeEach(() => {
+    plugin = new MarginBookmarksPlugin();
+  });
+
+  describe('handleFirehoseRecord', () => {
+    it('creates backlinks for bookmarks of Chive eprints', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      await plugin.handleFirehoseRecord({
+        uri: 'at://did:plc:user/at.margin.bookmark/abc',
+        collection: 'at.margin.bookmark',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: {
+          $type: 'at.margin.bookmark',
+          source:
+            'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aauthor%2Fpub.chive.eprint.submission%2Fxyz',
+          sourceHash: 'abc123',
+          title: 'Important NLP Paper',
+          description: 'A groundbreaking study on language models',
+          tags: ['nlp', 'language-models'],
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        deleted: false,
+        timestamp: new Date(),
+      });
+
+      expect(backlinkService.createBacklink).toHaveBeenCalledWith({
+        sourceUri: 'at://did:plc:user/at.margin.bookmark/abc',
+        sourceType: 'margin.bookmark',
+        targetUri: expect.stringContaining('chive.pub/eprints/'),
+        context: 'Important NLP Paper',
+      });
+    });
+
+    it('uses description as context when title is missing', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      await plugin.handleFirehoseRecord({
+        uri: 'at://did:plc:user/at.margin.bookmark/abc',
+        collection: 'at.margin.bookmark',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: {
+          $type: 'at.margin.bookmark',
+          source: 'https://chive.pub/eprints/test',
+          description: 'Interesting read on semantics',
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        deleted: false,
+        timestamp: new Date(),
+      });
+
+      expect(backlinkService.createBacklink).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: 'Interesting read on semantics',
+        })
+      );
+    });
+  });
+});

--- a/tests/unit/plugins/cosmik-connections.test.ts
+++ b/tests/unit/plugins/cosmik-connections.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the CosmikConnectionsPlugin.
+ *
+ * @packageDocumentation
+ */
+
+import 'reflect-metadata';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { CosmikConnectionsPlugin } from '@/plugins/builtin/cosmik-connections.js';
+
+describe('CosmikConnectionsPlugin', () => {
+  let plugin: CosmikConnectionsPlugin;
+
+  beforeEach(() => {
+    plugin = new CosmikConnectionsPlugin();
+  });
+
+  describe('metadata', () => {
+    it('has correct plugin ID', () => {
+      expect(plugin.id).toBe('pub.chive.plugin.cosmik-connections');
+    });
+
+    it('tracks network.cosmik.connection collection', () => {
+      expect(plugin.trackedCollection).toBe('network.cosmik.connection');
+    });
+
+    it('uses cosmik.connection source type', () => {
+      expect(plugin.sourceType).toBe('cosmik.connection');
+    });
+
+    it('declares correct firehose hook permission', () => {
+      const hooks = plugin.manifest.permissions.hooks ?? [];
+      expect(hooks).toContain('firehose.network.cosmik.connection');
+    });
+  });
+
+  describe('extractEprintRefs', () => {
+    it('extracts eprint AT-URI from source field', () => {
+      const record = {
+        $type: 'network.cosmik.connection',
+        source: 'at://did:plc:abc/pub.chive.eprint.submission/123',
+        target: 'https://example.com',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toContain('at://did:plc:abc/pub.chive.eprint.submission/123');
+    });
+
+    it('extracts eprint AT-URI from target field', () => {
+      const record = {
+        $type: 'network.cosmik.connection',
+        source: 'https://example.com',
+        target: 'at://did:plc:abc/pub.chive.eprint.submission/456',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toContain('at://did:plc:abc/pub.chive.eprint.submission/456');
+    });
+
+    it('extracts Chive web URL from source field', () => {
+      const record = {
+        $type: 'network.cosmik.connection',
+        source:
+          'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aabc%2Fpub.chive.eprint.submission%2F123',
+        target: 'https://example.com',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(1);
+    });
+
+    it('extracts refs from both source and target', () => {
+      const record = {
+        $type: 'network.cosmik.connection',
+        source: 'at://did:plc:abc/pub.chive.eprint.submission/123',
+        target:
+          'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Adef%2Fpub.chive.eprint.submission%2F456',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(2);
+    });
+
+    it('returns empty for non-Chive URLs', () => {
+      const record = {
+        $type: 'network.cosmik.connection',
+        source: 'https://example.com/paper',
+        target: 'https://arxiv.org/abs/1234',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/plugins/cosmik-follows.test.ts
+++ b/tests/unit/plugins/cosmik-follows.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for the CosmikFollowsPlugin.
+ *
+ * @packageDocumentation
+ */
+
+import 'reflect-metadata';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { CosmikFollowsPlugin } from '@/plugins/builtin/cosmik-follows.js';
+
+describe('CosmikFollowsPlugin', () => {
+  let plugin: CosmikFollowsPlugin;
+
+  beforeEach(() => {
+    plugin = new CosmikFollowsPlugin();
+  });
+
+  describe('metadata', () => {
+    it('has correct plugin ID', () => {
+      expect(plugin.id).toBe('pub.chive.plugin.cosmik-follows');
+    });
+
+    it('declares correct firehose hook permission', () => {
+      const hooks = plugin.manifest.permissions.hooks ?? [];
+      expect(hooks).toContain('firehose.network.cosmik.follow');
+    });
+
+    it('has a valid version', () => {
+      expect(plugin.manifest.version).toBe('0.5.2');
+    });
+  });
+});

--- a/tests/unit/plugins/cosmik-link-removals.test.ts
+++ b/tests/unit/plugins/cosmik-link-removals.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for the CosmikLinkRemovalsPlugin.
+ *
+ * @packageDocumentation
+ */
+
+import 'reflect-metadata';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { CosmikLinkRemovalsPlugin } from '@/plugins/builtin/cosmik-link-removals.js';
+
+describe('CosmikLinkRemovalsPlugin', () => {
+  let plugin: CosmikLinkRemovalsPlugin;
+
+  beforeEach(() => {
+    plugin = new CosmikLinkRemovalsPlugin();
+  });
+
+  describe('metadata', () => {
+    it('has correct plugin ID', () => {
+      expect(plugin.id).toBe('pub.chive.plugin.cosmik-link-removals');
+    });
+
+    it('declares correct firehose hook permission', () => {
+      const hooks = plugin.manifest.permissions.hooks ?? [];
+      expect(hooks).toContain('firehose.network.cosmik.collectionLinkRemoval');
+    });
+
+    it('has a valid version', () => {
+      expect(plugin.manifest.version).toBe('0.5.2');
+    });
+  });
+});

--- a/tests/unit/plugins/margin-annotations.test.ts
+++ b/tests/unit/plugins/margin-annotations.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for the Margin annotations tracking plugins.
+ *
+ * @packageDocumentation
+ */
+
+import 'reflect-metadata';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  MarginAnnotationsPlugin,
+  MarginHighlightsPlugin,
+  MarginBookmarksPlugin,
+} from '@/plugins/builtin/margin-annotations.js';
+
+describe('MarginAnnotationsPlugin', () => {
+  let plugin: MarginAnnotationsPlugin;
+
+  beforeEach(() => {
+    plugin = new MarginAnnotationsPlugin();
+  });
+
+  describe('metadata', () => {
+    it('has correct plugin ID', () => {
+      expect(plugin.id).toBe('pub.chive.plugin.margin-annotations');
+    });
+
+    it('tracks at.margin.annotation collection', () => {
+      expect(plugin.trackedCollection).toBe('at.margin.annotation');
+    });
+
+    it('uses margin.annotation source type', () => {
+      expect(plugin.sourceType).toBe('margin.annotation');
+    });
+
+    it('declares correct firehose hook permission', () => {
+      const hooks = plugin.manifest.permissions.hooks ?? [];
+      expect(hooks).toContain('firehose.at.margin.annotation');
+    });
+  });
+
+  describe('extractEprintRefs', () => {
+    it('extracts Chive eprint URL from target.source', () => {
+      const record = {
+        $type: 'at.margin.annotation',
+        target: {
+          source:
+            'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aabc%2Fpub.chive.eprint.submission%2F123',
+          sourceHash: 'abc123',
+        },
+        body: { value: 'Great paper!' },
+        motivation: 'commenting',
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(1);
+      expect(refs[0]).toContain('chive.pub/eprints/');
+    });
+
+    it('extracts eprint AT-URI from target.source', () => {
+      const record = {
+        $type: 'at.margin.annotation',
+        target: {
+          source: 'at://did:plc:abc/pub.chive.eprint.submission/123',
+        },
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(1);
+    });
+
+    it('returns empty for non-Chive URLs', () => {
+      const record = {
+        $type: 'at.margin.annotation',
+        target: {
+          source: 'https://arxiv.org/abs/1234.5678',
+          sourceHash: 'def456',
+        },
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(0);
+    });
+
+    it('returns empty when target.source is missing', () => {
+      const record = {
+        $type: 'at.margin.annotation',
+        target: {},
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(0);
+    });
+  });
+});
+
+describe('MarginHighlightsPlugin', () => {
+  let plugin: MarginHighlightsPlugin;
+
+  beforeEach(() => {
+    plugin = new MarginHighlightsPlugin();
+  });
+
+  describe('metadata', () => {
+    it('has correct plugin ID', () => {
+      expect(plugin.id).toBe('pub.chive.plugin.margin-highlights');
+    });
+
+    it('tracks at.margin.highlight collection', () => {
+      expect(plugin.trackedCollection).toBe('at.margin.highlight');
+    });
+
+    it('uses margin.highlight source type', () => {
+      expect(plugin.sourceType).toBe('margin.highlight');
+    });
+  });
+
+  describe('extractEprintRefs', () => {
+    it('extracts Chive URL from highlight target', () => {
+      const record = {
+        $type: 'at.margin.highlight',
+        target: {
+          source:
+            'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aabc%2Fpub.chive.eprint.submission%2F123',
+        },
+        color: '#ffeb3b',
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(1);
+    });
+
+    it('returns empty for non-Chive highlights', () => {
+      const record = {
+        $type: 'at.margin.highlight',
+        target: { source: 'https://example.com/article' },
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(0);
+    });
+  });
+});
+
+describe('MarginBookmarksPlugin', () => {
+  let plugin: MarginBookmarksPlugin;
+
+  beforeEach(() => {
+    plugin = new MarginBookmarksPlugin();
+  });
+
+  describe('metadata', () => {
+    it('has correct plugin ID', () => {
+      expect(plugin.id).toBe('pub.chive.plugin.margin-bookmarks');
+    });
+
+    it('tracks at.margin.bookmark collection', () => {
+      expect(plugin.trackedCollection).toBe('at.margin.bookmark');
+    });
+
+    it('uses margin.bookmark source type', () => {
+      expect(plugin.sourceType).toBe('margin.bookmark');
+    });
+  });
+
+  describe('extractEprintRefs', () => {
+    it('extracts Chive URL from bookmark source', () => {
+      const record = {
+        $type: 'at.margin.bookmark',
+        source:
+          'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aabc%2Fpub.chive.eprint.submission%2F123',
+        sourceHash: 'abc123',
+        title: 'Interesting Paper',
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(1);
+    });
+
+    it('extracts eprint AT-URI from bookmark source', () => {
+      const record = {
+        $type: 'at.margin.bookmark',
+        source: 'at://did:plc:abc/pub.chive.eprint.submission/123',
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(1);
+    });
+
+    it('returns empty for non-Chive bookmarks', () => {
+      const record = {
+        $type: 'at.margin.bookmark',
+        source: 'https://arxiv.org/abs/1234.5678',
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(0);
+    });
+
+    it('returns context from title', () => {
+      const record = {
+        $type: 'at.margin.bookmark',
+        source: 'https://chive.pub/eprints/test',
+        title: 'Great Paper on NLP',
+        description: 'A comprehensive study',
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      // Access protected method via plugin instance cast
+      const context = (
+        plugin as unknown as { extractContext: (r: unknown) => string | undefined }
+      ).extractContext(record);
+      expect(context).toBe('Great Paper on NLP');
+    });
+  });
+});

--- a/web/components/collection/wizard-steps/step-cosmik.tsx
+++ b/web/components/collection/wizard-steps/step-cosmik.tsx
@@ -4,19 +4,22 @@
  * Semble integration step for the collection wizard.
  *
  * @remarks
- * Step 5: Toggle Semble mirroring and preview what will be created.
+ * Step 5: Toggle Semble mirroring, configure collaborators, edge sync,
+ * and preview what will be created.
  *
  * @packageDocumentation
  */
 
+import { useState, useCallback } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
-import { FileText } from 'lucide-react';
+import { FileText, X, Plus, Link2, Users } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 import type { CollectionFormValues } from './types';
@@ -39,7 +42,7 @@ export interface StepCosmikProps {
 // =============================================================================
 
 /**
- * Semble integration step: toggle mirroring and preview.
+ * Semble integration step: toggle mirroring, collaborators, edge sync, and preview.
  *
  * @param props - Component props
  * @returns Cosmik step element
@@ -47,10 +50,35 @@ export interface StepCosmikProps {
 export function StepCosmik({ form }: StepCosmikProps) {
   const { setValue, watch } = form;
   const enableCosmikMirror = watch('enableCosmikMirror');
+  const syncEdgesAsConnections = watch('syncEdgesAsConnections');
+  const cosmikCollaborators = watch('cosmikCollaborators') ?? [];
   const name = watch('name');
   const description = watch('description');
   const visibility = watch('visibility');
   const items = watch('items') ?? [];
+  const edges = watch('edges') ?? [];
+
+  const [newCollaboratorDid, setNewCollaboratorDid] = useState('');
+
+  const addCollaborator = useCallback(() => {
+    const did = newCollaboratorDid.trim();
+    if (!did || !did.startsWith('did:')) return;
+    if (cosmikCollaborators.includes(did)) return;
+
+    setValue('cosmikCollaborators', [...cosmikCollaborators, did], { shouldDirty: true });
+    setNewCollaboratorDid('');
+  }, [newCollaboratorDid, cosmikCollaborators, setValue]);
+
+  const removeCollaborator = useCallback(
+    (did: string) => {
+      setValue(
+        'cosmikCollaborators',
+        cosmikCollaborators.filter((d) => d !== did),
+        { shouldDirty: true }
+      );
+    },
+    [cosmikCollaborators, setValue]
+  );
 
   return (
     <div className="space-y-6">
@@ -84,6 +112,91 @@ export function StepCosmik({ form }: StepCosmikProps) {
 
           {enableCosmikMirror && (
             <div className="mt-4 space-y-4">
+              {/* Edge sync toggle */}
+              {edges.length > 0 && (
+                <div className="flex items-start gap-3">
+                  <Checkbox
+                    id="sync-edges"
+                    checked={syncEdgesAsConnections}
+                    onCheckedChange={(checked) => {
+                      setValue('syncEdgesAsConnections', !!checked, { shouldDirty: true });
+                    }}
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="sync-edges" className="cursor-pointer flex items-center gap-1">
+                      <Link2 className="h-3.5 w-3.5" />
+                      Sync edges as Semble connections
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Mirror {edges.length} edge{edges.length !== 1 ? 's' : ''} as{' '}
+                      <code className="rounded bg-muted px-1 py-0.5 text-[10px]">
+                        network.cosmik.connection
+                      </code>{' '}
+                      records so relationships are visible in Semble.
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {/* Collaborators section */}
+              <div className="space-y-2">
+                <Label className="flex items-center gap-1">
+                  <Users className="h-3.5 w-3.5" />
+                  Collaborators
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Add DIDs of users who can contribute to this collection on Semble.
+                </p>
+
+                {cosmikCollaborators.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {cosmikCollaborators.map((did) => (
+                      <Badge key={did} variant="secondary" className="gap-1 py-0.5 pl-2 pr-1">
+                        <span className="text-[10px] font-mono truncate max-w-[200px]">{did}</span>
+                        <button
+                          type="button"
+                          onClick={() => removeCollaborator(did)}
+                          className="ml-0.5 rounded-full p-0.5 hover:bg-muted"
+                          aria-label={`Remove collaborator ${did}`}
+                        >
+                          <X className="h-2.5 w-2.5" />
+                        </button>
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={newCollaboratorDid}
+                    onChange={(e) => setNewCollaboratorDid(e.target.value)}
+                    placeholder="did:plc:..."
+                    className="flex h-8 flex-1 rounded-md border border-input bg-transparent px-2 py-1 text-xs font-mono"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        addCollaborator();
+                      }
+                    }}
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={addCollaborator}
+                    disabled={!newCollaboratorDid.trim().startsWith('did:')}
+                    className="h-8"
+                  >
+                    <Plus className="h-3 w-3 mr-1" />
+                    Add
+                  </Button>
+                </div>
+              </div>
+
+              <Separator />
+
+              {/* Mirror preview */}
               <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
                 <h4 className="text-sm font-medium">Semble Mirror Preview</h4>
 
@@ -104,6 +217,12 @@ export function StepCosmik({ form }: StepCosmikProps) {
                       {visibility}
                     </Badge>
                   </div>
+                  {cosmikCollaborators.length > 0 && (
+                    <div className="text-sm">
+                      <span className="text-muted-foreground">Collaborators:</span>{' '}
+                      <span className="font-medium">{cosmikCollaborators.length}</span>
+                    </div>
+                  )}
                 </div>
 
                 <Separator />
@@ -115,6 +234,15 @@ export function StepCosmik({ form }: StepCosmikProps) {
                       {items.length} card{items.length !== 1 ? 's' : ''}
                     </span>
                   </div>
+
+                  {syncEdgesAsConnections && edges.length > 0 && (
+                    <div className="text-sm">
+                      <span className="text-muted-foreground">Connections to create:</span>{' '}
+                      <span className="font-medium">
+                        {edges.length} connection{edges.length !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                  )}
 
                   {items.length > 0 ? (
                     <div className="space-y-1 max-h-[200px] overflow-y-auto">
@@ -159,7 +287,16 @@ export function StepCosmik({ form }: StepCosmikProps) {
                 records and grouped into a{' '}
                 <code className="rounded bg-muted px-1 py-0.5 text-[10px]">
                   network.cosmik.collection
-                </code>{' '}
+                </code>
+                {syncEdgesAsConnections && edges.length > 0 && (
+                  <>
+                    {' '}
+                    with edges as{' '}
+                    <code className="rounded bg-muted px-1 py-0.5 text-[10px]">
+                      network.cosmik.connection
+                    </code>
+                  </>
+                )}{' '}
                 in your PDS.
               </p>
             </div>

--- a/web/components/collection/wizard-steps/step-edges.tsx
+++ b/web/components/collection/wizard-steps/step-edges.tsx
@@ -262,6 +262,14 @@ export function StepEdges({ form }: StepEdgesProps) {
           Define relationships between items. For example, &quot;Paper A cites Paper B&quot; or
           &quot;Author X contributed to Paper Y.&quot;
         </p>
+        {form.watch('enableCosmikMirror') && form.watch('syncEdgesAsConnections') && (
+          <div className="mt-2 flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+            <svg className="h-3 w-3" viewBox="0 0 12 12" fill="currentColor">
+              <circle cx="6" cy="6" r="6" />
+            </svg>
+            Edges will be synced to Semble as connections
+          </div>
+        )}
       </div>
 
       {/* Edge creation form */}

--- a/web/components/collection/wizard-steps/types.ts
+++ b/web/components/collection/wizard-steps/types.ts
@@ -84,6 +84,10 @@ export interface CollectionFormValues {
   edges: CollectionEdgeFormData[];
   subcollections: SubcollectionFormData[];
   enableCosmikMirror: boolean;
+  /** Collaborator DIDs for shared Cosmik collections */
+  cosmikCollaborators: string[];
+  /** Whether to sync edges as Cosmik connections */
+  syncEdgesAsConnections: boolean;
 }
 
 // =============================================================================
@@ -152,6 +156,8 @@ export const collectionFormSchema = z.object({
     )
     .optional(),
   enableCosmikMirror: z.boolean().default(false),
+  cosmikCollaborators: z.array(z.string()).default([]),
+  syncEdgesAsConnections: z.boolean().default(true),
 });
 
 /**

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -3811,6 +3811,8 @@ export async function createCosmikMirror(
     description?: string;
     /** Visibility setting */
     visibility: 'listed' | 'unlisted';
+    /** Collaborator DIDs for shared collections */
+    collaborators?: string[];
     /** Items to create cards for */
     items: Array<{
       /** URL or AT-URI of the item */
@@ -3824,11 +3826,19 @@ export async function createCosmikMirror(
       /** Additional metadata for rich card content */
       metadata?: ItemMetadata;
     }>;
+    /** Inter-item edges to mirror as Cosmik connections */
+    edges?: Array<{
+      sourceUri: string;
+      targetUri: string;
+      relationSlug: string;
+      note?: string;
+    }>;
   }
 ): Promise<{
   cosmikCollectionUri: string;
   cosmikCollectionCid: string;
   cosmikItems: Record<string, CosmikItemMapping>;
+  cosmikConnections: Record<string, CosmikConnectionMapping>;
 }> {
   const did = getAgentDid(agent);
   if (!did) {
@@ -3847,7 +3857,7 @@ export async function createCosmikMirror(
     $type: 'network.cosmik.collection',
     name: input.title,
     accessType: toCosmikAccessType(input.visibility),
-    collaborators: [],
+    collaborators: input.collaborators ?? [],
     createdAt: now,
     updatedAt: now,
   };
@@ -3892,7 +3902,21 @@ export async function createCosmikMirror(
     };
   }
 
-  // Step 3: Update the Chive collection node's metadata with Cosmik URIs
+  // Step 3: Create Cosmik connections for inter-item edges
+  let cosmikConnections: Record<string, CosmikConnectionMapping> = {};
+
+  if (input.edges && input.edges.length > 0) {
+    // Build a map of item AT-URIs to Chive web URLs for connection source/target
+    const itemUrlMap = new Map<string, string>();
+    for (const item of input.items) {
+      const httpUrl = toChiveUrl(item.url, item.itemType, item.subkind);
+      itemUrlMap.set(item.url, httpUrl);
+    }
+
+    cosmikConnections = await createCosmikConnectionsForEdges(agent, input.edges, itemUrlMap);
+  }
+
+  // Step 4: Update the Chive collection node's metadata with Cosmik URIs
   const parsed = parseAtUri(input.collectionUri);
   if (parsed && parsed.did === did) {
     const existingResponse = await agent.com.atproto.repo.getRecord({
@@ -3910,6 +3934,7 @@ export async function createCosmikMirror(
         cosmikCollectionUri,
         cosmikCollectionCid,
         cosmikItems,
+        cosmikConnections,
       },
     };
 
@@ -3924,9 +3949,10 @@ export async function createCosmikMirror(
   recordLogger.info('Cosmik mirror created', {
     cosmikCollectionUri,
     cardCount: Object.keys(cosmikItems).length,
+    connectionCount: Object.keys(cosmikConnections).length,
   });
 
-  return { cosmikCollectionUri, cosmikCollectionCid, cosmikItems };
+  return { cosmikCollectionUri, cosmikCollectionCid, cosmikItems, cosmikConnections };
 }
 
 /**
@@ -3998,7 +4024,8 @@ export async function updateCosmikCollection(
 export async function deleteCosmikMirror(
   agent: Agent,
   cosmikCollectionUri: string,
-  cosmikItems?: Record<string, CosmikItemMapping>
+  cosmikItems?: Record<string, CosmikItemMapping>,
+  cosmikConnections?: Record<string, CosmikConnectionMapping>
 ): Promise<void> {
   const did = getAgentDid(agent);
   if (!did) {
@@ -4007,7 +4034,10 @@ export async function deleteCosmikMirror(
 
   recordLogger.info('Deleting Cosmik mirror', { cosmikCollectionUri });
 
-  // Delete all links and cards first
+  // Delete connections first
+  await deleteCosmikConnections(agent, cosmikConnections);
+
+  // Delete all links and cards
   if (cosmikItems) {
     for (const [url, mapping] of Object.entries(cosmikItems)) {
       try {
@@ -4220,6 +4250,851 @@ async function removeCosmikItemMetadata(
     collection: 'pub.chive.graph.node',
     rkey: parsed.rkey,
     record: updatedRecord,
+  });
+}
+
+// =============================================================================
+// COSMIK CONNECTION RECORDS (edges between links)
+// =============================================================================
+
+/**
+ * Cosmik connection record matching Semble's `network.cosmik.connection` lexicon.
+ *
+ * @remarks
+ * Represents an edge between two entities (URLs or AT URIs) in the Semble graph.
+ * Used to mirror Chive's inter-item edges to the Cosmik/Semble ecosystem.
+ */
+export interface CosmikConnectionRecord {
+  [key: string]: unknown;
+  $type: 'network.cosmik.connection';
+  source: string;
+  target: string;
+  connectionType?: string;
+  note?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Mapping of a Cosmik connection's record URI, stored in Chive node metadata.
+ */
+export interface CosmikConnectionMapping {
+  connectionUri: string;
+  connectionCid: string;
+}
+
+/**
+ * Creates a Cosmik connection record in the user's PDS.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param input - Connection data
+ * @returns Created record result
+ */
+export async function createCosmikConnection(
+  agent: Agent,
+  input: {
+    source: string;
+    target: string;
+    connectionType?: string;
+    note?: string;
+  }
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const now = new Date().toISOString();
+
+  const record: CosmikConnectionRecord = {
+    $type: 'network.cosmik.connection',
+    source: input.source,
+    target: input.target,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  if (input.connectionType) record.connectionType = input.connectionType;
+  if (input.note) record.note = input.note;
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'network.cosmik.connection',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+/**
+ * Deletes a Cosmik connection record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param connectionUri - AT-URI of the connection record
+ */
+export async function deleteCosmikConnection(agent: Agent, connectionUri: string): Promise<void> {
+  const parsed = parseAtUri(connectionUri);
+  if (!parsed) return;
+
+  await agent.com.atproto.repo.deleteRecord({
+    repo: parsed.did,
+    collection: 'network.cosmik.connection',
+    rkey: parsed.rkey,
+  });
+}
+
+/**
+ * Updates a Cosmik connection record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param connectionUri - AT-URI of the connection record
+ * @param changes - Fields to update
+ */
+export async function updateCosmikConnection(
+  agent: Agent,
+  connectionUri: string,
+  changes: {
+    connectionType?: string;
+    note?: string;
+  }
+): Promise<void> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const parsed = parseAtUri(connectionUri);
+  if (!parsed) return;
+
+  const existingResponse = await agent.com.atproto.repo.getRecord({
+    repo: parsed.did,
+    collection: 'network.cosmik.connection',
+    rkey: parsed.rkey,
+  });
+
+  const existing = existingResponse.data.value as CosmikConnectionRecord;
+
+  const updatedRecord: CosmikConnectionRecord = {
+    ...existing,
+    updatedAt: new Date().toISOString(),
+  };
+
+  if (changes.connectionType !== undefined) updatedRecord.connectionType = changes.connectionType;
+  if (changes.note !== undefined) updatedRecord.note = changes.note;
+
+  await agent.com.atproto.repo.putRecord({
+    repo: parsed.did,
+    collection: 'network.cosmik.connection',
+    rkey: parsed.rkey,
+    record: updatedRecord,
+  });
+}
+
+/**
+ * Creates Cosmik connections for all inter-item edges in a collection.
+ *
+ * @remarks
+ * Called during mirror creation and when edges are added to a mirrored collection.
+ * Converts AT-URIs to Chive web URLs for the source/target fields, and maps
+ * Chive relation slugs to Cosmik connectionType values.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param edges - Inter-item edges to mirror
+ * @param itemUrlMap - Map of item AT-URIs to their Chive web URLs
+ * @returns Mapping of Chive edge key to Cosmik connection URI/CID
+ */
+export async function createCosmikConnectionsForEdges(
+  agent: Agent,
+  edges: Array<{
+    sourceUri: string;
+    targetUri: string;
+    relationSlug: string;
+    note?: string;
+  }>,
+  itemUrlMap: Map<string, string>
+): Promise<Record<string, CosmikConnectionMapping>> {
+  const connections: Record<string, CosmikConnectionMapping> = {};
+
+  for (const edge of edges) {
+    const sourceUrl = itemUrlMap.get(edge.sourceUri) ?? edge.sourceUri;
+    const targetUrl = itemUrlMap.get(edge.targetUri) ?? edge.targetUri;
+
+    const result = await createCosmikConnection(agent, {
+      source: sourceUrl,
+      target: targetUrl,
+      connectionType: edge.relationSlug,
+      note: edge.note,
+    });
+
+    const edgeKey = `${edge.sourceUri}::${edge.targetUri}::${edge.relationSlug}`;
+    connections[edgeKey] = {
+      connectionUri: result.uri,
+      connectionCid: result.cid,
+    };
+  }
+
+  return connections;
+}
+
+/**
+ * Deletes all Cosmik connections associated with a mirror.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param cosmikConnections - Mapping of edge keys to connection URIs
+ */
+export async function deleteCosmikConnections(
+  agent: Agent,
+  cosmikConnections?: Record<string, CosmikConnectionMapping>
+): Promise<void> {
+  if (!cosmikConnections) return;
+
+  for (const [key, mapping] of Object.entries(cosmikConnections)) {
+    try {
+      await deleteCosmikConnection(agent, mapping.connectionUri);
+    } catch (err) {
+      recordLogger.warn('Failed to delete Cosmik connection', {
+        key,
+        connectionUri: mapping.connectionUri,
+        err,
+      });
+    }
+  }
+}
+
+// =============================================================================
+// COSMIK COLLECTION LINK REMOVAL (tombstones for collaborative collections)
+// =============================================================================
+
+/**
+ * Cosmik collectionLinkRemoval record matching Semble's lexicon.
+ *
+ * @remarks
+ * Created by a collection owner to indicate that a collaborator's link
+ * has been removed. Since the owner cannot delete records in another user's
+ * PDS, this tombstone record signals the removal.
+ */
+export interface CosmikCollectionLinkRemovalRecord {
+  [key: string]: unknown;
+  $type: 'network.cosmik.collectionLinkRemoval';
+  collection: { uri: string; cid: string };
+  removedLink: { uri: string; cid: string };
+  removedAt: string;
+}
+
+/**
+ * Creates a collectionLinkRemoval tombstone record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param input - Removal data
+ * @returns Created record result
+ */
+export async function createCosmikCollectionLinkRemoval(
+  agent: Agent,
+  input: {
+    collectionUri: string;
+    collectionCid: string;
+    linkUri: string;
+    linkCid: string;
+  }
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const record: CosmikCollectionLinkRemovalRecord = {
+    $type: 'network.cosmik.collectionLinkRemoval',
+    collection: { uri: input.collectionUri, cid: input.collectionCid },
+    removedLink: { uri: input.linkUri, cid: input.linkCid },
+    removedAt: new Date().toISOString(),
+  };
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'network.cosmik.collectionLinkRemoval',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+// =============================================================================
+// COSMIK FOLLOW RECORDS
+// =============================================================================
+
+/**
+ * Cosmik follow record matching Semble's `network.cosmik.follow` lexicon.
+ */
+export interface CosmikFollowRecord {
+  [key: string]: unknown;
+  $type: 'network.cosmik.follow';
+  subject: string;
+  createdAt: string;
+}
+
+/**
+ * Creates a Cosmik follow record for a user or collection.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param subject - DID (user follow) or AT-URI (collection follow)
+ * @returns Created record result
+ */
+export async function createCosmikFollow(
+  agent: Agent,
+  subject: string
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const record: CosmikFollowRecord = {
+    $type: 'network.cosmik.follow',
+    subject,
+    createdAt: new Date().toISOString(),
+  };
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'network.cosmik.follow',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+/**
+ * Deletes a Cosmik follow record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param followUri - AT-URI of the follow record
+ */
+export async function deleteCosmikFollow(agent: Agent, followUri: string): Promise<void> {
+  const parsed = parseAtUri(followUri);
+  if (!parsed) return;
+
+  await agent.com.atproto.repo.deleteRecord({
+    repo: parsed.did,
+    collection: 'network.cosmik.follow',
+    rkey: parsed.rkey,
+  });
+}
+
+// =============================================================================
+// COSMIK NOTE CARD RECORDS
+// =============================================================================
+
+/**
+ * Cosmik note card record matching Semble's `network.cosmik.card` NOTE type.
+ */
+export interface CosmikNoteCardRecord {
+  [key: string]: unknown;
+  $type: 'network.cosmik.card';
+  type: 'NOTE';
+  content: {
+    $type: 'network.cosmik.card#noteContent';
+    text: string;
+  };
+  parentCard?: { uri: string; cid: string };
+  originalCard?: { uri: string; cid: string };
+  provenance?: { via: { uri: string; cid: string } };
+  createdAt: string;
+}
+
+/**
+ * Creates a NOTE-type Cosmik card.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param input - Note card data
+ * @returns Created record result
+ */
+export async function createCosmikNoteCard(
+  agent: Agent,
+  input: {
+    text: string;
+    parentCard?: { uri: string; cid: string };
+    originalCard?: { uri: string; cid: string };
+    provenanceVia?: { uri: string; cid: string };
+  }
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const record: CosmikNoteCardRecord = {
+    $type: 'network.cosmik.card',
+    type: 'NOTE',
+    content: {
+      $type: 'network.cosmik.card#noteContent',
+      text: input.text,
+    },
+    createdAt: new Date().toISOString(),
+  };
+
+  if (input.parentCard) record.parentCard = input.parentCard;
+  if (input.originalCard) record.originalCard = input.originalCard;
+  if (input.provenanceVia) record.provenance = { via: input.provenanceVia };
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'network.cosmik.card',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+// =============================================================================
+// MARGIN ANNOTATION RECORDS (at.margin.*)
+// =============================================================================
+
+/**
+ * Margin annotation target structure (W3C SpecificResource).
+ */
+export interface MarginAnnotationTarget {
+  $type: 'at.margin.annotation#target';
+  source: string;
+  sourceHash?: string;
+  title?: string;
+  selector?: MarginSelector;
+}
+
+/**
+ * Margin TextQuoteSelector (W3C TextQuoteSelector).
+ */
+export interface MarginTextQuoteSelector {
+  type: 'TextQuoteSelector';
+  exact: string;
+  prefix?: string;
+  suffix?: string;
+}
+
+/**
+ * Margin TextPositionSelector (W3C TextPositionSelector).
+ */
+export interface MarginTextPositionSelector {
+  type: 'TextPositionSelector';
+  start: number;
+  end: number;
+}
+
+/**
+ * Margin FragmentSelector (W3C FragmentSelector).
+ */
+export interface MarginFragmentSelector {
+  type: 'FragmentSelector';
+  value: string;
+  conformsTo?: string;
+}
+
+/**
+ * Union of all Margin selector types.
+ */
+export type MarginSelector =
+  | MarginTextQuoteSelector
+  | MarginTextPositionSelector
+  | MarginFragmentSelector;
+
+/**
+ * Margin annotation body (W3C AnnotationBody).
+ */
+export interface MarginAnnotationBody {
+  $type: 'at.margin.annotation#body';
+  value: string;
+  format?: string;
+  language?: string;
+}
+
+/**
+ * W3C motivation values supported by Margin.
+ */
+export type MarginMotivation =
+  | 'commenting'
+  | 'highlighting'
+  | 'bookmarking'
+  | 'tagging'
+  | 'describing'
+  | 'linking'
+  | 'replying'
+  | 'editing'
+  | 'questioning'
+  | 'assessing';
+
+/**
+ * Margin annotation record matching `at.margin.annotation` lexicon.
+ */
+export interface MarginAnnotationRecord {
+  [key: string]: unknown;
+  $type: 'at.margin.annotation';
+  target: MarginAnnotationTarget;
+  body?: MarginAnnotationBody;
+  motivation?: MarginMotivation;
+  tags?: string[];
+  createdAt: string;
+}
+
+/**
+ * Computes a SHA256 hash of a normalized URL for Margin sourceHash.
+ *
+ * @param url - URL to hash
+ * @returns Hex-encoded SHA256 hash
+ */
+async function computeSourceHash(url: string): Promise<string> {
+  const normalized = url.toLowerCase().replace(/\/+$/, '');
+  const encoder = new TextEncoder();
+  const data = encoder.encode(normalized);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Creates a Margin annotation record in the user's PDS.
+ *
+ * @remarks
+ * Used for dual-writing Chive reviews as W3C Web Annotations. Maps
+ * review body text to annotation body, and inline selections to
+ * TextQuoteSelector.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param input - Annotation data
+ * @returns Created record result
+ */
+export async function createMarginAnnotation(
+  agent: Agent,
+  input: {
+    sourceUrl: string;
+    pageTitle?: string;
+    body?: string;
+    bodyFormat?: string;
+    motivation?: MarginMotivation;
+    selector?: MarginSelector;
+    tags?: string[];
+  }
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const sourceHash = await computeSourceHash(input.sourceUrl);
+
+  const target: MarginAnnotationTarget = {
+    $type: 'at.margin.annotation#target',
+    source: input.sourceUrl,
+    sourceHash,
+  };
+
+  if (input.pageTitle) target.title = input.pageTitle;
+  if (input.selector) target.selector = input.selector;
+
+  const record: MarginAnnotationRecord = {
+    $type: 'at.margin.annotation',
+    target,
+    createdAt: new Date().toISOString(),
+  };
+
+  if (input.body) {
+    record.body = {
+      $type: 'at.margin.annotation#body',
+      value: input.body,
+      format: input.bodyFormat ?? 'text/plain',
+    };
+  }
+
+  if (input.motivation) record.motivation = input.motivation;
+  if (input.tags && input.tags.length > 0) record.tags = input.tags.slice(0, 10);
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'at.margin.annotation',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+/**
+ * Deletes a Margin annotation record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param annotationUri - AT-URI of the annotation record
+ */
+export async function deleteMarginAnnotation(agent: Agent, annotationUri: string): Promise<void> {
+  const parsed = parseAtUri(annotationUri);
+  if (!parsed) return;
+
+  await agent.com.atproto.repo.deleteRecord({
+    repo: parsed.did,
+    collection: parsed.collection,
+    rkey: parsed.rkey,
+  });
+}
+
+/**
+ * Updates a Margin annotation record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param annotationUri - AT-URI of the annotation record
+ * @param changes - Fields to update
+ */
+export async function updateMarginAnnotation(
+  agent: Agent,
+  annotationUri: string,
+  changes: {
+    body?: string;
+    bodyFormat?: string;
+    motivation?: MarginMotivation;
+    tags?: string[];
+  }
+): Promise<void> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const parsed = parseAtUri(annotationUri);
+  if (!parsed) return;
+
+  const existingResponse = await agent.com.atproto.repo.getRecord({
+    repo: parsed.did,
+    collection: 'at.margin.annotation',
+    rkey: parsed.rkey,
+  });
+
+  const existing = existingResponse.data.value as MarginAnnotationRecord;
+  const updated: MarginAnnotationRecord = { ...existing };
+
+  if (changes.body !== undefined) {
+    updated.body = {
+      $type: 'at.margin.annotation#body',
+      value: changes.body,
+      format: changes.bodyFormat ?? existing.body?.format ?? 'text/plain',
+    };
+  }
+
+  if (changes.motivation !== undefined) updated.motivation = changes.motivation;
+  if (changes.tags !== undefined) updated.tags = changes.tags.slice(0, 10);
+
+  await agent.com.atproto.repo.putRecord({
+    repo: parsed.did,
+    collection: 'at.margin.annotation',
+    rkey: parsed.rkey,
+    record: updated,
+  });
+}
+
+/**
+ * Margin bookmark record matching `at.margin.bookmark` lexicon.
+ */
+export interface MarginBookmarkRecord {
+  [key: string]: unknown;
+  $type: 'at.margin.bookmark';
+  source: string;
+  sourceHash?: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  createdAt: string;
+}
+
+/**
+ * Creates a Margin bookmark record in the user's PDS.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param input - Bookmark data
+ * @returns Created record result
+ */
+export async function createMarginBookmark(
+  agent: Agent,
+  input: {
+    sourceUrl: string;
+    title?: string;
+    description?: string;
+    tags?: string[];
+  }
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const sourceHash = await computeSourceHash(input.sourceUrl);
+
+  const record: MarginBookmarkRecord = {
+    $type: 'at.margin.bookmark',
+    source: input.sourceUrl,
+    sourceHash,
+    createdAt: new Date().toISOString(),
+  };
+
+  if (input.title) record.title = input.title;
+  if (input.description) record.description = input.description;
+  if (input.tags && input.tags.length > 0) record.tags = input.tags.slice(0, 10);
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'at.margin.bookmark',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+/**
+ * Deletes a Margin bookmark record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param bookmarkUri - AT-URI of the bookmark record
+ */
+export async function deleteMarginBookmark(agent: Agent, bookmarkUri: string): Promise<void> {
+  const parsed = parseAtUri(bookmarkUri);
+  if (!parsed) return;
+
+  await agent.com.atproto.repo.deleteRecord({
+    repo: parsed.did,
+    collection: 'at.margin.bookmark',
+    rkey: parsed.rkey,
+  });
+}
+
+/**
+ * Margin reply record matching `at.margin.reply` lexicon.
+ */
+export interface MarginReplyRecord {
+  [key: string]: unknown;
+  $type: 'at.margin.reply';
+  parent: { uri: string; cid: string };
+  root: { uri: string; cid: string };
+  text: string;
+  format?: string;
+  createdAt: string;
+}
+
+/**
+ * Creates a Margin reply record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param input - Reply data
+ * @returns Created record result
+ */
+export async function createMarginReply(
+  agent: Agent,
+  input: {
+    parentUri: string;
+    parentCid: string;
+    rootUri: string;
+    rootCid: string;
+    text: string;
+    format?: string;
+  }
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const record: MarginReplyRecord = {
+    $type: 'at.margin.reply',
+    parent: { uri: input.parentUri, cid: input.parentCid },
+    root: { uri: input.rootUri, cid: input.rootCid },
+    text: input.text,
+    createdAt: new Date().toISOString(),
+  };
+
+  if (input.format) record.format = input.format;
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'at.margin.reply',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+/**
+ * Margin like record matching `at.margin.like` lexicon.
+ */
+export interface MarginLikeRecord {
+  [key: string]: unknown;
+  $type: 'at.margin.like';
+  subject: { uri: string; cid: string };
+  createdAt: string;
+}
+
+/**
+ * Creates a Margin like record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param subjectUri - AT-URI of the annotation or reply to like
+ * @param subjectCid - CID of the target record
+ * @returns Created record result
+ */
+export async function createMarginLike(
+  agent: Agent,
+  subjectUri: string,
+  subjectCid: string
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const record: MarginLikeRecord = {
+    $type: 'at.margin.like',
+    subject: { uri: subjectUri, cid: subjectCid },
+    createdAt: new Date().toISOString(),
+  };
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'at.margin.like',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+/**
+ * Deletes a Margin like record.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param likeUri - AT-URI of the like record
+ */
+export async function deleteMarginLike(agent: Agent, likeUri: string): Promise<void> {
+  const parsed = parseAtUri(likeUri);
+  if (!parsed) return;
+
+  await agent.com.atproto.repo.deleteRecord({
+    repo: parsed.did,
+    collection: 'at.margin.like',
+    rkey: parsed.rkey,
   });
 }
 

--- a/web/lib/hooks/use-collections.ts
+++ b/web/lib/hooks/use-collections.ts
@@ -55,12 +55,28 @@ import {
   deleteCosmikMirror,
   addCosmikItem,
   removeCosmikItem,
+  createCosmikConnection,
+  deleteCosmikConnection,
+  createCosmikConnectionsForEdges,
+  deleteCosmikConnections,
+  createCosmikFollow,
+  deleteCosmikFollow,
+  createCosmikCollectionLinkRemoval,
+  createMarginAnnotation,
+  deleteMarginAnnotation,
+  updateMarginAnnotation,
+  createMarginBookmark,
+  deleteMarginBookmark,
+  createMarginReply,
+  createMarginLike,
+  deleteMarginLike,
   type CreateCollectionNodeInput,
   type UpdateCollectionNodeInput,
   type AddItemToCollectionInput,
   type AddSubcollectionInput,
   type MoveSubcollectionInput,
   type CosmikItemMapping,
+  type CosmikConnectionMapping,
 } from '@/lib/atproto/record-creator';
 
 const logger = createLogger({ context: { component: 'use-collections' } });
@@ -488,6 +504,15 @@ export interface CreateCollectionMutationInput extends CreateCollectionNodeInput
       isPersonal?: boolean;
     };
   }>;
+  /** Inter-item edges to mirror as Cosmik connections when enableCosmikMirror is true */
+  edges?: Array<{
+    sourceUri: string;
+    targetUri: string;
+    relationSlug: string;
+    note?: string;
+  }>;
+  /** Collaborator DIDs for shared Cosmik collections */
+  collaborators?: string[];
 }
 
 /**
@@ -547,6 +572,7 @@ export function useCreateCollection() {
             title: input.name,
             description: input.description,
             visibility: input.visibility,
+            collaborators: input.collaborators,
             items: (input.items ?? []).map((item) => ({
               url: item.uri,
               title: item.label,
@@ -554,6 +580,7 @@ export function useCreateCollection() {
               itemType: item.type,
               metadata: item.metadata,
             })),
+            edges: input.edges,
           });
 
           cosmikCollectionUri = cosmikResult.cosmikCollectionUri;
@@ -569,6 +596,7 @@ export function useCreateCollection() {
           logger.info('Cosmik mirror created', {
             cosmikCollectionUri: cosmikResult.cosmikCollectionUri,
             itemCount: Object.keys(cosmikResult.cosmikItems).length,
+            connectionCount: Object.keys(cosmikResult.cosmikConnections).length,
           });
         } catch (cosmikError) {
           logger.warn('Cosmik mirror creation failed; collection was created without mirror', {
@@ -1351,6 +1379,325 @@ export function useMoveSubcollection() {
       queryClient.invalidateQueries({
         queryKey: collectionKeys.parent(variables.subcollectionUri),
       });
+    },
+  });
+}
+
+// =============================================================================
+// COSMIK FOLLOW HOOKS
+// =============================================================================
+
+/**
+ * Query key factory for follow queries.
+ */
+export const followKeys = {
+  all: ['follows'] as const,
+  status: (followerDid: string, subject: string) =>
+    [...followKeys.all, 'status', followerDid, subject] as const,
+  count: (subject: string) => [...followKeys.all, 'count', subject] as const,
+};
+
+/**
+ * Fetches the follower count for a collection.
+ *
+ * @param collectionUri - AT-URI of the collection
+ * @param options - Hook options
+ * @returns Query result with follower count
+ */
+export function useFollowerCount(collectionUri: string, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: followKeys.count(collectionUri),
+    queryFn: async (): Promise<{ count: number }> => {
+      const response = await api.pub.chive.collection.getFollowerCount({
+        uri: collectionUri,
+      });
+      return response.data as unknown as { count: number };
+    },
+    enabled: !!collectionUri && (options?.enabled ?? true),
+    staleTime: 60 * 1000,
+  });
+}
+
+/**
+ * Checks if the current user follows a collection.
+ *
+ * @param followerDid - DID of the current user
+ * @param subject - AT-URI of the collection to check
+ * @param options - Hook options
+ * @returns Query result with follow URI or null
+ */
+export function useFollowStatus(
+  followerDid: string,
+  subject: string,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: followKeys.status(followerDid, subject),
+    queryFn: async (): Promise<{ followUri: string | null }> => {
+      const response = await api.pub.chive.collection.getFollowStatus({
+        followerDid,
+        subject,
+      });
+      return response.data as unknown as { followUri: string | null };
+    },
+    enabled: !!followerDid && !!subject && (options?.enabled ?? true),
+    staleTime: 30 * 1000,
+  });
+}
+
+/**
+ * Mutation hook for following a collection.
+ *
+ * @returns Mutation object for creating a follow
+ */
+export function useFollowCollection() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      subject,
+    }: {
+      subject: string;
+      followerDid: string;
+    }): Promise<{ followUri: string }> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError('Not authenticated. Please log in again.', 401, 'followCollection');
+      }
+
+      const result = await createCosmikFollow(agent, subject);
+      return { followUri: result.uri };
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: followKeys.status(variables.followerDid, variables.subject),
+      });
+      queryClient.invalidateQueries({
+        queryKey: followKeys.count(variables.subject),
+      });
+    },
+  });
+}
+
+/**
+ * Mutation hook for unfollowing a collection.
+ *
+ * @returns Mutation object for deleting a follow
+ */
+export function useUnfollowCollection() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      followUri,
+    }: {
+      followUri: string;
+      subject: string;
+      followerDid: string;
+    }): Promise<void> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError('Not authenticated. Please log in again.', 401, 'unfollowCollection');
+      }
+
+      await deleteCosmikFollow(agent, followUri);
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: followKeys.status(variables.followerDid, variables.subject),
+      });
+      queryClient.invalidateQueries({
+        queryKey: followKeys.count(variables.subject),
+      });
+    },
+  });
+}
+
+// =============================================================================
+// COSMIK CONNECTION HOOKS (edges between links)
+// =============================================================================
+
+/**
+ * Mutation hook for creating a Cosmik connection (edge between links).
+ *
+ * @remarks
+ * Used when adding an inter-item edge to a collection that has Cosmik mirroring enabled.
+ *
+ * @returns Mutation object for creating connections
+ */
+export function useCreateCosmikConnection() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: {
+      collectionUri: string;
+      source: string;
+      target: string;
+      connectionType?: string;
+      note?: string;
+    }): Promise<{ connectionUri: string; connectionCid: string }> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError(
+          'Not authenticated. Please log in again.',
+          401,
+          'createCosmikConnection'
+        );
+      }
+
+      const result = await createCosmikConnection(agent, {
+        source: input.source,
+        target: input.target,
+        connectionType: input.connectionType,
+        note: input.note,
+      });
+
+      return { connectionUri: result.uri, connectionCid: result.cid };
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: collectionKeys.detail(variables.collectionUri),
+      });
+    },
+  });
+}
+
+/**
+ * Mutation hook for deleting a Cosmik connection.
+ *
+ * @returns Mutation object for deleting connections
+ */
+export function useDeleteCosmikConnection() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      connectionUri,
+    }: {
+      connectionUri: string;
+      collectionUri: string;
+    }): Promise<void> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError(
+          'Not authenticated. Please log in again.',
+          401,
+          'deleteCosmikConnection'
+        );
+      }
+
+      await deleteCosmikConnection(agent, connectionUri);
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: collectionKeys.detail(variables.collectionUri),
+      });
+    },
+  });
+}
+
+// =============================================================================
+// MARGIN ANNOTATION HOOKS
+// =============================================================================
+
+/**
+ * Query key factory for Margin annotation queries.
+ */
+export const marginKeys = {
+  all: ['margin'] as const,
+  annotations: (eprintUri: string) => [...marginKeys.all, 'annotations', eprintUri] as const,
+};
+
+/**
+ * Fetches Margin annotations for an eprint.
+ *
+ * @param eprintUri - AT-URI of the eprint
+ * @param options - Hook options
+ * @returns Query result with annotations
+ */
+export function useMarginAnnotations(eprintUri: string, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: marginKeys.annotations(eprintUri),
+    queryFn: async () => {
+      const response = await api.pub.chive.collection.getMarginAnnotations({
+        eprintUri,
+        limit: 50,
+      });
+      return response.data;
+    },
+    enabled: !!eprintUri && (options?.enabled ?? true),
+    staleTime: 60 * 1000,
+  });
+}
+
+/**
+ * Mutation hook for creating a Margin annotation (dual-write from Chive review).
+ *
+ * @returns Mutation object for creating annotations
+ */
+export function useCreateMarginAnnotation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: {
+      sourceUrl: string;
+      pageTitle?: string;
+      body?: string;
+      bodyFormat?: string;
+      motivation?: 'commenting' | 'assessing' | 'highlighting';
+      tags?: string[];
+      eprintUri: string;
+    }): Promise<{ annotationUri: string; annotationCid: string }> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError(
+          'Not authenticated. Please log in again.',
+          401,
+          'createMarginAnnotation'
+        );
+      }
+
+      const result = await createMarginAnnotation(agent, {
+        sourceUrl: input.sourceUrl,
+        pageTitle: input.pageTitle,
+        body: input.body,
+        bodyFormat: input.bodyFormat,
+        motivation: input.motivation,
+        tags: input.tags,
+      });
+
+      return { annotationUri: result.uri, annotationCid: result.cid };
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: marginKeys.annotations(variables.eprintUri),
+      });
+    },
+  });
+}
+
+/**
+ * Mutation hook for creating a Margin bookmark (dual-write from Chive bookmark).
+ *
+ * @returns Mutation object for creating bookmarks
+ */
+export function useCreateMarginBookmark() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: {
+      sourceUrl: string;
+      title?: string;
+      description?: string;
+      tags?: string[];
+    }): Promise<{ bookmarkUri: string; bookmarkCid: string }> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError('Not authenticated. Please log in again.', 401, 'createMarginBookmark');
+      }
+
+      const result = await createMarginBookmark(agent, input);
+      return { bookmarkUri: result.uri, bookmarkCid: result.cid };
     },
   });
 }


### PR DESCRIPTION
## Summary

- Add full dual-write support for `network.cosmik.connection` records, mirroring Chive inter-item edges as Semble connections (edges between links)
- Add collaborative collection support via `network.cosmik.collectionLinkRemoval` tombstones and `collaborators` field on `network.cosmik.collection`
- Add collection following via `network.cosmik.follow` with follower counts and follow/unfollow hooks
- Add deep Margin integration (`at.margin.*`): dual-write Chive reviews as W3C Web Annotations, index incoming annotations/highlights/bookmarks/replies from firehose
- Add NOTE card support and provenance tracking for Cosmik cards
- Add database migration with 5 new tables, 2 new backlink count columns, and updated source type constraints
- Add 4 new firehose plugins: CosmikConnectionsPlugin, CosmikFollowsPlugin, CosmikLinkRemovalsPlugin, MarginAnnotationsPlugin (with highlight, bookmark, and reply sub-plugins)
- Update collection wizard with collaborator DID picker, edge sync toggle, and connection count preview
- Add 48 new unit tests across 6 test files

## Test plan

- [x] TypeScript compiles cleanly (0 errors)
- [x] Lint passes (0 errors, 88 pre-existing warnings)
- [x] All 3999 unit tests pass (154 files, 48 new)
- [ ] Run migration on staging database
- [ ] Create collection with edges and Cosmik mirror enabled, verify `network.cosmik.connection` records in PDS
- [ ] Verify Margin annotations targeting eprint URLs are indexed from firehose
- [ ] Verify collaborative collection flow with `collectionLinkRemoval` tombstones
- [ ] Verify collection follow/unfollow creates/deletes `network.cosmik.follow` records