### PR TITLE
KG-native connection mapping, generic collaboration, and server metadata

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -329,6 +329,43 @@ jobs:
                   }
               }
 
+      - name: Backfill Elasticsearch from Postgres if empty
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_SSH_USER }}
+          key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          command_timeout: 30m
+          script: |
+            set -e
+            cd /opt/chive
+
+            # Compare Postgres and Elasticsearch eprint counts. When ES is
+            # behind Postgres — which happens after the setup step recreates
+            # the index, or when a fresh container comes up against a
+            # populated Postgres — run the full reindex script. When ES
+            # already matches (the steady state after any deploy), this is
+            # a no-op.
+            PG_COUNT=$(docker exec chive-postgres psql -U chive -d chive -tAc 'SELECT COUNT(*) FROM eprints_index;')
+            ES_COUNT=$(docker exec chive-elasticsearch curl -s 'http://localhost:9200/eprints/_count' | sed -n 's/.*"count":\([0-9]*\).*/\1/p')
+            ES_COUNT=${ES_COUNT:-0}
+
+            echo "Postgres eprints: $PG_COUNT"
+            echo "Elasticsearch eprints: $ES_COUNT"
+
+            if [ "$PG_COUNT" -gt "$ES_COUNT" ]; then
+              echo "Elasticsearch is behind Postgres ($ES_COUNT < $PG_COUNT) — running reindex"
+              # chive-api already has DATABASE_URL, ELASTICSEARCH_URL,
+              # NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD baked in from
+              # .env.production, so we only pass overrides needed to use
+              # in-network hostnames.
+              docker exec \
+                chive-api \
+                node --enable-source-maps dist/scripts/reindex-all-eprints.js
+            else
+              echo "Elasticsearch is in sync with Postgres — skipping reindex"
+            fi
+
       - name: Verify staging deployment
         run: |
           echo "Waiting for services to fully start..."

--- a/lexicons/pub/chive/collaboration/invite.json
+++ b/lexicons/pub/chive/collaboration/invite.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.collaboration.invite",
+  "revision": 1,
+  "description": "Invitation record from a subject-record author to a potential collaborator. Lives in the inviter's PDS. Generic over any Chive record (collections in v1; eprints, reviews, and other records in the future).",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "invitee", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef to any Chive-authored record being shared (collection, eprint, review, etc.)."
+          },
+          "invitee": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the user being invited."
+          },
+          "role": {
+            "type": "string",
+            "knownValues": ["collaborator", "editor", "viewer", "co-author", "reviewer"],
+            "description": "Role granted by this invitation. Defaults to 'collaborator'."
+          },
+          "message": {
+            "type": "string",
+            "maxLength": 500,
+            "maxGraphemes": 200,
+            "description": "Optional personal note shown to the invitee."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Optional expiration after which the invite is no longer valid."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/pub/chive/collaboration/inviteAcceptance.json
+++ b/lexicons/pub/chive/collaboration/inviteAcceptance.json
@@ -1,0 +1,32 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.collaboration.inviteAcceptance",
+  "revision": 1,
+  "description": "Acceptance record created by an invitee, acknowledging a collaboration invite. Lives in the invitee's PDS. The combination of an existing invite and a matching acceptance — both non-deleted — is what grants the invitee's writes to be surfaced against the subject record.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["invite", "subject", "createdAt"],
+        "properties": {
+          "invite": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef to the corresponding pub.chive.collaboration.invite record."
+          },
+          "subject": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef to the subject record of the invite (collection, eprint, etc.). Redundant with the invite reference but convenient for firehose-time indexing before the invite is resolved."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/pub/chive/collaboration/listCollaborators.json
+++ b/lexicons/pub/chive/collaboration/listCollaborators.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.collaboration.listCollaborators",
+  "revision": 1,
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List active collaborators on a subject record (DIDs that have both a non-deleted invite from the subject's author and a non-deleted acceptance of that invite).",
+      "parameters": {
+        "type": "params",
+        "required": ["subjectUri"],
+        "properties": {
+          "subjectUri": {
+            "type": "string",
+            "format": "at-uri"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["collaborators"],
+          "properties": {
+            "collaborators": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#collaboratorView"
+              }
+            }
+          }
+        }
+      }
+    },
+    "collaboratorView": {
+      "type": "object",
+      "required": ["did", "inviteUri", "acceptanceUri", "acceptedAt"],
+      "properties": {
+        "did": { "type": "string", "format": "did" },
+        "inviteUri": { "type": "string", "format": "at-uri" },
+        "acceptanceUri": { "type": "string", "format": "at-uri" },
+        "role": { "type": "string" },
+        "acceptedAt": { "type": "string", "format": "datetime" }
+      }
+    }
+  }
+}

--- a/lexicons/pub/chive/collaboration/listInvites.json
+++ b/lexicons/pub/chive/collaboration/listInvites.json
@@ -1,0 +1,90 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.collaboration.listInvites",
+  "revision": 1,
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List collaboration invites, filtered by invitee, inviter, and/or subject. Typically used to populate an invitee's inbox.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "invitee": {
+            "type": "string",
+            "format": "did",
+            "description": "Filter to invites directed at this DID."
+          },
+          "inviter": {
+            "type": "string",
+            "format": "did",
+            "description": "Filter to invites authored by this DID."
+          },
+          "subjectUri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Filter to invites for this subject record."
+          },
+          "subjectCollection": {
+            "type": "string",
+            "description": "Filter to invites where the subject's NSID matches (e.g., `pub.chive.graph.node` for collections)."
+          },
+          "state": {
+            "type": "string",
+            "knownValues": ["pending", "accepted", "rejected", "expired", "all"],
+            "default": "all",
+            "description": "Acceptance-derived state filter."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": {
+            "type": "string"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["invites"],
+          "properties": {
+            "invites": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#inviteView"
+              }
+            },
+            "cursor": { "type": "string" },
+            "hasMore": { "type": "boolean" },
+            "total": { "type": "integer" }
+          }
+        }
+      }
+    },
+    "inviteView": {
+      "type": "object",
+      "required": ["uri", "inviter", "invitee", "subjectUri", "state", "createdAt"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "inviter": { "type": "string", "format": "did" },
+        "invitee": { "type": "string", "format": "did" },
+        "subjectUri": { "type": "string", "format": "at-uri" },
+        "subjectCollection": { "type": "string" },
+        "role": { "type": "string" },
+        "message": { "type": "string" },
+        "state": {
+          "type": "string",
+          "knownValues": ["pending", "accepted", "rejected", "expired"]
+        },
+        "acceptanceUri": { "type": "string", "format": "at-uri" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "expiresAt": { "type": "string", "format": "datetime" },
+        "acceptedAt": { "type": "string", "format": "datetime" }
+      }
+    }
+  }
+}

--- a/lexicons/pub/chive/graph/listNodes.json
+++ b/lexicons/pub/chive/graph/listNodes.json
@@ -23,6 +23,14 @@
             "knownValues": ["proposed", "provisional", "established", "deprecated"],
             "description": "Filter by lifecycle status"
           },
+          "externalIdSystem": {
+            "type": "string",
+            "description": "Filter nodes whose externalIds array includes an entry with this system. Must be combined with externalIdIdentifier."
+          },
+          "externalIdIdentifier": {
+            "type": "string",
+            "description": "Filter nodes whose externalIds array includes an entry with this identifier. Must be combined with externalIdSystem."
+          },
           "limit": {
             "type": "integer",
             "minimum": 1,

--- a/lexicons/pub/chive/graph/node.json
+++ b/lexicons/pub/chive/graph/node.json
@@ -125,7 +125,11 @@
             "mesh",
             "aat",
             "gnd",
-            "anzsrc"
+            "anzsrc",
+            "skos",
+            "cosmik",
+            "schema-org",
+            "dublin-core"
           ],
           "description": "Identifier system"
         },

--- a/lexicons/pub/chive/resolve/byExternalId.json
+++ b/lexicons/pub/chive/resolve/byExternalId.json
@@ -1,0 +1,57 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.resolve.byExternalId",
+  "revision": 1,
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Resolve an external identifier (DOI, arXiv, ORCID, ROR, ISBN, etc.) to the Chive entity that declares it — either a Chive-native eprint submission or a knowledge-graph node.",
+      "parameters": {
+        "type": "params",
+        "required": ["system", "identifier"],
+        "properties": {
+          "system": {
+            "type": "string",
+            "knownValues": ["doi", "arxiv", "orcid", "ror", "isbn", "pmid", "wikidata"],
+            "description": "External identifier system."
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Identifier value (without URL prefix)."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["found"],
+          "properties": {
+            "found": {
+              "type": "boolean",
+              "description": "Whether a matching entity was found."
+            },
+            "entityType": {
+              "type": "string",
+              "knownValues": ["eprint", "author", "graphNode"],
+              "description": "Kind of entity that matched."
+            },
+            "uri": {
+              "type": "string",
+              "format": "at-uri",
+              "description": "AT-URI of the matched entity."
+            },
+            "label": {
+              "type": "string",
+              "description": "Display label for the matched entity."
+            },
+            "webPath": {
+              "type": "string",
+              "description": "Chive web path that renders this entity (e.g., /eprints/...)."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/db/lib/relations.ts
+++ b/scripts/db/lib/relations.ts
@@ -32,6 +32,13 @@ export interface RelationDefinition {
   readonly skosUri?: string;
   /** Wikidata property ID if applicable */
   readonly wikidataProperty?: string;
+  /**
+   * Cosmik/Semble connection type when this relation is mirrored to
+   * `network.cosmik.connection` records (cosmik.network ecosystem).
+   */
+  readonly cosmikConnectionType?: string;
+  /** CiTO (Citation Typing Ontology) URI if applicable (SPAR Ontologies). */
+  readonly citoUri?: string;
 }
 
 /**
@@ -73,6 +80,7 @@ export const RELATIONS: readonly RelationDefinition[] = [
     symmetric: true,
     skosUri: 'http://www.w3.org/2004/02/skos/core#related',
     wikidataProperty: 'P527', // has part
+    cosmikConnectionType: 'RELATED',
   },
   {
     slug: 'exact-match',
@@ -142,6 +150,7 @@ export const RELATIONS: readonly RelationDefinition[] = [
     inverseSlug: 'has-part',
     transitive: true,
     wikidataProperty: 'P361', // part of
+    cosmikConnectionType: 'PART_OF',
   },
   {
     slug: 'has-part',
@@ -150,6 +159,7 @@ export const RELATIONS: readonly RelationDefinition[] = [
     inverseSlug: 'part-of',
     transitive: true,
     wikidataProperty: 'P527', // has part
+    cosmikConnectionType: 'HAS_PART',
   },
   {
     slug: 'located-in',
@@ -191,6 +201,156 @@ export const RELATIONS: readonly RelationDefinition[] = [
     label: 'Applied In',
     description: 'Domain uses a methodology',
     inverseSlug: 'applies-to',
+  },
+
+  // =============================================================================
+  // Academic / citation relations (CiTO-aligned)
+  // =============================================================================
+  {
+    slug: 'cites',
+    label: 'Cites',
+    description: 'Work formally references another work',
+    inverseSlug: 'cited-by',
+    citoUri: 'http://purl.org/spar/cito/cites',
+    wikidataProperty: 'P2860', // cites work
+    cosmikConnectionType: 'REFERENCES',
+  },
+  {
+    slug: 'cited-by',
+    label: 'Cited By',
+    description: 'Work is formally referenced by another work',
+    inverseSlug: 'cites',
+    citoUri: 'http://purl.org/spar/cito/isCitedBy',
+    cosmikConnectionType: 'CITED_BY',
+  },
+  {
+    slug: 'builds-on',
+    label: 'Builds On',
+    description: 'Derivative work extending prior work',
+    inverseSlug: 'extended-by',
+    citoUri: 'http://purl.org/spar/cito/extends',
+    cosmikConnectionType: 'BUILDS_ON',
+  },
+  {
+    slug: 'extended-by',
+    label: 'Extended By',
+    description: 'Earlier work extended by a derivative',
+    inverseSlug: 'builds-on',
+    citoUri: 'http://purl.org/spar/cito/isExtendedBy',
+    cosmikConnectionType: 'EXTENDED_BY',
+  },
+  {
+    slug: 'supports',
+    label: 'Supports',
+    description: 'Work corroborates or substantiates another',
+    inverseSlug: 'supported-by',
+    citoUri: 'http://purl.org/spar/cito/confirms',
+    cosmikConnectionType: 'SUPPORTS',
+  },
+  {
+    slug: 'supported-by',
+    label: 'Supported By',
+    description: 'Work is corroborated by another',
+    inverseSlug: 'supports',
+    citoUri: 'http://purl.org/spar/cito/isConfirmedBy',
+  },
+  {
+    slug: 'contradicts',
+    label: 'Contradicts',
+    description: 'Work disputes or disagrees with another',
+    inverseSlug: 'contradicted-by',
+    citoUri: 'http://purl.org/spar/cito/disagreesWith',
+    cosmikConnectionType: 'OPPOSES',
+  },
+  {
+    slug: 'contradicted-by',
+    label: 'Contradicted By',
+    description: 'Work is disputed by another',
+    inverseSlug: 'contradicts',
+    citoUri: 'http://purl.org/spar/cito/isDisagreedWithBy',
+  },
+  {
+    slug: 'replicates',
+    label: 'Replicates',
+    description: 'Work replicates findings of another',
+    inverseSlug: 'replicated-by',
+    citoUri: 'http://purl.org/spar/cito/includesExcerptFrom',
+    cosmikConnectionType: 'REPLICATES',
+  },
+  {
+    slug: 'replicated-by',
+    label: 'Replicated By',
+    description: 'Work is replicated by another',
+    inverseSlug: 'replicates',
+  },
+  {
+    slug: 'explains',
+    label: 'Explains',
+    description: 'Work elaborates or clarifies another',
+    inverseSlug: 'explained-by',
+    citoUri: 'http://purl.org/spar/cito/discusses',
+    cosmikConnectionType: 'EXPLAINER',
+  },
+  {
+    slug: 'explained-by',
+    label: 'Explained By',
+    description: 'Work is explained by another',
+    inverseSlug: 'explains',
+    citoUri: 'http://purl.org/spar/cito/isDiscussedBy',
+  },
+  {
+    slug: 'supplements',
+    label: 'Supplements',
+    description: 'Work provides supplementary material for another',
+    inverseSlug: 'supplemented-by',
+    citoUri: 'http://purl.org/spar/cito/providesDataFor',
+    cosmikConnectionType: 'SUPPLEMENT',
+  },
+  {
+    slug: 'supplemented-by',
+    label: 'Supplemented By',
+    description: 'Work is supplemented by another',
+    inverseSlug: 'supplements',
+    citoUri: 'http://purl.org/spar/cito/hasReplyFrom',
+  },
+  {
+    slug: 'depends-on',
+    label: 'Depends On',
+    description: 'Work requires or builds upon another as prerequisite',
+    inverseSlug: 'depended-on-by',
+    cosmikConnectionType: 'DEPENDS_ON',
+  },
+  {
+    slug: 'depended-on-by',
+    label: 'Depended On By',
+    description: 'Work is a prerequisite for another',
+    inverseSlug: 'depends-on',
+  },
+  {
+    slug: 'leads-to',
+    label: 'Leads To',
+    description: 'Work leads naturally to another (sequential reading order)',
+    inverseSlug: 'follows-from',
+    cosmikConnectionType: 'LEADS_TO',
+  },
+  {
+    slug: 'follows-from',
+    label: 'Follows From',
+    description: 'Work follows from another',
+    inverseSlug: 'leads-to',
+  },
+  {
+    slug: 'addresses',
+    label: 'Addresses',
+    description: 'Work addresses a question, problem, or phenomenon',
+    inverseSlug: 'addressed-by',
+    cosmikConnectionType: 'ADDRESSES',
+  },
+  {
+    slug: 'addressed-by',
+    label: 'Addressed By',
+    description: 'Question/problem is addressed by a work',
+    inverseSlug: 'addresses',
   },
 ];
 

--- a/scripts/db/seed-relations.ts
+++ b/scripts/db/seed-relations.ts
@@ -41,6 +41,24 @@ export async function seedRelations(nodeCreator: NodeCreator): Promise<number> {
       });
     }
 
+    if (relation.citoUri) {
+      externalIds.push({
+        system: 'schema-org',
+        identifier: relation.citoUri.split('/').pop() ?? relation.slug,
+        uri: relation.citoUri,
+        matchType: 'exact',
+      });
+    }
+
+    if (relation.cosmikConnectionType) {
+      externalIds.push({
+        system: 'cosmik',
+        identifier: relation.cosmikConnectionType,
+        uri: `cosmik://connectionType/${relation.cosmikConnectionType}`,
+        matchType: 'exact',
+      });
+    }
+
     const metadata: Record<string, string | boolean> = {};
     if (relation.symmetric) metadata.symmetric = true;
     if (relation.inverseSlug) metadata.inverseSlug = relation.inverseSlug;

--- a/src/api/handlers/xrpc/collaboration/index.ts
+++ b/src/api/handlers/xrpc/collaboration/index.ts
@@ -1,0 +1,32 @@
+/**
+ * XRPC collaboration handler exports.
+ *
+ * @remarks
+ * Generic collaboration (invite / accept / list) endpoints. v1 consumers
+ * are collections; the same endpoints will serve eprint co-authorship and
+ * collaborative reviews in future iterations.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type { XRPCMethod } from '../../../xrpc/types.js';
+
+import { listCollaborators } from './listCollaborators.js';
+import { listInvites } from './listInvites.js';
+
+export { listInvites } from './listInvites.js';
+export { listCollaborators } from './listCollaborators.js';
+export type { ListInvitesParams, ListInvitesOutput } from './listInvites.js';
+export type { ListCollaboratorsParams, ListCollaboratorsOutput } from './listCollaborators.js';
+
+/**
+ * All collaboration XRPC methods keyed by NSID.
+ *
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const collaborationMethods: Record<string, XRPCMethod<any, any, any>> = {
+  'pub.chive.collaboration.listInvites': listInvites,
+  'pub.chive.collaboration.listCollaborators': listCollaborators,
+};

--- a/src/api/handlers/xrpc/collaboration/listCollaborators.ts
+++ b/src/api/handlers/xrpc/collaboration/listCollaborators.ts
@@ -1,0 +1,56 @@
+/**
+ * XRPC handler for pub.chive.collaboration.listCollaborators.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type {
+  QueryParams,
+  OutputSchema,
+} from '../../../../lexicons/generated/types/pub/chive/collaboration/listCollaborators.js';
+import type { AtUri } from '../../../../types/atproto.js';
+import { ValidationError } from '../../../../types/errors.js';
+import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/** Re-exported params. */
+export type ListCollaboratorsParams = QueryParams;
+
+/** Re-exported output. */
+export type ListCollaboratorsOutput = OutputSchema;
+
+/**
+ * XRPC method for pub.chive.collaboration.listCollaborators query.
+ *
+ * @public
+ */
+export const listCollaborators: XRPCMethod<QueryParams, void, OutputSchema> = {
+  auth: 'optional',
+  handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
+    const { collaborationService } = c.get('services');
+    if (!params.subjectUri) {
+      throw new ValidationError('Missing subjectUri', 'subjectUri');
+    }
+
+    if (!collaborationService) {
+      return { encoding: 'application/json', body: { collaborators: [] } };
+    }
+
+    const collaborators = await collaborationService.getActiveCollaborators(
+      params.subjectUri as AtUri
+    );
+
+    return {
+      encoding: 'application/json',
+      body: {
+        collaborators: collaborators.map((c) => ({
+          did: c.did,
+          inviteUri: c.inviteUri,
+          acceptanceUri: c.acceptanceUri,
+          role: c.role,
+          acceptedAt: c.acceptedAt.toISOString(),
+        })),
+      },
+    };
+  },
+};

--- a/src/api/handlers/xrpc/collaboration/listInvites.ts
+++ b/src/api/handlers/xrpc/collaboration/listInvites.ts
@@ -1,0 +1,67 @@
+/**
+ * XRPC handler for pub.chive.collaboration.listInvites.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type {
+  QueryParams,
+  OutputSchema,
+} from '../../../../lexicons/generated/types/pub/chive/collaboration/listInvites.js';
+import type { AtUri, DID } from '../../../../types/atproto.js';
+import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/** Re-exported params. */
+export type ListInvitesParams = QueryParams;
+
+/** Re-exported output. */
+export type ListInvitesOutput = OutputSchema;
+
+/**
+ * XRPC method for pub.chive.collaboration.listInvites query.
+ *
+ * @public
+ */
+export const listInvites: XRPCMethod<QueryParams, void, OutputSchema> = {
+  auth: 'optional',
+  handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
+    const { collaborationService } = c.get('services');
+    if (!collaborationService) {
+      return { encoding: 'application/json', body: { invites: [] } };
+    }
+
+    const result = await collaborationService.listInvites({
+      invitee: params.invitee as DID | undefined,
+      inviter: params.inviter as DID | undefined,
+      subjectUri: params.subjectUri as AtUri | undefined,
+      subjectCollection: params.subjectCollection,
+      state: params.state as 'pending' | 'accepted' | 'rejected' | 'expired' | 'all' | undefined,
+      limit: params.limit,
+      cursor: params.cursor,
+    });
+
+    return {
+      encoding: 'application/json',
+      body: {
+        invites: result.invites.map((inv) => ({
+          uri: inv.uri,
+          inviter: inv.inviter,
+          invitee: inv.invitee,
+          subjectUri: inv.subjectUri,
+          subjectCollection: inv.subjectCollection,
+          role: inv.role,
+          message: inv.message,
+          state: inv.state,
+          acceptanceUri: inv.acceptanceUri,
+          createdAt: inv.createdAt.toISOString(),
+          expiresAt: inv.expiresAt?.toISOString(),
+          acceptedAt: inv.acceptedAt?.toISOString(),
+        })),
+        cursor: result.cursor,
+        hasMore: result.hasMore,
+        total: result.total,
+      },
+    };
+  },
+};

--- a/src/api/handlers/xrpc/graph/listNodes.ts
+++ b/src/api/handlers/xrpc/graph/listNodes.ts
@@ -83,6 +83,8 @@ export const listNodes: XRPCMethod<QueryParams, void, OutputSchema> = {
       kind: params.kind,
       subkind: params.subkind,
       status: params.status,
+      externalIdSystem: params.externalIdSystem,
+      externalIdIdentifier: params.externalIdIdentifier,
       limit: params.limit,
     });
 
@@ -95,6 +97,8 @@ export const listNodes: XRPCMethod<QueryParams, void, OutputSchema> = {
         | 'established'
         | 'deprecated'
         | undefined,
+      externalIdSystem: params.externalIdSystem,
+      externalIdIdentifier: params.externalIdIdentifier,
       limit: params.limit,
       cursor: params.cursor,
     });

--- a/src/api/handlers/xrpc/index.ts
+++ b/src/api/handlers/xrpc/index.ts
@@ -26,6 +26,7 @@ export { annotationMethods } from './annotation/index.js';
 export * from './author/index.js';
 export * from './backlink/index.js';
 export * from './claiming/index.js';
+export * from './collaboration/index.js';
 export { collectionMethods } from './collection/index.js';
 export * from './discovery/index.js';
 export * from './endorsement/index.js';
@@ -49,6 +50,7 @@ import { annotationMethods } from './annotation/index.js';
 import { authorMethods } from './author/index.js';
 import { backlinkMethods } from './backlink/index.js';
 import { claimingMethods, claimingRestEndpoints } from './claiming/index.js';
+import { collaborationMethods } from './collaboration/index.js';
 import { collectionMethods } from './collection/index.js';
 import { discoveryMethods } from './discovery/index.js';
 import { endorsementMethods } from './endorsement/index.js';
@@ -75,6 +77,7 @@ export const allXRPCMethods = {
   ...authorMethods,
   ...backlinkMethods,
   ...claimingMethods,
+  ...collaborationMethods,
   ...collectionMethods,
   ...discoveryMethods,
   ...endorsementMethods,

--- a/src/api/handlers/xrpc/index.ts
+++ b/src/api/handlers/xrpc/index.ts
@@ -34,6 +34,7 @@ export * from './graph/index.js';
 export * from './import/index.js';
 export * from './metrics/index.js';
 export * from './eprint/index.js';
+export * from './resolve/index.js';
 export * from './review/index.js';
 export * from './sync/index.js';
 export * from './tag/index.js';
@@ -58,6 +59,7 @@ import { importMethods } from './import/index.js';
 import { metricsMethods } from './metrics/index.js';
 import { moderationMethods } from './moderation/index.js';
 import { notificationMethods } from './notification/index.js';
+import { resolveMethods } from './resolve/index.js';
 import { reviewMethods } from './review/index.js';
 import { syncMethods } from './sync/index.js';
 import { tagMethods } from './tag/index.js';
@@ -83,6 +85,7 @@ export const allXRPCMethods = {
   ...metricsMethods,
   ...moderationMethods,
   ...notificationMethods,
+  ...resolveMethods,
   ...reviewMethods,
   ...syncMethods,
   ...tagMethods,

--- a/src/api/handlers/xrpc/resolve/byExternalId.ts
+++ b/src/api/handlers/xrpc/resolve/byExternalId.ts
@@ -1,0 +1,136 @@
+/**
+ * XRPC handler for pub.chive.resolve.byExternalId.
+ *
+ * @remarks
+ * Resolves an external identifier (DOI, arXiv, ORCID, ROR, ISBN, PMID,
+ * Wikidata) to the Chive entity that declares it. Looks in two places:
+ *
+ * 1. Chive-native eprint submissions (`publishedVersion.doi`,
+ *    `externalIds.arxivId`, etc.) — via `EprintService.findByExternalIds`.
+ * 2. Knowledge-graph nodes (`externalIds` array on `pub.chive.graph.node`) —
+ *    via `NodeService.listNodes` with `externalIdSystem` filter.
+ *
+ * Returns the first match. Used by canonical external-ID web routes
+ * (`/doi/<id>`, `/arxiv/<id>`, etc.) to route to the right Chive page.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type {
+  QueryParams,
+  OutputSchema,
+} from '../../../../lexicons/generated/types/pub/chive/resolve/byExternalId.js';
+import { ValidationError } from '../../../../types/errors.js';
+import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/**
+ * Maps an external-ID `system` to the corresponding field key on
+ * `EprintService.findByExternalIds`.
+ */
+const EPRINT_FIELD_BY_SYSTEM: Record<string, string> = {
+  doi: 'doi',
+  arxiv: 'arxivId',
+  pmid: 'pmid',
+};
+
+/** Re-exported query parameters. */
+export type ResolveByExternalIdParams = QueryParams;
+
+/** Re-exported output schema. */
+export type ResolveByExternalIdOutput = OutputSchema;
+
+/**
+ * XRPC method for pub.chive.resolve.byExternalId query.
+ *
+ * @public
+ */
+export const byExternalId: XRPCMethod<QueryParams, void, OutputSchema> = {
+  auth: 'optional',
+  handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
+    const { eprint: eprintService, nodeService } = c.get('services');
+    const logger = c.get('logger');
+
+    if (!params.system || !params.identifier) {
+      throw new ValidationError('Both `system` and `identifier` parameters are required', 'params');
+    }
+
+    const system = params.system;
+    const identifier = params.identifier;
+
+    logger.debug('Resolving by external ID', { system, identifier });
+
+    // 1. Check Chive-native eprints first.
+    const eprintField = EPRINT_FIELD_BY_SYSTEM[system];
+    if (eprintField && eprintService) {
+      try {
+        const eprint = await eprintService.findByExternalIds({
+          [eprintField]: identifier,
+        } as Record<string, string>);
+        if (eprint) {
+          return {
+            encoding: 'application/json',
+            body: {
+              found: true,
+              entityType: 'eprint',
+              uri: eprint.uri,
+              label: eprint.title ?? '',
+              webPath: `/eprints/${encodeURIComponent(eprint.uri)}`,
+            },
+          };
+        }
+      } catch (err) {
+        logger.warn('Eprint external-id lookup failed', {
+          system,
+          identifier,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // 2. Check knowledge-graph nodes.
+    if (nodeService) {
+      try {
+        const result = await nodeService.listNodes({
+          externalIdSystem: system,
+          externalIdIdentifier: identifier,
+          limit: 1,
+        });
+        const node = result.nodes[0];
+        if (node) {
+          // Authors are nodes with subkind=person/author and DID on metadata.
+          const isAuthor = node.subkind === 'person' || node.subkind === 'author';
+          const entityType = isAuthor ? 'author' : 'graphNode';
+          const did =
+            node.metadata && typeof node.metadata === 'object' && 'did' in node.metadata
+              ? ((node.metadata as { did?: unknown }).did as string | undefined)
+              : undefined;
+          const webPath = isAuthor
+            ? `/authors/${did ?? node.uri}`
+            : `/graph?node=${encodeURIComponent(node.uri)}`;
+          return {
+            encoding: 'application/json',
+            body: {
+              found: true,
+              entityType,
+              uri: node.uri,
+              label: node.label,
+              webPath,
+            },
+          };
+        }
+      } catch (err) {
+        logger.warn('Graph node external-id lookup failed', {
+          system,
+          identifier,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return {
+      encoding: 'application/json',
+      body: { found: false },
+    };
+  },
+};

--- a/src/api/handlers/xrpc/resolve/index.ts
+++ b/src/api/handlers/xrpc/resolve/index.ts
@@ -1,0 +1,27 @@
+/**
+ * XRPC resolve handler exports.
+ *
+ * @remarks
+ * Entity-resolution endpoints mapping external identifiers (DOI, arXiv,
+ * ORCID, ROR, ISBN, PMID, Wikidata) to Chive-native entities.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type { XRPCMethod } from '../../../xrpc/types.js';
+
+import { byExternalId } from './byExternalId.js';
+
+export { byExternalId } from './byExternalId.js';
+export type { ResolveByExternalIdParams, ResolveByExternalIdOutput } from './byExternalId.js';
+
+/**
+ * All resolve XRPC methods keyed by NSID.
+ *
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const resolveMethods: Record<string, XRPCMethod<any, any, any>> = {
+  'pub.chive.resolve.byExternalId': byExternalId,
+};

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -33,6 +33,7 @@ import type { BacklinkService } from '../services/backlink/backlink-service.js';
 import type { BlobProxyService } from '../services/blob-proxy/proxy-service.js';
 import type { CitationExtractionService } from '../services/citation/citation-extraction-service.js';
 import type { ClaimingService } from '../services/claiming/claiming-service.js';
+import type { CollaborationService } from '../services/collaboration/collaboration-service.js';
 import type { CollectionService } from '../services/collection/collection-service.js';
 import type { DiscoveryService } from '../services/discovery/discovery-service.js';
 import type { EprintService } from '../services/eprint/eprint-service.js';
@@ -269,6 +270,12 @@ export interface ServerConfig {
   readonly collectionService?: CollectionService;
 
   /**
+   * Collaboration service for indexing invites / acceptances and deriving
+   * active collaborators (optional).
+   */
+  readonly collaborationService?: CollaborationService;
+
+  /**
    * Admin service for dashboard operations (optional).
    */
   readonly adminService?: AdminService;
@@ -389,6 +396,7 @@ export function createServer(config: ServerConfig): Hono<ChiveEnv> {
       indexRetryWorker: config.indexRetryWorker,
       personalGraph: config.personalGraphService,
       collection: config.collectionService,
+      collaborationService: config.collaborationService,
       admin: config.adminService,
       backfillManager: config.backfillManager,
       citationExtraction: config.citationExtractionService,

--- a/src/api/types/context.ts
+++ b/src/api/types/context.ts
@@ -20,6 +20,7 @@ import type { BacklinkService } from '../../services/backlink/backlink-service.j
 import type { BlobProxyService } from '../../services/blob-proxy/proxy-service.js';
 import type { CitationExtractionService } from '../../services/citation/citation-extraction-service.js';
 import type { ClaimingService } from '../../services/claiming/claiming-service.js';
+import type { CollaborationService } from '../../services/collaboration/collaboration-service.js';
 import type { CollectionService } from '../../services/collection/collection-service.js';
 import type { DiscoveryService } from '../../services/discovery/discovery-service.js';
 import type { EprintService } from '../../services/eprint/eprint-service.js';
@@ -85,6 +86,7 @@ export interface ChiveServices {
   readonly indexRetryWorker?: IndexRetryWorker;
   readonly personalGraph?: PersonalGraphService;
   readonly collection?: CollectionService;
+  readonly collaborationService?: CollaborationService;
   readonly admin?: AdminService;
   readonly backfillManager?: BackfillManager;
   readonly citationExtraction?: CitationExtractionService;

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ import { CitationExtractionService } from './services/citation/citation-extracti
 import { DocumentTextExtractor } from './services/citation/document-text-extractor.js';
 import { GrobidClient } from './services/citation/grobid-client.js';
 import { ClaimingService } from './services/claiming/claiming-service.js';
+import { CollaborationService } from './services/collaboration/collaboration-service.js';
 import { CollectionService } from './services/collection/collection-service.js';
 import { createResiliencePolicy } from './services/common/resilience.js';
 import { DiscoveryService } from './services/discovery/discovery-service.js';
@@ -535,9 +536,10 @@ function createServices(
     logger,
   });
 
-  // Create personal graph and collection services
+  // Create personal graph, collection, and collaboration services
   const personalGraphService = new PersonalGraphService({ pool: pgPool, logger });
   const collectionService = new CollectionService({ pool: pgPool, logger });
+  const collaborationService = new CollaborationService({ pool: pgPool, logger });
 
   // Create PDS Discovery services
   const pdsRegistry = new PDSRegistry(pgPool, logger);
@@ -621,6 +623,7 @@ function createServices(
     recommendationService: recommendationEngine,
     personalGraphService,
     collectionService,
+    collaborationService,
     adminService,
     backfillManager,
     contentReportService,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ import 'reflect-metadata';
 import { serve } from '@hono/node-server';
 import EventEmitter2Module from 'eventemitter2';
 import { Redis } from 'ioredis';
-import { container } from 'tsyringe';
 
 const { EventEmitter2 } = EventEmitter2Module;
 type EventEmitter2Type = InstanceType<typeof EventEmitter2>;
@@ -30,6 +29,7 @@ import { GovernanceSyncJob } from './jobs/governance-sync-job.js';
 import { PDSScanSchedulerJob } from './jobs/pds-scan-scheduler-job.js';
 import { TagSyncJob } from './jobs/tag-sync-job.js';
 import { PinoLogger } from './observability/logger.js';
+import { registerPluginDependencies } from './plugins/core/plugin-di-helpers.js';
 import {
   registerPluginSystem,
   getPluginManager,
@@ -93,8 +93,6 @@ import { getDatabaseConfig } from './storage/postgresql/config.js';
 import { closePool, createPool } from './storage/postgresql/connection.js';
 import { FacetUsageHistoryRepository } from './storage/postgresql/facet-usage-history-repository.js';
 import type { DID } from './types/atproto.js';
-import type { ICacheProvider } from './types/interfaces/cache.interface.js';
-import type { IMetrics } from './types/interfaces/metrics.interface.js';
 import { FreshnessWorker } from './workers/freshness-worker.js';
 import { IndexRetryWorker } from './workers/index-retry-worker.js';
 
@@ -775,63 +773,6 @@ async function shutdown(state: AppState, signal: string): Promise<void> {
 }
 
 /**
- * Creates a Redis-backed cache provider for the plugin system.
- */
-function createPluginCacheProvider(redis: Redis): ICacheProvider {
-  const PREFIX = 'chive:plugin:';
-  return {
-    async get<T>(key: string): Promise<T | null> {
-      const value = await redis.get(`${PREFIX}${key}`);
-      if (value === null) return null;
-      try {
-        return JSON.parse(value) as T;
-      } catch {
-        return null;
-      }
-    },
-    async set<T>(key: string, value: T, ttl?: number): Promise<void> {
-      const serialized = JSON.stringify(value);
-      if (ttl) {
-        await redis.setex(`${PREFIX}${key}`, ttl, serialized);
-      } else {
-        await redis.set(`${PREFIX}${key}`, serialized);
-      }
-    },
-    async delete(key: string): Promise<void> {
-      await redis.del(`${PREFIX}${key}`);
-    },
-    async exists(key: string): Promise<boolean> {
-      const result = await redis.exists(`${PREFIX}${key}`);
-      return result === 1;
-    },
-    async expire(key: string, ttl: number): Promise<void> {
-      await redis.expire(`${PREFIX}${key}`, ttl);
-    },
-  };
-}
-
-/**
- * Creates a no-op metrics provider for the plugin system.
- * In production, this would be replaced with Prometheus metrics.
- */
-function createNoopMetrics(): IMetrics {
-  return {
-    incrementCounter: (_name, _labels, _value) => {
-      // No-op for development
-    },
-    setGauge: (_name, _value, _labels) => {
-      // No-op for development
-    },
-    observeHistogram: (_name, _value, _labels) => {
-      // No-op for development
-    },
-    startTimer: (_name, _labels) => () => {
-      // No-op for development
-    },
-  };
-}
-
-/**
  * Initializes the plugin system with hybrid search/import architecture.
  *
  * @remarks
@@ -856,9 +797,7 @@ async function initializePluginSystem(
   logger.info('Initializing plugin system (hybrid architecture)...');
 
   // Register dependencies with tsyringe container
-  container.register('ILogger', { useValue: logger });
-  container.register('ICacheProvider', { useValue: createPluginCacheProvider(redis) });
-  container.register('IMetrics', { useValue: createNoopMetrics() });
+  registerPluginDependencies(logger, redis);
 
   // Register plugin system components
   registerPluginSystem();

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -40,6 +40,7 @@ import {
   MarginHighlightsPlugin,
   MarginRepliesPlugin,
 } from './plugins/builtin/margin-annotations.js';
+import { registerPluginDependencies } from './plugins/core/plugin-di-helpers.js';
 import {
   getEventBus,
   getPluginManager,
@@ -492,6 +493,7 @@ async function main(): Promise<void> {
     // =====================================================================
     // Register plugin system and load cross-ecosystem tracking plugins
     // =====================================================================
+    registerPluginDependencies(logger, redis);
     registerPluginSystem();
     const pluginManager = getPluginManager();
     const pluginEventBus = getEventBus();

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -50,6 +50,7 @@ import { BacklinkService } from './services/backlink/backlink-service.js';
 import { CitationExtractionService } from './services/citation/citation-extraction-service.js';
 import { DocumentTextExtractor } from './services/citation/document-text-extractor.js';
 import { GrobidClient } from './services/citation/grobid-client.js';
+import { CollaborationService } from './services/collaboration/collaboration-service.js';
 import { CollectionService } from './services/collection/collection-service.js';
 import { createResiliencePolicy } from './services/common/resilience.js';
 import { EprintService } from './services/eprint/eprint-service.js';
@@ -474,9 +475,11 @@ async function main(): Promise<void> {
     await state.fieldLabelResolutionJob.start();
     logger.info('Field label resolution job started');
 
-    // Create personal graph and collection services for firehose indexing
+    // Create personal graph, collection, and collaboration services for
+    // firehose indexing
     const personalGraphService = new PersonalGraphService({ pool: pgPool, logger });
     const collectionService = new CollectionService({ pool: pgPool, logger });
+    const collaborationService = new CollaborationService({ pool: pgPool, logger });
 
     // Node service for relation-node lookups (used by cosmik-connections
     // plugin for reverse mapping connectionType → chive relation slug)
@@ -537,6 +540,7 @@ async function main(): Promise<void> {
       citationExtractionJob, // Async citation extraction after eprint indexing
       collectionService, // Index collections from personal PDSes
       personalGraphService, // Index personal graph nodes/edges from PDSes
+      collaborationService, // Index invites + acceptances from personal PDSes
       pluginEventBus, // Forward foreign-namespace records to plugins
     });
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -30,7 +30,23 @@ import { CitationExtractionJob } from './jobs/citation-extraction-job.js';
 import { FieldLabelResolutionJob } from './jobs/field-label-resolution-job.js';
 import { FieldPromotionJob } from './jobs/field-promotion-job.js';
 import { PinoLogger } from './observability/logger.js';
+import { CosmikBacklinksPlugin } from './plugins/builtin/cosmik-backlinks.js';
+import { CosmikConnectionsPlugin } from './plugins/builtin/cosmik-connections.js';
+import { CosmikFollowsPlugin } from './plugins/builtin/cosmik-follows.js';
+import { CosmikLinkRemovalsPlugin } from './plugins/builtin/cosmik-link-removals.js';
+import {
+  MarginAnnotationsPlugin,
+  MarginBookmarksPlugin,
+  MarginHighlightsPlugin,
+  MarginRepliesPlugin,
+} from './plugins/builtin/margin-annotations.js';
+import {
+  getEventBus,
+  getPluginManager,
+  registerPluginSystem,
+} from './plugins/core/plugin-registry.js';
 import { ActivityService } from './services/activity/activity-service.js';
+import { BacklinkService } from './services/backlink/backlink-service.js';
 import { CitationExtractionService } from './services/citation/citation-extraction-service.js';
 import { DocumentTextExtractor } from './services/citation/document-text-extractor.js';
 import { GrobidClient } from './services/citation/grobid-client.js';
@@ -39,6 +55,7 @@ import { createResiliencePolicy } from './services/common/resilience.js';
 import { EprintService } from './services/eprint/eprint-service.js';
 import { AutomaticProposalService } from './services/governance/automatic-proposal-service.js';
 import { GovernancePDSWriter } from './services/governance/governance-pds-writer.js';
+import { NodeService } from './services/governance/node-service.js';
 import { PersonalGraphService } from './services/graph/personal-graph-service.js';
 import { createEventProcessor } from './services/indexing/event-processor.js';
 import { IndexingService } from './services/indexing/indexing-service.js';
@@ -50,6 +67,7 @@ import { ElasticsearchConnectionPool } from './storage/elasticsearch/connection.
 import { Neo4jAdapter } from './storage/neo4j/adapter.js';
 import { CitationGraph } from './storage/neo4j/citation-graph.js';
 import { Neo4jConnection } from './storage/neo4j/connection.js';
+import { NodeRepository } from './storage/neo4j/node-repository.js';
 import { TagManager } from './storage/neo4j/tag-manager.js';
 import { PostgreSQLAdapter } from './storage/postgresql/adapter.js';
 import { getDatabaseConfig } from './storage/postgresql/config.js';
@@ -460,6 +478,49 @@ async function main(): Promise<void> {
     const personalGraphService = new PersonalGraphService({ pool: pgPool, logger });
     const collectionService = new CollectionService({ pool: pgPool, logger });
 
+    // Node service for relation-node lookups (used by cosmik-connections
+    // plugin for reverse mapping connectionType → chive relation slug)
+    const nodeRepository = new NodeRepository(neo4jConnection);
+    const nodeService = new NodeService({ nodeRepository, logger });
+
+    // Backlink service for plugin-emitted eprint references
+    const backlinkService = new BacklinkService(logger, pgPool);
+
+    // =====================================================================
+    // Register plugin system and load cross-ecosystem tracking plugins
+    // =====================================================================
+    registerPluginSystem();
+    const pluginManager = getPluginManager();
+    const pluginEventBus = getEventBus();
+
+    const pluginContext = {
+      backlinkService,
+      collectionService,
+      nodeService,
+    };
+
+    // Cosmik (Semble) ecosystem plugins
+    try {
+      await pluginManager.loadBuiltinPlugin(new CosmikBacklinksPlugin(), pluginContext);
+      await pluginManager.loadBuiltinPlugin(new CosmikConnectionsPlugin(), pluginContext);
+      await pluginManager.loadBuiltinPlugin(new CosmikFollowsPlugin(), pluginContext);
+      await pluginManager.loadBuiltinPlugin(new CosmikLinkRemovalsPlugin(), pluginContext);
+      logger.info('Cosmik ecosystem plugins loaded');
+    } catch (err) {
+      logger.error('Failed to load Cosmik plugins', err instanceof Error ? err : undefined);
+    }
+
+    // Margin (W3C Web Annotation) ecosystem plugins
+    try {
+      await pluginManager.loadBuiltinPlugin(new MarginAnnotationsPlugin(), pluginContext);
+      await pluginManager.loadBuiltinPlugin(new MarginHighlightsPlugin(), pluginContext);
+      await pluginManager.loadBuiltinPlugin(new MarginBookmarksPlugin(), pluginContext);
+      await pluginManager.loadBuiltinPlugin(new MarginRepliesPlugin(), pluginContext);
+      logger.info('Margin ecosystem plugins loaded');
+    } catch (err) {
+      logger.error('Failed to load Margin plugins', err instanceof Error ? err : undefined);
+    }
+
     // Create event processor with PDS auto-discovery
     const processor = createEventProcessor({
       pool: pgPool,
@@ -467,6 +528,7 @@ async function main(): Promise<void> {
       eprintService,
       reviewService,
       graphService,
+      nodeService,
       automaticProposalService,
       identity: identityResolver,
       logger,
@@ -475,6 +537,7 @@ async function main(): Promise<void> {
       citationExtractionJob, // Async citation extraction after eprint indexing
       collectionService, // Index collections from personal PDSes
       personalGraphService, // Index personal graph nodes/edges from PDSes
+      pluginEventBus, // Forward foreign-namespace records to plugins
     });
 
     // Create indexing service

--- a/src/plugins/builtin/cosmik-connections.ts
+++ b/src/plugins/builtin/cosmik-connections.ts
@@ -2,14 +2,20 @@
  * Cosmik connections tracking plugin.
  *
  * @remarks
- * Tracks `network.cosmik.connection` records from the firehose. Connections
- * represent edges between two entities (URLs or AT URIs) in the Semble graph.
+ * Tracks `network.cosmik.connection` records from the firehose. Each
+ * connection is an edge between two entities (URLs or AT URIs) in the
+ * Semble graph. This plugin performs two jobs:
  *
- * When a connection references a Chive eprint URL as either source or target,
- * this plugin creates a backlink for aggregation and discovery.
+ * 1. **Backlink tracking.** When either endpoint references a Chive eprint
+ *    URL, create a backlink for aggregation and discovery on the eprint
+ *    detail page.
+ * 2. **Graph mirroring.** Index the connection into `cosmik_connections_index`
+ *    with a reverse-resolved Chive relation slug (via the relation node's
+ *    `externalIds` entries) so Chive UIs can render it as a native-looking
+ *    graph edge.
  *
- * ATProto Compliance:
- * - All backlinks indexed from firehose (rebuildable via replay)
+ * **ATProto Compliance:**
+ * - All data sourced from firehose (rebuildable via replay)
  * - Tracks deletions to honor record removal
  * - Never writes to user PDSes
  *
@@ -18,10 +24,15 @@
  * @since 0.5.2
  */
 
+import type { CollectionService } from '../../services/collection/collection-service.js';
+import type { NodeService } from '../../services/governance/node-service.js';
+import type { AtUri, CID } from '../../types/atproto.js';
 import type {
   BacklinkSourceType,
+  IPluginContext,
   IPluginManifest,
 } from '../../types/interfaces/plugin.interface.js';
+import type { FirehoseRecord } from '../core/backlink-plugin.js';
 import { BacklinkTrackingPlugin } from '../core/backlink-plugin.js';
 
 /**
@@ -42,10 +53,6 @@ interface CosmikConnection {
 /**
  * Cosmik connections tracking plugin.
  *
- * @remarks
- * Tracks eprint references in Cosmik connection records via firehose.
- * Connections can reference eprints in either source or target fields.
- *
  * @public
  */
 export class CosmikConnectionsPlugin extends BacklinkTrackingPlugin {
@@ -58,7 +65,7 @@ export class CosmikConnectionsPlugin extends BacklinkTrackingPlugin {
   readonly manifest: IPluginManifest = {
     id: 'pub.chive.plugin.cosmik-connections',
     name: 'Cosmik Connections',
-    version: '0.5.2',
+    version: '0.5.3',
     description: 'Tracks edges between entities referencing Chive eprints from Semble connections',
     author: 'Aaron Steven White',
     license: 'MIT',
@@ -72,31 +79,44 @@ export class CosmikConnectionsPlugin extends BacklinkTrackingPlugin {
   };
 
   /**
-   * Extracts eprint AT-URIs or Chive URLs from a connection's source and target.
-   *
-   * @param record - Cosmik connection record
-   * @returns Array of eprint references found in source/target
+   * Collection service for writing to `cosmik_connections_index`.
    */
+  private collectionService?: CollectionService;
+
+  /**
+   * Node service for resolving `connectionType` to Chive relation slugs.
+   */
+  private nodeService?: NodeService;
+
+  /**
+   * In-process cache of `(system, identifier)` → relation node lookups.
+   *
+   * @remarks
+   * Relation nodes are effectively immutable once published; caching avoids
+   * a graph query per indexed connection. Cleared by `onInitialize`.
+   *
+   * @internal
+   */
+  private readonly relationCache = new Map<string, { slug: string; uri: string } | null>();
+
+  override async initialize(context: IPluginContext): Promise<void> {
+    await super.initialize(context);
+    this.collectionService = context.config.collectionService as CollectionService | undefined;
+    this.nodeService = context.config.nodeService as NodeService | undefined;
+  }
+
   extractEprintRefs(record: unknown): string[] {
     const connection = record as CosmikConnection;
     const refs: string[] = [];
-
     if (this.isChiveEprintReference(connection.source)) {
       refs.push(connection.source);
     }
     if (this.isChiveEprintReference(connection.target)) {
       refs.push(connection.target);
     }
-
     return refs;
   }
 
-  /**
-   * Extracts context from a connection record.
-   *
-   * @param record - Connection record
-   * @returns Connection type and note as context
-   */
   protected override extractContext(record: unknown): string | undefined {
     const connection = record as CosmikConnection;
     const parts: string[] = [];
@@ -110,12 +130,103 @@ export class CosmikConnectionsPlugin extends BacklinkTrackingPlugin {
   }
 
   /**
+   * Override the base handler so we can index the connection in addition
+   * to creating backlinks.
+   *
+   * @param record - Firehose record
+   */
+  override async handleFirehoseRecord(record: FirehoseRecord): Promise<void> {
+    // Run backlink tracking from the base class first
+    await super.handleFirehoseRecord(record);
+
+    // Index the connection into cosmik_connections_index with reverse-mapped
+    // Chive relation slug, regardless of whether an eprint is referenced.
+    if (record.deleted) {
+      await this.deleteConnection(record.uri as AtUri);
+      return;
+    }
+
+    if (!record.record || !this.collectionService) return;
+    const connection = record.record as unknown as CosmikConnection;
+    const { slug, uri } = await this.resolveChiveRelation(connection.connectionType);
+
+    await this.collectionService.indexCosmikConnection(
+      {
+        source: connection.source,
+        target: connection.target,
+        connectionType: connection.connectionType,
+        note: connection.note,
+        chiveRelationSlug: slug ?? undefined,
+        chiveRelationUri: uri ?? undefined,
+      },
+      {
+        uri: record.uri as AtUri,
+        cid: (record.cid ?? '') as unknown as CID,
+        indexedAt: record.timestamp,
+        pdsUrl: '',
+      }
+    );
+  }
+
+  /**
+   * Resolves a Cosmik `connectionType` to a Chive relation slug via the
+   * relation node's `externalIds`.
+   *
+   * @param connectionType - Cosmik `connectionType` value, or undefined
+   * @returns Chive relation slug and URI, or null/null if unresolvable
+   */
+  private async resolveChiveRelation(
+    connectionType: string | undefined
+  ): Promise<{ slug: string | null; uri: string | null }> {
+    if (!connectionType || !this.nodeService) return { slug: null, uri: null };
+
+    const cacheKey = `cosmik::${connectionType}`;
+    if (this.relationCache.has(cacheKey)) {
+      const cached = this.relationCache.get(cacheKey) ?? null;
+      return { slug: cached?.slug ?? null, uri: cached?.uri ?? null };
+    }
+
+    try {
+      const node = await this.nodeService.findRelationByExternalId('cosmik', connectionType);
+      if (!node) {
+        this.relationCache.set(cacheKey, null);
+        return { slug: null, uri: null };
+      }
+      // Relation nodes store their slug either in metadata.slug or derivable
+      // from the label.
+      let metadataSlug = '';
+      if (node.metadata && typeof node.metadata === 'object' && 'slug' in node.metadata) {
+        const rawSlug = (node.metadata as { slug?: unknown }).slug;
+        if (typeof rawSlug === 'string') {
+          metadataSlug = rawSlug;
+        }
+      }
+      const slug = metadataSlug || node.label.toLowerCase().replace(/\s+/g, '-');
+      const result = { slug, uri: node.uri };
+      this.relationCache.set(cacheKey, result);
+      return { slug, uri: node.uri };
+    } catch (err) {
+      this.logger.warn('Failed to resolve Chive relation for Cosmik connectionType', {
+        connectionType,
+        error: (err as Error).message,
+      });
+      return { slug: null, uri: null };
+    }
+  }
+
+  /**
+   * Removes a connection from the index (firehose delete event).
+   */
+  private async deleteConnection(uri: AtUri): Promise<void> {
+    if (!this.collectionService) return;
+    await this.collectionService.deleteCosmikConnection(uri);
+  }
+
+  /**
    * Checks if a string references a Chive eprint via AT-URI or web URL.
    */
   private isChiveEprintReference(value: string): boolean {
-    // Check AT-URI format
     if (value.includes('pub.chive.eprint.submission')) return true;
-    // Check for Chive web URLs: https://chive.pub/eprints/...
     if (value.includes('chive.pub/eprints/')) return true;
     return false;
   }

--- a/src/plugins/core/plugin-di-helpers.ts
+++ b/src/plugins/core/plugin-di-helpers.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared DI registration helpers for the plugin system.
+ *
+ * @remarks
+ * Both the API server and the indexer load the plugin system, which depends
+ * on `ILogger`, `ICacheProvider`, and `IMetrics` being registered with the
+ * tsyringe container before `registerPluginSystem()` is called. These helpers
+ * centralize that wiring so the two entry points can't drift apart.
+ *
+ * @packageDocumentation
+ */
+
+import type { Redis } from 'ioredis';
+import { container } from 'tsyringe';
+
+import type { ICacheProvider } from '../../types/interfaces/cache.interface.js';
+import type { ILogger } from '../../types/interfaces/logger.interface.js';
+import type { IMetrics } from '../../types/interfaces/metrics.interface.js';
+
+export function createPluginCacheProvider(redis: Redis): ICacheProvider {
+  const PREFIX = 'chive:plugin:';
+  return {
+    async get<T>(key: string): Promise<T | null> {
+      const value = await redis.get(`${PREFIX}${key}`);
+      if (value === null) return null;
+      try {
+        return JSON.parse(value) as T;
+      } catch {
+        return null;
+      }
+    },
+    async set<T>(key: string, value: T, ttl?: number): Promise<void> {
+      const serialized = JSON.stringify(value);
+      if (ttl) {
+        await redis.setex(`${PREFIX}${key}`, ttl, serialized);
+      } else {
+        await redis.set(`${PREFIX}${key}`, serialized);
+      }
+    },
+    async delete(key: string): Promise<void> {
+      await redis.del(`${PREFIX}${key}`);
+    },
+    async exists(key: string): Promise<boolean> {
+      const result = await redis.exists(`${PREFIX}${key}`);
+      return result === 1;
+    },
+    async expire(key: string, ttl: number): Promise<void> {
+      await redis.expire(`${PREFIX}${key}`, ttl);
+    },
+  };
+}
+
+export function createNoopMetrics(): IMetrics {
+  const noop = (): void => {
+    // No-op metrics provider; replace with Prometheus in production.
+  };
+  return {
+    incrementCounter: noop,
+    setGauge: noop,
+    observeHistogram: noop,
+    startTimer: () => noop,
+  };
+}
+
+/**
+ * Pre-registers the tokens that `registerPluginSystem()` resolves.
+ */
+export function registerPluginDependencies(logger: ILogger, redis: Redis): void {
+  container.register('ILogger', { useValue: logger });
+  container.register('ICacheProvider', { useValue: createPluginCacheProvider(redis) });
+  container.register('IMetrics', { useValue: createNoopMetrics() });
+}

--- a/src/services/collaboration/collaboration-service.ts
+++ b/src/services/collaboration/collaboration-service.ts
@@ -1,0 +1,557 @@
+/**
+ * Collaboration service: manages invites, acceptances, and derived active-
+ * collaborator state for any Chive-authored subject record.
+ *
+ * @remarks
+ * The collaboration model follows Chive's write-authority philosophy:
+ * each party writes a record in its own PDS declaring its side of the
+ * handshake. The AppView observes both sides from the firehose and
+ * computes derived state — mirroring the governance consensus model.
+ *
+ * Records:
+ *
+ * - `pub.chive.collaboration.invite` — lives in the subject-record author's
+ *   PDS. Owner declares "I invite this DID to collaborate on this record."
+ * - `pub.chive.collaboration.inviteAcceptance` — lives in the invitee's
+ *   PDS. Invitee declares "I accept this specific invite."
+ *
+ * Active collaboration exists when both an invite and a matching
+ * acceptance are non-deleted. Either party can revoke by deleting their
+ * own record; the other party's record remains in their PDS but is no
+ * longer surfaced in the derived view.
+ *
+ * ATProto Compliance:
+ * - Read-only AppView: all state is derived from firehose records
+ * - Never writes to foreign PDSes
+ * - Out-of-order firehose delivery is handled via
+ *   `collaboration_pending_state`, so no valid handshake is silently
+ *   dropped
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type { Pool } from 'pg';
+
+import type { AtUri, DID } from '../../types/atproto.js';
+import { DatabaseError } from '../../types/errors.js';
+import type { ILogger } from '../../types/interfaces/logger.interface.js';
+import { Err, Ok, type Result } from '../../types/result.js';
+import type { RecordMetadata } from '../eprint/eprint-service.js';
+
+/**
+ * Options for constructing a `CollaborationService`.
+ *
+ * @public
+ */
+export interface CollaborationServiceOptions {
+  readonly pool: Pool;
+  readonly logger: ILogger;
+}
+
+/**
+ * A single active collaborator on a subject record.
+ *
+ * @public
+ */
+export interface ActiveCollaborator {
+  readonly did: DID;
+  readonly inviteUri: string;
+  readonly acceptanceUri: string;
+  readonly role?: string;
+  readonly acceptedAt: Date;
+}
+
+/**
+ * Derived state of an individual invite (from the invitee's perspective).
+ *
+ * @public
+ */
+export interface InviteView {
+  readonly uri: AtUri;
+  readonly inviter: DID;
+  readonly invitee: DID;
+  readonly subjectUri: AtUri;
+  readonly subjectCollection: string;
+  readonly role?: string;
+  readonly message?: string;
+  readonly state: 'pending' | 'accepted' | 'rejected' | 'expired';
+  readonly acceptanceUri?: string;
+  readonly createdAt: Date;
+  readonly expiresAt?: Date;
+  readonly acceptedAt?: Date;
+}
+
+/**
+ * Parsed invite record body.
+ *
+ * @public
+ */
+export interface InviteRecord {
+  subject: { uri: string; cid?: string };
+  invitee: string;
+  role?: string;
+  message?: string;
+  createdAt: string;
+  expiresAt?: string;
+}
+
+/**
+ * Parsed acceptance record body.
+ *
+ * @public
+ */
+export interface AcceptanceRecord {
+  invite: { uri: string; cid?: string };
+  subject: { uri: string; cid?: string };
+  createdAt: string;
+}
+
+/**
+ * Collaboration service.
+ *
+ * @public
+ */
+export class CollaborationService {
+  private readonly pool: Pool;
+  private readonly logger: ILogger;
+
+  constructor(options: CollaborationServiceOptions) {
+    this.pool = options.pool;
+    this.logger = options.logger;
+  }
+
+  /**
+   * Indexes an invite record from the firehose.
+   */
+  async indexInvite(
+    record: InviteRecord,
+    metadata: RecordMetadata
+  ): Promise<Result<void, DatabaseError>> {
+    try {
+      const inviterDid = extractDid(metadata.uri);
+      const subjectAuthor = extractDid(record.subject.uri as AtUri);
+      const subjectCollection = extractCollection(record.subject.uri as AtUri);
+
+      await this.pool.query(
+        `INSERT INTO collaboration_invites_index (
+          uri, cid, inviter_did, invitee_did, subject_uri,
+          subject_author_did, subject_collection, role, message,
+          created_at, expires_at, pds_url, indexed_at, last_synced_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW(), NOW())
+        ON CONFLICT (uri) DO UPDATE SET
+          cid = EXCLUDED.cid,
+          role = EXCLUDED.role,
+          message = EXCLUDED.message,
+          expires_at = EXCLUDED.expires_at,
+          deleted_at = NULL,
+          last_synced_at = NOW()`,
+        [
+          metadata.uri,
+          metadata.cid,
+          inviterDid,
+          record.invitee,
+          record.subject.uri,
+          subjectAuthor,
+          subjectCollection,
+          record.role ?? null,
+          record.message ?? null,
+          new Date(record.createdAt),
+          record.expiresAt ? new Date(record.expiresAt) : null,
+          metadata.pdsUrl,
+        ]
+      );
+
+      await this.reevaluatePair(record.subject.uri, record.invitee);
+
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError('WRITE', `Failed to index invite: ${toMessage(error)}`);
+      this.logger.error('Failed to index invite', dbError, { uri: metadata.uri });
+      return Err(dbError);
+    }
+  }
+
+  /**
+   * Marks an invite as deleted (firehose delete event).
+   */
+  async deleteInvite(uri: AtUri): Promise<Result<void, DatabaseError>> {
+    try {
+      const result = await this.pool.query<{
+        subject_uri: string;
+        invitee_did: string;
+      }>(
+        `UPDATE collaboration_invites_index
+         SET deleted_at = NOW()
+         WHERE uri = $1
+         RETURNING subject_uri, invitee_did`,
+        [uri]
+      );
+      const row = result.rows[0];
+      if (row) {
+        await this.reevaluatePair(row.subject_uri, row.invitee_did);
+      }
+      return Ok(undefined);
+    } catch (error) {
+      return Err(new DatabaseError('DELETE', `Failed to delete invite: ${toMessage(error)}`));
+    }
+  }
+
+  /**
+   * Indexes an acceptance record from the firehose.
+   */
+  async indexAcceptance(
+    record: AcceptanceRecord,
+    metadata: RecordMetadata
+  ): Promise<Result<void, DatabaseError>> {
+    try {
+      const accepterDid = extractDid(metadata.uri);
+
+      await this.pool.query(
+        `INSERT INTO collaboration_acceptances_index (
+          uri, cid, accepter_did, invite_uri, subject_uri,
+          created_at, pds_url, indexed_at, last_synced_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+        ON CONFLICT (uri) DO UPDATE SET
+          cid = EXCLUDED.cid,
+          deleted_at = NULL,
+          last_synced_at = NOW()`,
+        [
+          metadata.uri,
+          metadata.cid,
+          accepterDid,
+          record.invite.uri,
+          record.subject.uri,
+          new Date(record.createdAt),
+          metadata.pdsUrl,
+        ]
+      );
+
+      await this.reevaluatePair(record.subject.uri, accepterDid);
+
+      return Ok(undefined);
+    } catch (error) {
+      const dbError = new DatabaseError('WRITE', `Failed to index acceptance: ${toMessage(error)}`);
+      this.logger.error('Failed to index acceptance', dbError, { uri: metadata.uri });
+      return Err(dbError);
+    }
+  }
+
+  /**
+   * Marks an acceptance as deleted (firehose delete event).
+   */
+  async deleteAcceptance(uri: AtUri): Promise<Result<void, DatabaseError>> {
+    try {
+      const result = await this.pool.query<{
+        subject_uri: string;
+        accepter_did: string;
+      }>(
+        `UPDATE collaboration_acceptances_index
+         SET deleted_at = NOW()
+         WHERE uri = $1
+         RETURNING subject_uri, accepter_did`,
+        [uri]
+      );
+      const row = result.rows[0];
+      if (row) {
+        await this.reevaluatePair(row.subject_uri, row.accepter_did);
+      }
+      return Ok(undefined);
+    } catch (error) {
+      return Err(new DatabaseError('DELETE', `Failed to delete acceptance: ${toMessage(error)}`));
+    }
+  }
+
+  /**
+   * Gets the active collaborators on a subject record.
+   *
+   * @param subjectUri - AT-URI of the subject record
+   * @returns Array of active collaborators (may be empty)
+   */
+  async getActiveCollaborators(subjectUri: AtUri): Promise<ActiveCollaborator[]> {
+    try {
+      const result = await this.pool.query<{
+        did: string;
+        invite_uri: string;
+        acceptance_uri: string;
+        role: string | null;
+        accepted_at: Date;
+      }>(
+        `SELECT i.invitee_did AS did,
+                i.uri AS invite_uri,
+                a.uri AS acceptance_uri,
+                i.role,
+                a.created_at AS accepted_at
+         FROM collaboration_invites_index i
+         INNER JOIN collaboration_acceptances_index a
+           ON a.invite_uri = i.uri
+          AND a.accepter_did = i.invitee_did
+          AND a.subject_uri = i.subject_uri
+         WHERE i.subject_uri = $1
+           AND i.deleted_at IS NULL
+           AND a.deleted_at IS NULL
+           AND (i.expires_at IS NULL OR i.expires_at > NOW())`,
+        [subjectUri]
+      );
+
+      return result.rows.map((row) => ({
+        did: row.did as DID,
+        inviteUri: row.invite_uri,
+        acceptanceUri: row.acceptance_uri,
+        role: row.role ?? undefined,
+        acceptedAt: new Date(row.accepted_at),
+      }));
+    } catch (error) {
+      this.logger.error('Failed to get active collaborators', toError(error), { subjectUri });
+      return [];
+    }
+  }
+
+  /**
+   * Checks whether a given DID is an active collaborator on a subject.
+   */
+  async isCollaborator(subjectUri: AtUri, did: DID): Promise<boolean> {
+    try {
+      const result = await this.pool.query<{ one: number }>(
+        `SELECT 1 AS one
+         FROM collaboration_invites_index i
+         INNER JOIN collaboration_acceptances_index a
+           ON a.invite_uri = i.uri
+          AND a.accepter_did = i.invitee_did
+          AND a.subject_uri = i.subject_uri
+         WHERE i.subject_uri = $1
+           AND i.invitee_did = $2
+           AND i.deleted_at IS NULL
+           AND a.deleted_at IS NULL
+           AND (i.expires_at IS NULL OR i.expires_at > NOW())
+         LIMIT 1`,
+        [subjectUri, did]
+      );
+      return result.rows.length > 0;
+    } catch (error) {
+      this.logger.error('Failed to check collaborator status', toError(error), {
+        subjectUri,
+        did,
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Lists invites matching the given filters. Used by invitee inboxes and
+   * inviter dashboards.
+   */
+  async listInvites(options: {
+    invitee?: DID;
+    inviter?: DID;
+    subjectUri?: AtUri;
+    subjectCollection?: string;
+    state?: 'pending' | 'accepted' | 'rejected' | 'expired' | 'all';
+    limit?: number;
+    cursor?: string;
+  }): Promise<{ invites: InviteView[]; cursor?: string; hasMore: boolean; total: number }> {
+    const limit = Math.min(options.limit ?? 50, 100);
+    const filters: string[] = [];
+    const params: unknown[] = [];
+
+    if (options.invitee) {
+      params.push(options.invitee);
+      filters.push(`i.invitee_did = $${params.length}`);
+    }
+    if (options.inviter) {
+      params.push(options.inviter);
+      filters.push(`i.inviter_did = $${params.length}`);
+    }
+    if (options.subjectUri) {
+      params.push(options.subjectUri);
+      filters.push(`i.subject_uri = $${params.length}`);
+    }
+    if (options.subjectCollection) {
+      params.push(options.subjectCollection);
+      filters.push(`i.subject_collection = $${params.length}`);
+    }
+
+    const whereClause = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
+
+    try {
+      const countResult = await this.pool.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM collaboration_invites_index i ${whereClause}`,
+        params
+      );
+      const total = parseInt(countResult.rows[0]?.count ?? '0', 10);
+
+      let cursorClause = '';
+      if (options.cursor) {
+        params.push(new Date(options.cursor));
+        cursorClause = `${filters.length > 0 ? 'AND' : 'WHERE'} i.created_at < $${params.length}`;
+      }
+
+      params.push(limit + 1);
+      const result = await this.pool.query<{
+        uri: string;
+        inviter_did: string;
+        invitee_did: string;
+        subject_uri: string;
+        subject_collection: string;
+        role: string | null;
+        message: string | null;
+        created_at: Date;
+        expires_at: Date | null;
+        deleted_at: Date | null;
+        acceptance_uri: string | null;
+        acceptance_deleted_at: Date | null;
+        acceptance_created_at: Date | null;
+      }>(
+        `SELECT i.uri, i.inviter_did, i.invitee_did, i.subject_uri,
+                i.subject_collection, i.role, i.message, i.created_at,
+                i.expires_at, i.deleted_at,
+                a.uri AS acceptance_uri,
+                a.deleted_at AS acceptance_deleted_at,
+                a.created_at AS acceptance_created_at
+         FROM collaboration_invites_index i
+         LEFT JOIN collaboration_acceptances_index a
+           ON a.invite_uri = i.uri
+          AND a.accepter_did = i.invitee_did
+          AND a.subject_uri = i.subject_uri
+         ${whereClause} ${cursorClause}
+         ORDER BY i.created_at DESC
+         LIMIT $${params.length}`,
+        params
+      );
+
+      const hasMore = result.rows.length > limit;
+      const rows = result.rows.slice(0, limit);
+
+      const mapped = rows.map<InviteView>((row) => {
+        const now = new Date();
+        const isExpired = row.expires_at && row.expires_at < now;
+        const isAccepted = row.acceptance_uri && !row.acceptance_deleted_at;
+        const isDeleted = row.deleted_at;
+        let state: InviteView['state'];
+        if (isDeleted) state = 'rejected';
+        else if (isExpired) state = 'expired';
+        else if (isAccepted) state = 'accepted';
+        else state = 'pending';
+
+        return {
+          uri: row.uri as AtUri,
+          inviter: row.inviter_did as DID,
+          invitee: row.invitee_did as DID,
+          subjectUri: row.subject_uri as AtUri,
+          subjectCollection: row.subject_collection,
+          role: row.role ?? undefined,
+          message: row.message ?? undefined,
+          state,
+          acceptanceUri: row.acceptance_uri ?? undefined,
+          createdAt: new Date(row.created_at),
+          expiresAt: row.expires_at ? new Date(row.expires_at) : undefined,
+          acceptedAt: row.acceptance_created_at ? new Date(row.acceptance_created_at) : undefined,
+        };
+      });
+
+      const filteredByState =
+        options.state && options.state !== 'all'
+          ? mapped.filter((view) => view.state === options.state)
+          : mapped;
+
+      const lastRow = rows[rows.length - 1];
+      const cursor = hasMore && lastRow ? lastRow.created_at.toISOString() : undefined;
+
+      return {
+        invites: filteredByState,
+        cursor,
+        hasMore,
+        total,
+      };
+    } catch (error) {
+      this.logger.error('Failed to list invites', toError(error), options);
+      return { invites: [], hasMore: false, total: 0 };
+    }
+  }
+
+  /**
+   * Re-evaluates the pending-state row for a (subject_uri, did) pair after
+   * an invite or acceptance event.
+   *
+   * @internal
+   */
+  private async reevaluatePair(subjectUri: string, did: string): Promise<void> {
+    const inviteResult = await this.pool.query<{ uri: string; deleted_at: Date | null }>(
+      `SELECT uri, deleted_at FROM collaboration_invites_index
+       WHERE subject_uri = $1 AND invitee_did = $2
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [subjectUri, did]
+    );
+    const acceptanceResult = await this.pool.query<{ uri: string; deleted_at: Date | null }>(
+      `SELECT uri, deleted_at FROM collaboration_acceptances_index
+       WHERE subject_uri = $1 AND accepter_did = $2
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [subjectUri, did]
+    );
+
+    const invite = inviteResult.rows[0];
+    const acceptance = acceptanceResult.rows[0];
+
+    let state: 'pending-acceptance' | 'pending-invite' | 'active' | 'inactive';
+    if (invite && !invite.deleted_at && acceptance && !acceptance.deleted_at) {
+      state = 'active';
+    } else if (invite && !invite.deleted_at && !acceptance) {
+      state = 'pending-acceptance';
+    } else if (!invite && acceptance && !acceptance.deleted_at) {
+      state = 'pending-invite';
+    } else {
+      state = 'inactive';
+    }
+
+    await this.pool.query(
+      `INSERT INTO collaboration_pending_state (
+        subject_uri, did, invite_uri, acceptance_uri, state, received_at, last_updated_at
+      ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+      ON CONFLICT (subject_uri, did) DO UPDATE SET
+        invite_uri = EXCLUDED.invite_uri,
+        acceptance_uri = EXCLUDED.acceptance_uri,
+        state = EXCLUDED.state,
+        last_updated_at = NOW()`,
+      [subjectUri, did, invite?.uri ?? null, acceptance?.uri ?? null, state]
+    );
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Extracts the DID authority segment of an AT-URI.
+ *
+ * @internal
+ */
+function extractDid(uri: AtUri): DID {
+  const parts = (uri as unknown as string).split('/');
+  return (parts[2] ?? '') as DID;
+}
+
+/**
+ * Extracts the collection NSID of an AT-URI.
+ *
+ * @internal
+ */
+function extractCollection(uri: AtUri): string {
+  const parts = (uri as unknown as string).split('/');
+  return parts[3] ?? '';
+}
+
+/**
+ * Converts an unknown to an Error (identity for Error, stringified otherwise).
+ *
+ * @internal
+ */
+function toError(value: unknown): Error | undefined {
+  return value instanceof Error ? value : undefined;
+}
+
+function toMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}

--- a/src/services/collection/collection-service.ts
+++ b/src/services/collection/collection-service.ts
@@ -1878,6 +1878,10 @@ export class CollectionService {
       target: string;
       connectionType?: string;
       note?: string;
+      /** Resolved Chive relation slug when the connectionType maps to one of our relations. */
+      chiveRelationSlug?: string;
+      /** AT-URI of the resolved Chive relation node. */
+      chiveRelationUri?: string;
     },
     metadata: RecordMetadata
   ): Promise<Result<void, DatabaseError>> {
@@ -1887,14 +1891,17 @@ export class CollectionService {
       await this.pool.query(
         `INSERT INTO cosmik_connections_index (
           uri, cid, owner_did, source_entity, target_entity,
-          connection_type, note, created_at, pds_url, indexed_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+          connection_type, note, chive_relation_slug, chive_relation_uri,
+          created_at, pds_url, indexed_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
         ON CONFLICT (uri) DO UPDATE SET
           cid = EXCLUDED.cid,
           source_entity = EXCLUDED.source_entity,
           target_entity = EXCLUDED.target_entity,
           connection_type = EXCLUDED.connection_type,
           note = EXCLUDED.note,
+          chive_relation_slug = EXCLUDED.chive_relation_slug,
+          chive_relation_uri = EXCLUDED.chive_relation_uri,
           updated_at = NOW()`,
         [
           metadata.uri,
@@ -1904,6 +1911,8 @@ export class CollectionService {
           record.target,
           record.connectionType ?? null,
           record.note ?? null,
+          record.chiveRelationSlug ?? null,
+          record.chiveRelationUri ?? null,
           metadata.indexedAt,
           metadata.pdsUrl,
         ]

--- a/src/services/governance/node-service.ts
+++ b/src/services/governance/node-service.ts
@@ -233,8 +233,35 @@ export class NodeService {
     status?: NodeStatus;
     limit?: number;
     cursor?: string;
+    externalIdSystem?: string;
+    externalIdIdentifier?: string;
   }): Promise<NodeSearchResult> {
     return this.nodeRepository.listNodes(options);
+  }
+
+  /**
+   * Finds a relation-type node whose `externalIds` include a matching
+   * `(system, identifier)` pair.
+   *
+   * @remarks
+   * Used for reverse-resolving foreign ecosystem identifiers (e.g., Cosmik
+   * `connectionType`, SKOS URIs) to Chive relation slugs.
+   *
+   * @param system - External-id system name
+   * @param identifier - Identifier value in that system
+   * @returns First matching relation-type node, or null if none found
+   *
+   * @public
+   */
+  async findRelationByExternalId(system: string, identifier: string): Promise<GraphNode | null> {
+    const result = await this.nodeRepository.listNodes({
+      kind: 'type',
+      subkind: 'relation',
+      externalIdSystem: system,
+      externalIdIdentifier: identifier,
+      limit: 1,
+    });
+    return result.nodes[0] ?? null;
   }
 
   /**

--- a/src/services/indexing/event-processor.ts
+++ b/src/services/indexing/event-processor.ts
@@ -344,6 +344,16 @@ export interface EventProcessorOptions {
    * When provided, personal (non-governance) graph records are indexed.
    */
   readonly personalGraphService?: PersonalGraphService;
+  /**
+   * Optional plugin event bus. When provided, records from foreign
+   * namespaces (e.g., `network.cosmik.*`, `at.margin.*`) are forwarded to
+   * plugins subscribed on the corresponding `firehose.<collection>` event.
+   * Chive-native records (`pub.chive.*`) are NOT forwarded — they flow
+   * through the switch below with full service access instead.
+   */
+  readonly pluginEventBus?: {
+    emit: (event: string, payload: unknown) => void;
+  };
 }
 
 /**
@@ -381,10 +391,35 @@ export function createEventProcessor(
     citationExtractionJob,
     collectionService,
     personalGraphService,
+    pluginEventBus,
   } = options;
 
   return async (event: ProcessedEvent): Promise<void> => {
     const { repo, collection, rkey, action, cid, seq, record } = event;
+
+    // Forward foreign-namespace records to plugins. Chive records (`pub.chive.*`)
+    // are handled inline by the switch below with direct service access; we
+    // don't emit them twice.
+    if (pluginEventBus && !collection.startsWith('pub.chive.')) {
+      const firehoseRecord = {
+        uri: `at://${repo}/${collection}/${rkey}`,
+        collection,
+        did: repo,
+        rkey,
+        record: record ?? null,
+        deleted: action === 'delete',
+        cid: cid ?? undefined,
+        timestamp: new Date(),
+      };
+      try {
+        pluginEventBus.emit(`firehose.${collection}`, firehoseRecord);
+      } catch (err) {
+        logger.warn('Plugin eventBus emit failed', {
+          collection,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
 
     logger.debug('Processing firehose event', {
       repo,

--- a/src/services/indexing/event-processor.ts
+++ b/src/services/indexing/event-processor.ts
@@ -46,6 +46,7 @@ import type { ILogger } from '../../types/interfaces/logger.interface.js';
 import type { IStorageBackend } from '../../types/interfaces/storage.interface.js';
 import type { ActivityService } from '../activity/activity-service.js';
 import type { AnnotationService } from '../annotation/annotation-service.js';
+import type { CollaborationService } from '../collaboration/collaboration-service.js';
 import type { CollectionService } from '../collection/collection-service.js';
 import type { EprintService, RecordMetadata } from '../eprint/eprint-service.js';
 import { transformPDSRecordWithSchema } from '../eprint/pds-record-transformer.js';
@@ -345,6 +346,11 @@ export interface EventProcessorOptions {
    */
   readonly personalGraphService?: PersonalGraphService;
   /**
+   * Optional collaboration service for indexing invites and acceptances.
+   * When provided, `pub.chive.collaboration.*` records flow through.
+   */
+  readonly collaborationService?: CollaborationService;
+  /**
    * Optional plugin event bus. When provided, records from foreign
    * namespaces (e.g., `network.cosmik.*`, `at.margin.*`) are forwarded to
    * plugins subscribed on the corresponding `firehose.<collection>` event.
@@ -391,6 +397,7 @@ export function createEventProcessor(
     citationExtractionJob,
     collectionService,
     personalGraphService,
+    collaborationService,
     pluginEventBus,
   } = options;
 
@@ -461,6 +468,7 @@ export function createEventProcessor(
         citationExtractionJob,
         collectionService,
         personalGraphService,
+        collaborationService,
       },
       {
         uri,
@@ -541,6 +549,7 @@ interface ProcessRecordContext {
   readonly citationExtractionJob?: CitationExtractionJob;
   readonly collectionService?: CollectionService;
   readonly personalGraphService?: PersonalGraphService;
+  readonly collaborationService?: CollaborationService;
 }
 
 interface RecordData {
@@ -585,6 +594,7 @@ async function processRecord(
     citationExtractionJob,
     collectionService,
     personalGraphService,
+    collaborationService,
   } = ctx;
   const { uri, cid, collection, action, record, pdsUrl } = data;
 
@@ -1564,6 +1574,66 @@ async function processRecord(
             new DatabaseError('INSERT', error.message, error)
           );
         }
+      }
+      return success();
+    }
+
+    case 'pub.chive.collaboration.invite': {
+      if (!collaborationService) return success();
+      if (action === 'delete') {
+        const res = await collaborationService.deleteInvite(uri);
+        if (!res.ok) return failure('Failed to delete invite', false, res.error);
+      } else if (record && typeof record === 'object') {
+        const r = record as {
+          subject?: { uri?: string; cid?: string };
+          invitee?: string;
+          role?: string;
+          message?: string;
+          createdAt?: string;
+          expiresAt?: string;
+        };
+        if (!r.subject?.uri || !r.invitee || !r.createdAt) {
+          return success();
+        }
+        const res = await collaborationService.indexInvite(
+          {
+            subject: { uri: r.subject.uri, cid: r.subject.cid },
+            invitee: r.invitee,
+            role: r.role,
+            message: r.message,
+            createdAt: r.createdAt,
+            expiresAt: r.expiresAt,
+          },
+          metadata
+        );
+        if (!res.ok) return failure('Failed to index invite', false, res.error);
+      }
+      return success();
+    }
+
+    case 'pub.chive.collaboration.inviteAcceptance': {
+      if (!collaborationService) return success();
+      if (action === 'delete') {
+        const res = await collaborationService.deleteAcceptance(uri);
+        if (!res.ok) return failure('Failed to delete acceptance', false, res.error);
+      } else if (record && typeof record === 'object') {
+        const r = record as {
+          invite?: { uri?: string; cid?: string };
+          subject?: { uri?: string; cid?: string };
+          createdAt?: string;
+        };
+        if (!r.invite?.uri || !r.subject?.uri || !r.createdAt) {
+          return success();
+        }
+        const res = await collaborationService.indexAcceptance(
+          {
+            invite: { uri: r.invite.uri, cid: r.invite.cid },
+            subject: { uri: r.subject.uri, cid: r.subject.cid },
+            createdAt: r.createdAt,
+          },
+          metadata
+        );
+        if (!res.ok) return failure('Failed to index acceptance', false, res.error);
       }
       return success();
     }

--- a/src/services/indexing/firehose-consumer.ts
+++ b/src/services/indexing/firehose-consumer.ts
@@ -445,8 +445,12 @@ export class FirehoseConsumer implements IEventStreamConsumer {
         url.searchParams.append('wantedCollections', collection);
       }
     } else {
-      // Default to all pub.chive.* collections
+      // Default: subscribe to Chive records plus cosmik/margin ecosystems we
+      // interoperate with. Jetstream supports multiple wantedCollections;
+      // trailing-wildcard filters match all records in that namespace.
       url.searchParams.append('wantedCollections', 'pub.chive.*');
+      url.searchParams.append('wantedCollections', 'network.cosmik.*');
+      url.searchParams.append('wantedCollections', 'at.margin.*');
     }
 
     // Create WebSocket

--- a/src/storage/neo4j/adapter.ts
+++ b/src/storage/neo4j/adapter.ts
@@ -199,7 +199,15 @@ export class Neo4jAdapter implements IGraphDatabase {
    * Lists nodes with filtering.
    */
   async listNodes(options: NodeSearchOptions): Promise<NodeSearchResult> {
-    const { kind, subkind, status, limit = 50, cursor } = options;
+    const {
+      kind,
+      subkind,
+      status,
+      limit = 50,
+      cursor,
+      externalIdSystem,
+      externalIdIdentifier,
+    } = options;
 
     // Build label filter
     let labelFilter = ':Node';
@@ -219,6 +227,17 @@ export class Neo4jAdapter implements IGraphDatabase {
     if (status) {
       conditions.push('n.status = $status');
       params.status = status;
+    }
+
+    if (externalIdSystem && externalIdIdentifier) {
+      // externalIds is stored as serialized JSON; match on both system and
+      // identifier via CONTAINS fragments. See neo4j/node-repository.ts for
+      // matching rationale.
+      conditions.push('n.externalIds IS NOT NULL');
+      conditions.push('n.externalIds CONTAINS $externalIdSystemFragment');
+      conditions.push('n.externalIds CONTAINS $externalIdIdentifierFragment');
+      params.externalIdSystemFragment = `"system":"${externalIdSystem}"`;
+      params.externalIdIdentifierFragment = `"identifier":"${externalIdIdentifier}"`;
     }
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';

--- a/src/storage/neo4j/node-repository.ts
+++ b/src/storage/neo4j/node-repository.ts
@@ -405,6 +405,15 @@ export class NodeRepository {
     status?: NodeStatus;
     limit?: number;
     cursor?: string;
+    /**
+     * Filter nodes whose `externalIds` array includes an entry matching both
+     * `system` and `identifier`. External IDs are stored in Neo4j as a
+     * serialized JSON string, so this filter uses a substring match on the
+     * JSON representation. Must be combined with `externalIdIdentifier`.
+     */
+    externalIdSystem?: string;
+    /** See `externalIdSystem`. */
+    externalIdIdentifier?: string;
   }): Promise<NodeSearchResult> {
     const limit = options?.limit ?? 50;
     const filters: string[] = [];
@@ -440,6 +449,18 @@ export class NodeRepository {
     if (options?.cursor) {
       filters.push('n.label > $cursor');
       params.cursor = options.cursor;
+    }
+
+    // External-id filter: match against the JSON-serialized externalIds
+    // property using CONTAINS for both system and identifier. Both fragments
+    // must be present in the same externalIds JSON string. Efficient enough
+    // for the expected result sizes (relation nodes: ~30, field nodes: ~1k).
+    if (options?.externalIdSystem && options?.externalIdIdentifier) {
+      filters.push('n.externalIds IS NOT NULL');
+      filters.push('n.externalIds CONTAINS $externalIdSystemFragment');
+      filters.push('n.externalIds CONTAINS $externalIdIdentifierFragment');
+      params.externalIdSystemFragment = `"system":"${options.externalIdSystem}"`;
+      params.externalIdIdentifierFragment = `"identifier":"${options.externalIdIdentifier}"`;
     }
 
     const whereClause = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';

--- a/src/storage/neo4j/types.ts
+++ b/src/storage/neo4j/types.ts
@@ -40,7 +40,11 @@ export type ExternalIdSystem =
   | 'mesh'
   | 'aat'
   | 'gnd'
-  | 'anzsrc';
+  | 'anzsrc'
+  | 'skos'
+  | 'cosmik'
+  | 'schema-org'
+  | 'dublin-core';
 
 /**
  * SKOS match type for external ID mapping

--- a/src/storage/postgresql/migrations/1741300000000_cosmik-relation-slug.ts
+++ b/src/storage/postgresql/migrations/1741300000000_cosmik-relation-slug.ts
@@ -1,0 +1,32 @@
+/**
+ * Add `chive_relation_slug` to cosmik_connections_index.
+ *
+ * @remarks
+ * When a `network.cosmik.connection` is indexed from the firehose, the
+ * cosmik-connections plugin resolves its `connectionType` against the
+ * `externalIds` of Chive relation-type nodes. The resolved slug (if any)
+ * is stored here so Chive UIs can render the connection as if it were a
+ * native Chive edge with that relation.
+ *
+ * The original `connection_type` column retains the raw Cosmik value for
+ * auditability and for cases where no Chive relation matches.
+ *
+ * @packageDocumentation
+ */
+
+import type { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumns('cosmik_connections_index', {
+    chive_relation_slug: { type: 'text' },
+    chive_relation_uri: { type: 'text' },
+  });
+
+  pgm.createIndex('cosmik_connections_index', 'chive_relation_slug');
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropColumns('cosmik_connections_index', ['chive_relation_slug', 'chive_relation_uri']);
+}

--- a/src/storage/postgresql/migrations/1741400000000_collaboration.ts
+++ b/src/storage/postgresql/migrations/1741400000000_collaboration.ts
@@ -1,0 +1,135 @@
+/**
+ * Chive-native collaboration schema.
+ *
+ * @remarks
+ * Stores `pub.chive.collaboration.invite` and
+ * `pub.chive.collaboration.inviteAcceptance` records indexed from the
+ * firehose, plus two "pending" tables that handle out-of-order delivery.
+ *
+ * ## Design
+ *
+ * Collaboration is generic over any Chive record type (not just collections),
+ * so tables are keyed on `subject_uri` rather than a collection-specific
+ * foreign key. AppView logic surfacing active collaborators computes
+ * `(invite, acceptance) not-deleted` pairs per subject.
+ *
+ * See `.claude/design/collaboration.md` for the full write-authority model.
+ *
+ * @packageDocumentation
+ */
+
+import type { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  // =========================================================================
+  // Invite records (authored in the subject's author's PDS)
+  // =========================================================================
+  pgm.createTable('collaboration_invites_index', {
+    uri: { type: 'text', primaryKey: true },
+    cid: { type: 'text', notNull: true },
+    inviter_did: { type: 'text', notNull: true },
+    invitee_did: { type: 'text', notNull: true },
+    subject_uri: { type: 'text', notNull: true },
+    subject_author_did: { type: 'text', notNull: true },
+    subject_collection: { type: 'text', notNull: true },
+    role: { type: 'text' },
+    message: { type: 'text' },
+    created_at: { type: 'timestamptz', notNull: true },
+    expires_at: { type: 'timestamptz' },
+    /** When set, the record has been withdrawn by the inviter. */
+    deleted_at: { type: 'timestamptz' },
+    pds_url: { type: 'text' },
+    indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    last_synced_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('collaboration_invites_index', 'invitee_did');
+  pgm.createIndex('collaboration_invites_index', 'inviter_did');
+  pgm.createIndex('collaboration_invites_index', 'subject_uri');
+  pgm.createIndex('collaboration_invites_index', 'subject_collection');
+
+  // =========================================================================
+  // Acceptance records (authored in the invitee's PDS)
+  // =========================================================================
+  pgm.createTable('collaboration_acceptances_index', {
+    uri: { type: 'text', primaryKey: true },
+    cid: { type: 'text', notNull: true },
+    accepter_did: { type: 'text', notNull: true },
+    invite_uri: { type: 'text', notNull: true },
+    subject_uri: { type: 'text', notNull: true },
+    created_at: { type: 'timestamptz', notNull: true },
+    /** When set, the record has been revoked by the invitee. */
+    deleted_at: { type: 'timestamptz' },
+    pds_url: { type: 'text' },
+    indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    last_synced_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('collaboration_acceptances_index', 'accepter_did');
+  pgm.createIndex('collaboration_acceptances_index', 'invite_uri');
+  pgm.createIndex('collaboration_acceptances_index', 'subject_uri');
+
+  // =========================================================================
+  // Pending collaboration state.
+  // =========================================================================
+  // Tracks invitation-acceptance pairs where one side of the handshake has
+  // been observed but the other has not yet, due to firehose ordering. On
+  // each invite/acceptance create or delete we re-evaluate the rows for the
+  // affected (subject_uri, did) pair. Rows become "active" when both sides
+  // are present and non-deleted; they are then surfaced by
+  // `getActiveCollaborators`.
+  pgm.createTable('collaboration_pending_state', {
+    id: { type: 'serial', primaryKey: true },
+    subject_uri: { type: 'text', notNull: true },
+    did: { type: 'text', notNull: true },
+    invite_uri: { type: 'text' },
+    acceptance_uri: { type: 'text' },
+    state: {
+      type: 'text',
+      notNull: true,
+      check: "state IN ('pending-acceptance','pending-invite','active','inactive')",
+    },
+    received_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    last_updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.addConstraint('collaboration_pending_state', 'collaboration_pending_state_unique_pair', {
+    unique: ['subject_uri', 'did'],
+  });
+  pgm.createIndex('collaboration_pending_state', 'subject_uri');
+  pgm.createIndex('collaboration_pending_state', 'did');
+  pgm.createIndex('collaboration_pending_state', 'state');
+
+  // =========================================================================
+  // Collection edges awaiting collaborator authorization.
+  // =========================================================================
+  // When we see a `contains` edge from a foreign DID against a mirrored
+  // collection, the DID may not yet be an active collaborator (invite or
+  // acceptance not indexed yet). We park these edges here and re-evaluate
+  // when collaboration state changes.
+  pgm.createTable('pending_collection_edges', {
+    edge_uri: { type: 'text', primaryKey: true },
+    collection_uri: { type: 'text', notNull: true },
+    source_uri: { type: 'text', notNull: true },
+    target_uri: { type: 'text', notNull: true },
+    added_by_did: { type: 'text', notNull: true },
+    relation_slug: { type: 'text', notNull: true },
+    /** When set, the edge has been promoted to `collection_edges_index`. */
+    resolved_at: { type: 'timestamptz' },
+    received_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    last_updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('pending_collection_edges', 'collection_uri');
+  pgm.createIndex('pending_collection_edges', 'added_by_did');
+  pgm.createIndex('pending_collection_edges', 'resolved_at');
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable('pending_collection_edges');
+  pgm.dropTable('collaboration_pending_state');
+  pgm.dropTable('collaboration_acceptances_index');
+  pgm.dropTable('collaboration_invites_index');
+}

--- a/src/types/interfaces/graph.interface.ts
+++ b/src/types/interfaces/graph.interface.ts
@@ -101,6 +101,16 @@ export interface NodeSearchOptions {
   readonly status?: NodeStatus;
   readonly limit?: number;
   readonly cursor?: string;
+  /**
+   * Filter nodes whose `externalIds` array includes an entry matching both
+   * `externalIdSystem` and `externalIdIdentifier`. Must be used together.
+   *
+   * @remarks
+   * Example: `{ externalIdSystem: 'cosmik', externalIdIdentifier: 'REFERENCES' }`
+   * returns nodes whose `externalIds` includes `{ system: 'cosmik', identifier: 'REFERENCES' }`.
+   */
+  readonly externalIdSystem?: string;
+  readonly externalIdIdentifier?: string;
 }
 
 /**

--- a/tests/compliance/database-compliance.test.ts
+++ b/tests/compliance/database-compliance.test.ts
@@ -601,12 +601,12 @@ describe('ATProto Database Compliance', () => {
         {
           name: 'Index semantics (_index naming)',
           query: `SELECT COUNT(*) as count FROM information_schema.tables WHERE table_schema = 'public' AND table_name LIKE '%_index'`,
-          expected: 22, // eprints, reviews, endorsements, user_tags, relevance_logs, activity_log, authors, coauthor_claims, changelogs, annotations, entity_links, user_related_works, personal_graph_nodes, personal_graph_edges, collections, collection_edges, eprint_versions, cosmik_connections, cosmik_follows, margin_annotations, margin_bookmarks, cosmik_link_removals
+          expected: 24, // eprints, reviews, endorsements, user_tags, relevance_logs, activity_log, authors, coauthor_claims, changelogs, annotations, entity_links, user_related_works, personal_graph_nodes, personal_graph_edges, collections, collection_edges, eprint_versions, cosmik_connections, cosmik_follows, margin_annotations, margin_bookmarks, cosmik_link_removals, collaboration_invites, collaboration_acceptances
         },
         {
           name: 'PDS source tracking',
           query: `SELECT COUNT(*) as count FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE '%_index' AND column_name = 'pds_url'`,
-          expected: 22, // All index tables have pds_url
+          expected: 24, // All index tables have pds_url
         },
         {
           name: 'No blob data',

--- a/tests/unit/services/collaboration/collaboration-service.test.ts
+++ b/tests/unit/services/collaboration/collaboration-service.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for CollaborationService.
+ *
+ * @remarks
+ * Verifies: invite/acceptance indexing, active-collaborator derivation,
+ * revocation semantics, and out-of-order firehose handling.
+ *
+ * @packageDocumentation
+ */
+
+import 'reflect-metadata';
+
+import type { Pool, QueryResultRow } from 'pg';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { CollaborationService } from '../../../../src/services/collaboration/collaboration-service.js';
+import type { AtUri, CID, DID } from '../../../../src/types/atproto.js';
+import type { ILogger } from '../../../../src/types/interfaces/logger.interface.js';
+import { isOk } from '../../../../src/types/result.js';
+
+const createMockLogger = (): ILogger => {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => logger),
+  };
+  return logger;
+};
+
+/**
+ * Minimal programmable mock Pool that records queries and returns configured
+ * responses in order. Enough for unit-level tests without a real DB.
+ */
+function createMockPool(responses: QueryResultRow[][]) {
+  let cursor = 0;
+  const queries: { sql: string; params: readonly unknown[] }[] = [];
+
+  const query = vi.fn((sql: string, params?: readonly unknown[]) => {
+    queries.push({ sql, params: params ?? [] });
+    const rows = responses[cursor] ?? [];
+    cursor++;
+    return Promise.resolve({ rows });
+  });
+
+  return {
+    pool: { query } as unknown as Pool,
+    queries,
+    reset: () => {
+      cursor = 0;
+      queries.length = 0;
+    },
+  };
+}
+
+describe('CollaborationService', () => {
+  const subjectUri = 'at://did:plc:owner/pub.chive.graph.node/c1' as AtUri;
+  const inviterDid = 'did:plc:owner' as DID;
+  const inviteeDid = 'did:plc:alice' as DID;
+  const inviteUri = 'at://did:plc:owner/pub.chive.collaboration.invite/i1' as AtUri;
+  const acceptanceUri = 'at://did:plc:alice/pub.chive.collaboration.inviteAcceptance/a1' as AtUri;
+
+  let logger: ILogger;
+  beforeEach(() => {
+    logger = createMockLogger();
+  });
+
+  describe('indexInvite', () => {
+    it('inserts the invite row and re-evaluates pending state', async () => {
+      const mock = createMockPool([[], [], []]);
+      const service = new CollaborationService({ pool: mock.pool, logger });
+
+      const result = await service.indexInvite(
+        {
+          subject: { uri: subjectUri },
+          invitee: inviteeDid,
+          role: 'collaborator',
+          createdAt: '2026-04-11T00:00:00Z',
+        },
+        {
+          uri: inviteUri,
+          cid: 'bafyrei' as CID,
+          pdsUrl: 'https://pds.example',
+          indexedAt: new Date(),
+        }
+      );
+
+      expect(isOk(result)).toBe(true);
+      expect(mock.queries[0]?.sql).toContain('INSERT INTO collaboration_invites_index');
+      // Next two queries select invite + acceptance for pair reevaluation
+      expect(mock.queries[1]?.sql).toContain('FROM collaboration_invites_index');
+      expect(mock.queries[2]?.sql).toContain('FROM collaboration_acceptances_index');
+    });
+
+    it('extracts the inviter DID from the invite URI authority', async () => {
+      const mock = createMockPool([[], [], [], []]);
+      const service = new CollaborationService({ pool: mock.pool, logger });
+
+      await service.indexInvite(
+        {
+          subject: { uri: subjectUri },
+          invitee: inviteeDid,
+          createdAt: '2026-04-11T00:00:00Z',
+        },
+        {
+          uri: inviteUri,
+          cid: 'bafyrei' as CID,
+          pdsUrl: 'https://pds.example',
+          indexedAt: new Date(),
+        }
+      );
+
+      const insertParams = mock.queries[0]?.params ?? [];
+      // params order: uri, cid, inviter_did, invitee_did, subject_uri, ...
+      expect(insertParams[2]).toBe(inviterDid);
+      expect(insertParams[3]).toBe(inviteeDid);
+      expect(insertParams[4]).toBe(subjectUri);
+    });
+  });
+
+  describe('isCollaborator', () => {
+    it('returns true when invite and acceptance both exist and are not deleted', async () => {
+      const mock = createMockPool([[{ one: 1 }]]);
+      const service = new CollaborationService({ pool: mock.pool, logger });
+
+      const result = await service.isCollaborator(subjectUri, inviteeDid);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when no matching row is found', async () => {
+      const mock = createMockPool([[]]);
+      const service = new CollaborationService({ pool: mock.pool, logger });
+      const result = await service.isCollaborator(subjectUri, inviteeDid);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getActiveCollaborators', () => {
+    it('maps rows into ActiveCollaborator records', async () => {
+      const now = new Date('2026-04-11T00:00:00Z');
+      const mock = createMockPool([
+        [
+          {
+            did: inviteeDid,
+            invite_uri: inviteUri,
+            acceptance_uri: acceptanceUri,
+            role: 'collaborator',
+            accepted_at: now,
+          },
+        ],
+      ]);
+      const service = new CollaborationService({ pool: mock.pool, logger });
+      const collaborators = await service.getActiveCollaborators(subjectUri);
+      expect(collaborators).toHaveLength(1);
+      expect(collaborators[0]?.did).toBe(inviteeDid);
+      expect(collaborators[0]?.role).toBe('collaborator');
+      expect(collaborators[0]?.inviteUri).toBe(inviteUri);
+      expect(collaborators[0]?.acceptanceUri).toBe(acceptanceUri);
+      expect(collaborators[0]?.acceptedAt).toEqual(now);
+    });
+  });
+
+  describe('deleteInvite', () => {
+    it('marks the invite row as deleted and re-evaluates pair', async () => {
+      const mock = createMockPool([[{ subject_uri: subjectUri, invitee_did: inviteeDid }], [], []]);
+      const service = new CollaborationService({ pool: mock.pool, logger });
+      const result = await service.deleteInvite(inviteUri);
+      expect(isOk(result)).toBe(true);
+      expect(mock.queries[0]?.sql).toContain('UPDATE collaboration_invites_index');
+      expect(mock.queries[0]?.sql).toContain('SET deleted_at = NOW()');
+    });
+  });
+
+  describe('out-of-order delivery', () => {
+    it('indexing acceptance before invite still records acceptance', async () => {
+      // Acceptance arrives first. pair-reevaluation runs against current
+      // state: no invite, acceptance present → pending-invite.
+      const mock = createMockPool([
+        [], // INSERT acceptance
+        [], // SELECT invite (none yet)
+        [], // SELECT acceptance (redundant)
+        [], // INSERT pending_state
+      ]);
+      const service = new CollaborationService({ pool: mock.pool, logger });
+      const result = await service.indexAcceptance(
+        {
+          invite: { uri: inviteUri },
+          subject: { uri: subjectUri },
+          createdAt: '2026-04-11T00:00:00Z',
+        },
+        {
+          uri: acceptanceUri,
+          cid: 'bafyrei' as CID,
+          pdsUrl: 'https://pds.example',
+          indexedAt: new Date(),
+        }
+      );
+      expect(isOk(result)).toBe(true);
+      expect(mock.queries[0]?.sql).toContain('INSERT INTO collaboration_acceptances_index');
+    });
+  });
+});

--- a/web/app/arxiv/[id]/page.tsx
+++ b/web/app/arxiv/[id]/page.tsx
@@ -1,0 +1,46 @@
+/**
+ * Canonical arXiv route: `/arxiv/2301.12345`.
+ *
+ * @remarks
+ * Resolves an arXiv identifier to the Chive entity that declares it
+ * (eprint submission or graph node) and redirects. See
+ * `web/app/doi/[...id]/page.tsx` for the shared convention.
+ *
+ * @packageDocumentation
+ */
+
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+
+import { createServerClient } from '@/lib/api/client';
+
+interface ArxivPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: ArxivPageProps): Promise<Metadata> {
+  const { id } = await params;
+  return {
+    title: `arXiv ${id}`,
+    description: `Chive resolver for arXiv ${id}`,
+  };
+}
+
+export default async function ArxivResolverPage({ params }: ArxivPageProps) {
+  const { id } = await params;
+  const identifier = decodeURIComponent(id);
+
+  let webPath: string | undefined;
+  try {
+    const serverApi = createServerClient();
+    const response = await serverApi.pub.chive.resolve.byExternalId({
+      system: 'arxiv',
+      identifier,
+    });
+    if (response.data.found) webPath = response.data.webPath;
+  } catch {
+    // Fall through.
+  }
+  if (webPath) redirect(webPath);
+  notFound();
+}

--- a/web/app/collections/[uri]/collection-detail-client.tsx
+++ b/web/app/collections/[uri]/collection-detail-client.tsx
@@ -39,6 +39,7 @@ import {
   useRemoveFromCollection,
   useUpdateCollectionItem,
   useReorderItems,
+  useRepairCosmikMirror,
   findContainsEdge,
   getSubcollectionUris,
   collectionKeys,
@@ -140,6 +141,7 @@ export function CollectionDetailClient({ uri }: CollectionDetailClientProps) {
   const deleteCollection = useDeleteCollection();
   const removeFromCollection = useRemoveFromCollection();
   const updateCollectionItem = useUpdateCollectionItem();
+  const repairCosmikMirror = useRepairCosmikMirror();
   const reorderItems = useReorderItems();
   const createPersonalEdge = useCreatePersonalEdge();
 
@@ -433,6 +435,28 @@ export function CollectionDetailClient({ uri }: CollectionDetailClientProps) {
     );
   }
 
+  const handleRepairMirror = useCallback(async () => {
+    if (!collection?.cosmikCollectionUri) return;
+    try {
+      const result = await repairCosmikMirror.mutateAsync({
+        collectionUri: collection.uri,
+        interItemEdges: interItemEdges.map((edge) => ({
+          edgeUri: edge.edgeUri,
+          sourceUri: edge.sourceUri,
+          targetUri: edge.targetUri,
+          relationSlug: edge.relationSlug,
+        })),
+        itemUrls: items.map((item) => item.itemUri),
+      });
+      toast.success(
+        `Mirror repaired — ${result.created} connections created, ${result.pruned} orphans pruned.`
+      );
+    } catch (err) {
+      logger.error('Repair mirror failed', err);
+      toast.error('Could not repair mirror.');
+    }
+  }, [collection, interItemEdges, items, repairCosmikMirror]);
+
   return (
     <div className="space-y-8">
       {/* 1. Collection header */}
@@ -442,6 +466,8 @@ export function CollectionDetailClient({ uri }: CollectionDetailClientProps) {
         subcollectionNames={subcollections.map((s) => s.label)}
         onDelete={handleDelete}
         isDeleting={deleteCollection.isPending}
+        onRepairMirror={isOwner && collection.cosmikCollectionUri ? handleRepairMirror : undefined}
+        isRepairing={repairCosmikMirror.isPending}
       />
 
       <Separator />

--- a/web/app/collections/[uri]/collection-detail-client.tsx
+++ b/web/app/collections/[uri]/collection-detail-client.tsx
@@ -367,6 +367,28 @@ export function CollectionDetailClient({ uri }: CollectionDetailClientProps) {
     return groups;
   }, [sortableItems]);
 
+  const handleRepairMirror = useCallback(async () => {
+    if (!collection?.cosmikCollectionUri) return;
+    try {
+      const result = await repairCosmikMirror.mutateAsync({
+        collectionUri: collection.uri,
+        interItemEdges: interItemEdges.map((edge) => ({
+          edgeUri: edge.edgeUri,
+          sourceUri: edge.sourceUri,
+          targetUri: edge.targetUri,
+          relationSlug: edge.relationSlug,
+        })),
+        itemUrls: items.map((item) => item.itemUri),
+      });
+      toast.success(
+        `Mirror repaired — ${result.created} connections created, ${result.pruned} orphans pruned.`
+      );
+    } catch (err) {
+      logger.error('Repair mirror failed', err);
+      toast.error('Could not repair mirror.');
+    }
+  }, [collection, interItemEdges, items, repairCosmikMirror]);
+
   const handleReorder = useCallback(
     (reordered: Array<CollectionItemView & { id: string }>) => {
       if (!collection) return;
@@ -434,28 +456,6 @@ export function CollectionDetailClient({ uri }: CollectionDetailClientProps) {
       </div>
     );
   }
-
-  const handleRepairMirror = useCallback(async () => {
-    if (!collection?.cosmikCollectionUri) return;
-    try {
-      const result = await repairCosmikMirror.mutateAsync({
-        collectionUri: collection.uri,
-        interItemEdges: interItemEdges.map((edge) => ({
-          edgeUri: edge.edgeUri,
-          sourceUri: edge.sourceUri,
-          targetUri: edge.targetUri,
-          relationSlug: edge.relationSlug,
-        })),
-        itemUrls: items.map((item) => item.itemUri),
-      });
-      toast.success(
-        `Mirror repaired — ${result.created} connections created, ${result.pruned} orphans pruned.`
-      );
-    } catch (err) {
-      logger.error('Repair mirror failed', err);
-      toast.error('Could not repair mirror.');
-    }
-  }, [collection, interItemEdges, items, repairCosmikMirror]);
 
   return (
     <div className="space-y-8">

--- a/web/app/doi/[...id]/page.tsx
+++ b/web/app/doi/[...id]/page.tsx
@@ -1,0 +1,58 @@
+/**
+ * Canonical DOI route: `/doi/10.1234/foo`.
+ *
+ * @remarks
+ * Resolves a DOI to its corresponding Chive entity (eprint or graph node)
+ * via `pub.chive.resolve.byExternalId` and redirects to the entity's
+ * canonical page. DOIs contain slashes, so we use a catch-all route
+ * (`[...id]`) and reconstruct the DOI from the path segments.
+ *
+ * This URL format is what Chive emits in `<link rel="alternate">` tags
+ * on entity pages and in Cosmik card metadata, so cross-app crawlers
+ * (Citoid, Zotero, Semble) can canonically identify a paper by DOI
+ * regardless of which Chive record declares it.
+ *
+ * @packageDocumentation
+ */
+
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+
+import { createServerClient } from '@/lib/api/client';
+
+interface DoiPageProps {
+  params: Promise<{ id: string[] }>;
+}
+
+export async function generateMetadata({ params }: DoiPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const doi = id.join('/');
+  return {
+    title: `DOI ${doi}`,
+    description: `Chive resolver for DOI ${doi}`,
+  };
+}
+
+export default async function DoiResolverPage({ params }: DoiPageProps) {
+  const { id } = await params;
+  const doi = decodeURIComponent(id.join('/'));
+
+  let webPath: string | undefined;
+  try {
+    const serverApi = createServerClient();
+    const response = await serverApi.pub.chive.resolve.byExternalId({
+      system: 'doi',
+      identifier: doi,
+    });
+    if (response.data.found) {
+      webPath = response.data.webPath;
+    }
+  } catch {
+    // Fall through to notFound below.
+  }
+
+  if (webPath) {
+    redirect(webPath);
+  }
+  notFound();
+}

--- a/web/app/eprints/[...uri]/page.tsx
+++ b/web/app/eprints/[...uri]/page.tsx
@@ -7,6 +7,12 @@ import { EprintDetailSkeleton } from './loading';
 import { EprintFaroErrorBoundary } from './eprint-error-boundary';
 import { createServerClient } from '@/lib/api/client';
 import type { Record as SubmissionRecord } from '@/lib/api/generated/types/pub/chive/eprint/submission';
+import {
+  buildEntityHeadTags,
+  type EntityHeadTag,
+  type EntityExternalId,
+} from '@/lib/metadata/entity-metadata';
+import { EntityHeadTags } from '@/lib/metadata/EntityHeadTags';
 
 /**
  * Eprint detail page route parameters.
@@ -103,11 +109,80 @@ export default async function EprintPage({ params }: EprintPageProps) {
     notFound();
   }
 
+  // Build `<head>` tag descriptors for Zotero/Citoid/Semble aggregation.
+  // Fetched here in addition to `generateMetadata` — Next.js request-level
+  // dedup makes this effectively one network round-trip.
+  let headTags: EntityHeadTag[] = [];
+  try {
+    const serverApi = createServerClient();
+    const response = await serverApi.pub.chive.eprint.getSubmission({ uri: fullUri });
+    const value = response.data.value as SubmissionRecord;
+    const canonicalUrl = `https://chive.pub/eprints/${encodeURIComponent(fullUri)}`;
+    const externalIds: EntityExternalId[] = [];
+    const publishedDoi = value.publishedVersion?.doi;
+    if (publishedDoi) {
+      externalIds.push({
+        system: 'doi',
+        identifier: publishedDoi,
+        uri: `https://doi.org/${publishedDoi}`,
+      });
+    }
+    const ext = value.externalIds;
+    if (ext) {
+      if (ext.arxivId) {
+        externalIds.push({
+          system: 'arxiv',
+          identifier: ext.arxivId,
+          uri: `https://arxiv.org/abs/${ext.arxivId}`,
+        });
+      }
+      if (ext.pmid) {
+        externalIds.push({
+          system: 'pmid',
+          identifier: ext.pmid,
+          uri: `https://pubmed.ncbi.nlm.nih.gov/${ext.pmid}`,
+        });
+      }
+      if (ext.zenodoDoi) {
+        externalIds.push({
+          system: 'doi',
+          identifier: ext.zenodoDoi,
+          uri: `https://doi.org/${ext.zenodoDoi}`,
+        });
+      }
+    }
+
+    let abstractText = value.abstractPlainText ?? '';
+    if (!abstractText && Array.isArray(value.abstract)) {
+      abstractText = value.abstract
+        .filter((item) => typeof item === 'object' && 'type' in item && item.type === 'text')
+        .map((item) => (item as { type: 'text'; content: string }).content)
+        .join(' ');
+    }
+
+    headTags = buildEntityHeadTags({
+      atUri: fullUri,
+      canonicalUrl,
+      title: value.title,
+      description: abstractText.slice(0, 500),
+      entityType: 'research',
+      authors: value.authors.map((a) => a.name ?? ''),
+      publishedDate: value.createdAt,
+      journalTitle: value.publishedVersion?.journal,
+      externalIds,
+    });
+  } catch {
+    // Head tags are best-effort; missing eprint returns empty tags.
+  }
+
   return (
-    <Suspense fallback={<EprintDetailSkeleton />}>
-      <EprintFaroErrorBoundary uri={fullUri}>
-        <EprintDetailContent uri={fullUri} />
-      </EprintFaroErrorBoundary>
-    </Suspense>
+    <>
+      <EntityHeadTags tags={headTags} />
+      <Suspense fallback={<EprintDetailSkeleton />}>
+        <EprintFaroErrorBoundary uri={fullUri}>
+          <EprintDetailContent uri={fullUri} />
+        </EprintFaroErrorBoundary>
+      </Suspense>
+    </>
   );
 }

--- a/web/app/invitations/page.tsx
+++ b/web/app/invitations/page.tsx
@@ -15,7 +15,7 @@ import { InvitationsPanel } from '@/components/invitations/invitations-panel';
 import { useCurrentUser } from '@/lib/auth';
 
 export default function InvitationsPage() {
-  const { user } = useCurrentUser();
+  const user = useCurrentUser();
 
   if (!user?.did) {
     return (

--- a/web/app/invitations/page.tsx
+++ b/web/app/invitations/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+/**
+ * Collaboration invitations page.
+ *
+ * @remarks
+ * Shows the signed-in user their pending and active collaboration
+ * invitations. Unified inbox across any Chive subject type that supports
+ * collaboration (collections in v1).
+ *
+ * @packageDocumentation
+ */
+
+import { InvitationsPanel } from '@/components/invitations/invitations-panel';
+import { useCurrentUser } from '@/lib/auth';
+
+export default function InvitationsPage() {
+  const { user } = useCurrentUser();
+
+  if (!user?.did) {
+    return (
+      <main className="mx-auto max-w-2xl space-y-4 p-6">
+        <h1 className="text-2xl font-bold">Invitations</h1>
+        <p className="text-muted-foreground">Sign in to view your collaboration invitations.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-bold">Invitations</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Pending and active collaboration invitations across your Chive records.
+        </p>
+      </header>
+      <InvitationsPanel viewerDid={user.did} />
+    </main>
+  );
+}

--- a/web/app/isbn/[id]/page.tsx
+++ b/web/app/isbn/[id]/page.tsx
@@ -1,0 +1,41 @@
+/**
+ * Canonical ISBN route: `/isbn/9780252067952`.
+ *
+ * @packageDocumentation
+ */
+
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+
+import { createServerClient } from '@/lib/api/client';
+
+interface IsbnPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: IsbnPageProps): Promise<Metadata> {
+  const { id } = await params;
+  return {
+    title: `ISBN ${id}`,
+    description: `Chive resolver for ISBN ${id}`,
+  };
+}
+
+export default async function IsbnResolverPage({ params }: IsbnPageProps) {
+  const { id } = await params;
+  const identifier = decodeURIComponent(id);
+
+  let webPath: string | undefined;
+  try {
+    const serverApi = createServerClient();
+    const response = await serverApi.pub.chive.resolve.byExternalId({
+      system: 'isbn',
+      identifier,
+    });
+    if (response.data.found) webPath = response.data.webPath;
+  } catch {
+    // Fall through.
+  }
+  if (webPath) redirect(webPath);
+  notFound();
+}

--- a/web/app/orcid/[id]/page.tsx
+++ b/web/app/orcid/[id]/page.tsx
@@ -1,0 +1,41 @@
+/**
+ * Canonical ORCID route: `/orcid/0000-0001-2345-6789`.
+ *
+ * @packageDocumentation
+ */
+
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+
+import { createServerClient } from '@/lib/api/client';
+
+interface OrcidPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: OrcidPageProps): Promise<Metadata> {
+  const { id } = await params;
+  return {
+    title: `ORCID ${id}`,
+    description: `Chive resolver for ORCID ${id}`,
+  };
+}
+
+export default async function OrcidResolverPage({ params }: OrcidPageProps) {
+  const { id } = await params;
+  const identifier = decodeURIComponent(id);
+
+  let webPath: string | undefined;
+  try {
+    const serverApi = createServerClient();
+    const response = await serverApi.pub.chive.resolve.byExternalId({
+      system: 'orcid',
+      identifier,
+    });
+    if (response.data.found) webPath = response.data.webPath;
+  } catch {
+    // Fall through.
+  }
+  if (webPath) redirect(webPath);
+  notFound();
+}

--- a/web/app/pmid/[id]/page.tsx
+++ b/web/app/pmid/[id]/page.tsx
@@ -1,0 +1,41 @@
+/**
+ * Canonical PubMed ID route: `/pmid/12345678`.
+ *
+ * @packageDocumentation
+ */
+
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+
+import { createServerClient } from '@/lib/api/client';
+
+interface PmidPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: PmidPageProps): Promise<Metadata> {
+  const { id } = await params;
+  return {
+    title: `PMID ${id}`,
+    description: `Chive resolver for PubMed ID ${id}`,
+  };
+}
+
+export default async function PmidResolverPage({ params }: PmidPageProps) {
+  const { id } = await params;
+  const identifier = decodeURIComponent(id);
+
+  let webPath: string | undefined;
+  try {
+    const serverApi = createServerClient();
+    const response = await serverApi.pub.chive.resolve.byExternalId({
+      system: 'pmid',
+      identifier,
+    });
+    if (response.data.found) webPath = response.data.webPath;
+  } catch {
+    // Fall through.
+  }
+  if (webPath) redirect(webPath);
+  notFound();
+}

--- a/web/app/ror/[id]/page.tsx
+++ b/web/app/ror/[id]/page.tsx
@@ -1,0 +1,41 @@
+/**
+ * Canonical ROR route: `/ror/02nr0ka47`.
+ *
+ * @packageDocumentation
+ */
+
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+
+import { createServerClient } from '@/lib/api/client';
+
+interface RorPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: RorPageProps): Promise<Metadata> {
+  const { id } = await params;
+  return {
+    title: `ROR ${id}`,
+    description: `Chive resolver for ROR ${id}`,
+  };
+}
+
+export default async function RorResolverPage({ params }: RorPageProps) {
+  const { id } = await params;
+  const identifier = decodeURIComponent(id);
+
+  let webPath: string | undefined;
+  try {
+    const serverApi = createServerClient();
+    const response = await serverApi.pub.chive.resolve.byExternalId({
+      system: 'ror',
+      identifier,
+    });
+    if (response.data.found) webPath = response.data.webPath;
+  } catch {
+    // Fall through.
+  }
+  if (webPath) redirect(webPath);
+  notFound();
+}

--- a/web/components/collection/collection-header.tsx
+++ b/web/components/collection/collection-header.tsx
@@ -20,6 +20,7 @@ import {
   Calendar,
   User as UserIcon,
   Package,
+  Wrench,
 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -63,6 +64,14 @@ interface CollectionHeaderProps {
   subcollectionNames?: string[];
   onDelete: (deleteSubcollections: boolean) => void;
   isDeleting?: boolean;
+  /**
+   * Called when the owner clicks "Repair mirror". When provided AND the
+   * collection has an active Semble mirror, a repair button is shown next
+   * to the "View on Semble" action.
+   */
+  onRepairMirror?: () => void;
+  /** Whether the repair-mirror request is in flight. */
+  isRepairing?: boolean;
 }
 
 /**
@@ -78,6 +87,8 @@ export function CollectionHeader({
   subcollectionNames,
   onDelete,
   isDeleting,
+  onRepairMirror,
+  isRepairing,
 }: CollectionHeaderProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteSubcollections, setDeleteSubcollections] = useState(false);
@@ -281,6 +292,19 @@ export function CollectionHeader({
               </Button>
             );
           })()}
+
+        {isOwner && collection.cosmikCollectionUri && onRepairMirror && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onRepairMirror}
+            disabled={isRepairing}
+            title="Reconcile the Semble mirror with the current collection: create missing connections, prune orphans."
+          >
+            <Wrench className="h-4 w-4 mr-1.5" />
+            {isRepairing ? 'Repairing…' : 'Repair mirror'}
+          </Button>
+        )}
       </div>
     </header>
   );

--- a/web/components/collection/collection-wizard.tsx
+++ b/web/components/collection/collection-wizard.tsx
@@ -196,7 +196,39 @@ export function CollectionWizard({
                 metadata: item.metadata,
               }))
             : undefined,
+        collaborators: values.cosmikCollaborators?.length ? values.cosmikCollaborators : undefined,
       });
+
+      // Create native Chive collaboration invites for each DID. This lives in
+      // the owner's PDS and grants permission only when the invitee accepts
+      // via `pub.chive.collaboration.inviteAcceptance`. The `collaborators[]`
+      // field written to the Cosmik mirror above is the Semble-side allowlist
+      // equivalent.
+      if (values.cosmikCollaborators?.length) {
+        try {
+          const { createInviteRecord } = await import('@/lib/atproto/record-creator');
+          for (const invitee of values.cosmikCollaborators) {
+            try {
+              await createInviteRecord(agent, {
+                subjectUri: collection.uri,
+                subjectCid: collection.cid,
+                invitee,
+                role: 'collaborator',
+              });
+            } catch (inviteErr) {
+              wizardLogger.warn('Failed to create collaboration invite', {
+                collectionUri: collection.uri,
+                invitee,
+                error: inviteErr instanceof Error ? inviteErr.message : String(inviteErr),
+              });
+            }
+          }
+        } catch (err) {
+          wizardLogger.warn('Invite batch failed to load record-creator module', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
 
       wizardLogger.info('Collection node created', { uri: collection.uri });
 

--- a/web/components/collection/collection-wizard.tsx
+++ b/web/components/collection/collection-wizard.tsx
@@ -381,16 +381,30 @@ export function CollectionWizard({
         }
       }
 
-      // 5. Create custom edges using remapped URIs
+      // 5. Create custom edges using remapped URIs, then dual-write to Semble
+      //    as network.cosmik.connection records when the collection is mirrored.
       const ownerDid = (agent as unknown as { did?: string }).did ?? '';
       for (const edge of values.edges ?? []) {
         try {
-          await createPersonalEdge.mutateAsync({
+          const personalEdge = await createPersonalEdge.mutateAsync({
             sourceUri: uriMap.get(edge.sourceUri) ?? edge.sourceUri,
             targetUri: uriMap.get(edge.targetUri) ?? edge.targetUri,
             relationSlug: edge.relationSlug,
             metadata: edge.note ? { note: edge.note } : undefined,
             ownerDid,
+            // Pass through the relation node's URI so syncEdgeToCosmik can
+            // resolve its `externalIds` to a Cosmik connectionType.
+            relationUri: edge.relationUri,
+            // Pass the parent collection URI so the edge hook can dual-write.
+            collectionUri: collection.uri,
+            // Pass the wizard-original URIs for endpoint URL resolution.
+            originalSourceUri: edge.sourceUri,
+            originalTargetUri: edge.targetUri,
+          });
+
+          wizardLogger.debug('Created personal edge', {
+            edgeUri: personalEdge.uri,
+            collectionUri: collection.uri,
           });
         } catch (edgeError) {
           wizardLogger.warn('Failed to create custom edge', {

--- a/web/components/collection/wizard-steps/step-edges.tsx
+++ b/web/components/collection/wizard-steps/step-edges.tsx
@@ -87,6 +87,13 @@ export function StepEdges({ form }: StepEdgesProps) {
   const [newRelationSymmetric, setNewRelationSymmetric] = useState(false);
   const [newRelationTransitive, setNewRelationTransitive] = useState(false);
   const [newRelationInverseSlug, setNewRelationInverseSlug] = useState('');
+  /**
+   * Optional Semble (Cosmik) connectionType mapping declared on the new
+   * relation. Stored as an `externalIds` entry with `system: "cosmik"`. When
+   * the relation is later used on an inter-item edge in a mirrored
+   * collection, this value drives the `network.cosmik.connection.connectionType`.
+   */
+  const [newRelationCosmikType, setNewRelationCosmikType] = useState('');
 
   const createPersonalNode = useCreatePersonalNode();
 
@@ -205,11 +212,29 @@ export function StepEdges({ form }: StepEdgesProps) {
       if (newRelationTransitive) metadata.transitive = true;
       if (newRelationInverseSlug) metadata.inverseSlug = newRelationInverseSlug;
 
+      const externalIds: Array<{
+        system: string;
+        identifier: string;
+        uri?: string;
+        matchType?: 'exact' | 'close' | 'broader' | 'narrower' | 'related';
+      }> = [];
+      const cosmikType = newRelationCosmikType.trim();
+      if (cosmikType) {
+        const normalized = cosmikType.toUpperCase().replace(/\s+/g, '_').replace(/-/g, '_');
+        externalIds.push({
+          system: 'cosmik',
+          identifier: normalized,
+          uri: `cosmik://connectionType/${normalized}`,
+          matchType: 'exact',
+        });
+      }
+
       const result = await createPersonalNode.mutateAsync({
         kind: 'type',
         subkind: 'relation',
         label: newRelationLabel,
         metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+        externalIds: externalIds.length > 0 ? externalIds : undefined,
       });
       setSelectedRelation({
         id: result.uri,
@@ -227,6 +252,7 @@ export function StepEdges({ form }: StepEdgesProps) {
       setNewRelationSymmetric(false);
       setNewRelationTransitive(false);
       setNewRelationInverseSlug('');
+      setNewRelationCosmikType('');
     } catch {
       toast.error('Failed to create relation type.');
     }
@@ -236,6 +262,7 @@ export function StepEdges({ form }: StepEdgesProps) {
     newRelationSymmetric,
     newRelationTransitive,
     newRelationInverseSlug,
+    newRelationCosmikType,
   ]);
 
   if (items.length < 2) {
@@ -379,6 +406,20 @@ export function StepEdges({ form }: StepEdgesProps) {
                       />
                     </div>
                   )}
+                  <div className="space-y-1">
+                    <Label className="text-xs">Semble connection type (optional)</Label>
+                    <input
+                      type="text"
+                      value={newRelationCosmikType}
+                      onChange={(e) => setNewRelationCosmikType(e.target.value)}
+                      placeholder="e.g., REFERENCES, BUILDS_ON"
+                      className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm font-mono"
+                    />
+                    <p className="text-[10px] text-muted-foreground">
+                      When edges using this relation are mirrored to Semble, the connection will use
+                      this <code>connectionType</code>. Leave empty to derive from the slug.
+                    </p>
+                  </div>
                   <div className="flex gap-2">
                     <Button type="button" size="sm" onClick={confirmCreateRelation}>
                       Create
@@ -390,6 +431,10 @@ export function StepEdges({ form }: StepEdgesProps) {
                       onClick={() => {
                         setShowNewRelationForm(false);
                         setNewRelationLabel('');
+                        setNewRelationSymmetric(false);
+                        setNewRelationTransitive(false);
+                        setNewRelationInverseSlug('');
+                        setNewRelationCosmikType('');
                       }}
                     >
                       Cancel

--- a/web/components/collection/wizard-steps/step-edges.tsx
+++ b/web/components/collection/wizard-steps/step-edges.tsx
@@ -121,6 +121,7 @@ export function StepEdges({ form }: StepEdgesProps) {
     const relationSlug =
       (selectedRelation.metadata?.slug as string | undefined) ??
       selectedRelation.label.toLowerCase().replace(/\s+/g, '-');
+    const relationUri = selectedRelation.uri;
 
     const newEdges: CollectionEdgeFormData[] = [];
 
@@ -128,6 +129,7 @@ export function StepEdges({ form }: StepEdgesProps) {
       sourceUri,
       targetUri,
       relationSlug,
+      relationUri,
       relationLabel: selectedRelation.label,
       note: edgeNote || undefined,
       isBidirectional: addReverse || undefined,
@@ -139,8 +141,13 @@ export function StepEdges({ form }: StepEdgesProps) {
         ? relationSlug
         : (selectedRelation.metadata?.inverseSlug as string);
       const inverseLabel = isSymmetric ? selectedRelation.label : slugToLabel(inverseSlug);
+      // When symmetric the inverse is the same node. For inverse-pair
+      // relations the inverse URI is not known from the current selection;
+      // downstream sync falls back to slug-based resolution.
+      const inverseUri = isSymmetric ? relationUri : undefined;
 
       forwardEdge.inverseRelationSlug = inverseSlug;
+      forwardEdge.inverseRelationUri = inverseUri;
       forwardEdge.inverseRelationLabel = inverseLabel;
 
       newEdges.push(forwardEdge);
@@ -148,10 +155,12 @@ export function StepEdges({ form }: StepEdgesProps) {
         sourceUri: targetUri,
         targetUri: sourceUri,
         relationSlug: inverseSlug,
+        relationUri: inverseUri,
         relationLabel: inverseLabel,
         note: edgeNote || undefined,
         isBidirectional: true,
         inverseRelationSlug: relationSlug,
+        inverseRelationUri: relationUri,
         inverseRelationLabel: selectedRelation.label,
       });
     } else {

--- a/web/components/collection/wizard-steps/step-items.tsx
+++ b/web/components/collection/wizard-steps/step-items.tsx
@@ -85,6 +85,18 @@ interface NodeSearchResult {
   kind?: string;
   description?: string;
   isPersonal?: boolean;
+  /**
+   * External identifier mappings on the node — DOI, arXiv, ORCID, ROR, etc.
+   * Surfaced through so the collection wizard can carry them into
+   * `CollectionItemFormData.metadata.externalIds` for rich Cosmik card
+   * emission.
+   */
+  externalIds?: Array<{
+    system: string;
+    identifier: string;
+    uri?: string;
+    matchType?: 'exact' | 'close' | 'broader' | 'narrower' | 'related';
+  }>;
 }
 
 /**
@@ -125,6 +137,7 @@ export function useNodeSearch(query: string, options: { limit?: number; enabled?
           kind: n['kind'] as string | undefined,
           description: n['description'] as string | undefined,
           isPersonal: (n['isPersonal'] as boolean | undefined) ?? false,
+          externalIds: n['externalIds'] as NodeSearchResult['externalIds'],
         }));
       } catch {
         return [];
@@ -629,7 +642,10 @@ export function StepItems({ form }: StepItemsProps) {
                             type: 'eprint',
                             label: hit.title ?? 'Untitled',
                             metadata: {
+                              subkind: 'eprint',
                               authors: hit.authors?.map((a) => a.name ?? 'Unknown'),
+                              description: hit.abstract,
+                              publishedDate: hit.createdAt,
                             },
                           })
                         }
@@ -729,6 +745,14 @@ export function StepItems({ form }: StepItemsProps) {
                                 kind: node.kind,
                                 description: node.description,
                                 isPersonal: node.isPersonal,
+                                externalIds: node.externalIds,
+                                // Surface DOI / ISBN at the top level so
+                                // Cosmik card emission picks them up without
+                                // externalIds traversal.
+                                doi: node.externalIds?.find((id) => id.system === 'doi')
+                                  ?.identifier,
+                                isbn: node.externalIds?.find((id) => id.system === 'isbn')
+                                  ?.identifier,
                               },
                             })
                           }

--- a/web/components/collection/wizard-steps/types.ts
+++ b/web/components/collection/wizard-steps/types.ts
@@ -26,7 +26,7 @@ export interface CollectionItemFormData {
   label: string;
   /** Optional annotation note */
   note?: string;
-  /** Optional metadata for richer rendering */
+  /** Optional metadata for richer rendering + Cosmik card emission */
   metadata?: {
     avatarUrl?: string;
     handle?: string;
@@ -35,7 +35,24 @@ export interface CollectionItemFormData {
     kind?: string;
     description?: string;
     isPersonal?: boolean;
-    [key: string]: string | string[] | boolean | undefined;
+    /** Digital Object Identifier (DOI). */
+    doi?: string;
+    /** ISBN for books. */
+    isbn?: string;
+    /** Publication / creation date (ISO 8601). */
+    publishedDate?: string;
+    /** Cover / preview image URL. */
+    imageUrl?: string;
+    /** Journal or venue title for scholarly artifacts. */
+    journalTitle?: string;
+    /** Additional external IDs from the item's graph node. */
+    externalIds?: Array<{
+      system: string;
+      identifier: string;
+      uri?: string;
+      matchType?: 'exact' | 'close' | 'broader' | 'narrower' | 'related';
+    }>;
+    [key: string]: unknown;
   };
 }
 

--- a/web/components/collection/wizard-steps/types.ts
+++ b/web/components/collection/wizard-steps/types.ts
@@ -49,6 +49,16 @@ export interface CollectionEdgeFormData {
   targetUri: string;
   /** Relation type slug */
   relationSlug: string;
+  /**
+   * AT-URI of the relation-type node.
+   *
+   * @remarks
+   * Captured when the user picks a relation so downstream edge creation
+   * can pass it through to the `pub.chive.graph.edge` record and to
+   * `syncEdgeToCosmik` for foreign-ecosystem mapping lookups via the
+   * relation's `externalIds`.
+   */
+  relationUri?: string;
   /** Display label for the relation */
   relationLabel: string;
   /** Optional note */
@@ -57,6 +67,8 @@ export interface CollectionEdgeFormData {
   isBidirectional?: boolean;
   /** Slug of the inverse relation (for paired edges) */
   inverseRelationSlug?: string;
+  /** AT-URI of the inverse relation-type node. */
+  inverseRelationUri?: string;
   /** Display label for the inverse relation */
   inverseRelationLabel?: string;
 }
@@ -139,10 +151,12 @@ export const collectionFormSchema = z.object({
         sourceUri: z.string(),
         targetUri: z.string(),
         relationSlug: z.string(),
+        relationUri: z.string().optional(),
         relationLabel: z.string(),
         note: z.string().optional(),
         isBidirectional: z.boolean().optional(),
         inverseRelationSlug: z.string().optional(),
+        inverseRelationUri: z.string().optional(),
         inverseRelationLabel: z.string().optional(),
       })
     )

--- a/web/components/invitations/invitations-panel.tsx
+++ b/web/components/invitations/invitations-panel.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+/**
+ * Invitations panel showing the signed-in user's pending collaboration
+ * invites and existing active collaborations.
+ *
+ * @remarks
+ * Renders pending invites with accept / decline buttons, and accepted
+ * invites with a "leave" option. Generic over subject type — in v1 we
+ * render inline links to the subject record's canonical page.
+ *
+ * @packageDocumentation
+ */
+
+import { useMemo, useState } from 'react';
+import { CheckCircle, XCircle, LogOut } from 'lucide-react';
+import { toast } from 'sonner';
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { createLogger } from '@/lib/observability/logger';
+import {
+  useListInvites,
+  useAcceptInvite,
+  useWithdrawAcceptance,
+  type CollaborationInviteView,
+} from '@/lib/hooks/use-collaboration';
+
+const logger = createLogger({ context: { component: 'invitations-panel' } });
+
+/**
+ * Props for {@link InvitationsPanel}.
+ *
+ * @public
+ */
+export interface InvitationsPanelProps {
+  /** DID of the signed-in user viewing their inbox. */
+  viewerDid: string;
+}
+
+/**
+ * Collaboration invitations panel.
+ *
+ * @public
+ */
+export function InvitationsPanel({ viewerDid }: InvitationsPanelProps) {
+  const pendingQuery = useListInvites({ invitee: viewerDid, state: 'pending' });
+  const acceptedQuery = useListInvites({ invitee: viewerDid, state: 'accepted' });
+  const acceptInvite = useAcceptInvite();
+  const withdrawAcceptance = useWithdrawAcceptance();
+
+  const pending = useMemo<CollaborationInviteView[]>(
+    () => pendingQuery.data?.invites ?? [],
+    [pendingQuery.data]
+  );
+  const accepted = useMemo<CollaborationInviteView[]>(
+    () => acceptedQuery.data?.invites ?? [],
+    [acceptedQuery.data]
+  );
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Pending Invites</h2>
+        {pending.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No pending invitations.</p>
+        ) : (
+          <div className="space-y-3">
+            {pending.map((invite) => (
+              <PendingInviteCard
+                key={invite.uri}
+                invite={invite}
+                onAccept={async () => {
+                  try {
+                    await acceptInvite.mutateAsync({
+                      inviteUri: invite.uri,
+                      // cid lookup is via strongRef at write time — we persist
+                      // the cid alongside the invite record on our side.
+                      inviteCid: '',
+                      subjectUri: invite.subjectUri,
+                      subjectCid: '',
+                    });
+                    toast.success('Invitation accepted.');
+                  } catch (err) {
+                    logger.error('Accept failed', err);
+                    toast.error('Could not accept invitation.');
+                  }
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Active Collaborations</h2>
+        {accepted.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Not currently collaborating on anything.</p>
+        ) : (
+          <div className="space-y-3">
+            {accepted.map((invite) => (
+              <AcceptedInviteCard
+                key={invite.uri}
+                invite={invite}
+                onLeave={async () => {
+                  if (!invite.acceptanceUri) return;
+                  try {
+                    await withdrawAcceptance.mutateAsync({
+                      acceptanceUri: invite.acceptanceUri,
+                    });
+                    toast.success('Left the collaboration.');
+                  } catch (err) {
+                    logger.error('Withdraw failed', err);
+                    toast.error('Could not leave.');
+                  }
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+/**
+ * Card for a pending invite with accept / decline actions.
+ *
+ * @internal
+ */
+function PendingInviteCard({
+  invite,
+  onAccept,
+}: {
+  invite: CollaborationInviteView;
+  onAccept: () => Promise<void>;
+}) {
+  const [actioning, setActioning] = useState(false);
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start gap-3 pb-3">
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary">{invite.role ?? 'collaborator'}</Badge>
+            <SubjectLabel invite={invite} />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            from <code className="font-mono">{invite.inviter}</code>
+          </p>
+          {invite.message && <p className="text-sm italic">“{invite.message}”</p>}
+        </div>
+      </CardHeader>
+      <CardContent className="flex gap-2 pt-0">
+        <Button
+          size="sm"
+          disabled={actioning}
+          onClick={async () => {
+            setActioning(true);
+            try {
+              await onAccept();
+            } finally {
+              setActioning(false);
+            }
+          }}
+        >
+          <CheckCircle className="h-4 w-4 mr-1.5" />
+          Accept
+        </Button>
+        <Button size="sm" variant="ghost" disabled title="Decline = ignore the invite">
+          <XCircle className="h-4 w-4 mr-1.5" />
+          Ignore
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Card for an accepted invite with leave action.
+ *
+ * @internal
+ */
+function AcceptedInviteCard({
+  invite,
+  onLeave,
+}: {
+  invite: CollaborationInviteView;
+  onLeave: () => Promise<void>;
+}) {
+  const [actioning, setActioning] = useState(false);
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start gap-3 pb-3">
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <Badge variant="default">{invite.role ?? 'collaborator'}</Badge>
+            <SubjectLabel invite={invite} />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            with <code className="font-mono">{invite.inviter}</code>
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={actioning}
+          onClick={async () => {
+            setActioning(true);
+            try {
+              await onLeave();
+            } finally {
+              setActioning(false);
+            }
+          }}
+        >
+          <LogOut className="h-4 w-4 mr-1.5" />
+          Leave
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Renders a link to the subject record.
+ *
+ * @internal
+ */
+function SubjectLabel({ invite }: { invite: CollaborationInviteView }) {
+  // For collections (graph nodes with subkind=collection), link to the
+  // collection detail page. For other subject types we render the AT-URI
+  // directly — future iterations will resolve to subject-type-specific
+  // pages as those get invite UIs.
+  if (invite.subjectCollection === 'pub.chive.graph.node') {
+    return (
+      <Link
+        href={`/collections/${encodeURIComponent(invite.subjectUri)}`}
+        className="text-sm font-medium hover:underline"
+      >
+        collection
+      </Link>
+    );
+  }
+  return (
+    <span className="text-sm font-mono text-muted-foreground truncate">{invite.subjectUri}</span>
+  );
+}

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -3560,6 +3560,16 @@ export interface CosmikUrlMetadata {
   author?: string;
   siteName?: string;
   type?: string;
+  /** Content MIME or identifier type for scholarly artifacts. */
+  publishedDate?: string;
+  /** Open Graph / preview image URL. */
+  imageUrl?: string;
+  /** Digital Object Identifier for academic content. */
+  doi?: string;
+  /** ISBN for books. */
+  isbn?: string;
+  /** Timestamp when the metadata was populated. */
+  retrievedAt?: string;
 }
 
 /**
@@ -3617,6 +3627,11 @@ export interface CosmikCardRecord {
 /**
  * Item metadata from the collection wizard, used to build rich Semble card content.
  */
+/**
+ * Metadata passed from the collection wizard or detail pages to
+ * `buildSembleCardMetadata`. These fields flow through to Cosmik/Semble's
+ * `network.cosmik.card#urlMetadata` record for rich card previews.
+ */
 interface ItemMetadata {
   subkind?: string;
   description?: string;
@@ -3625,6 +3640,23 @@ interface ItemMetadata {
   kind?: string;
   avatarUrl?: string;
   isPersonal?: boolean;
+  /** DOI extracted from eprint.publishedVersion.doi or externalIds.zenodoDoi. */
+  doi?: string;
+  /** ISBN for book items (if the graph node carries one). */
+  isbn?: string;
+  /** ISO date string for the publication event. */
+  publishedDate?: string;
+  /** Cover / preview image URL. */
+  imageUrl?: string;
+  /** All known external IDs on the item's graph node, in original form. */
+  externalIds?: Array<{
+    system: string;
+    identifier: string;
+    uri?: string;
+    matchType?: 'exact' | 'close' | 'broader' | 'narrower' | 'related';
+  }>;
+  /** Journal / publication venue for articles. */
+  journalTitle?: string;
 }
 
 /**
@@ -3644,35 +3676,94 @@ function buildSembleCardMetadata(
     $type: 'network.cosmik.card#urlMetadata',
     title: label,
     siteName: 'Chive',
+    retrievedAt: new Date().toISOString(),
   };
+
+  // Pull DOI / ISBN from dedicated fields first, then fall back to externalIds.
+  const doi = metadata?.doi ?? metadata?.externalIds?.find((id) => id.system === 'doi')?.identifier;
+  const isbn =
+    metadata?.isbn ?? metadata?.externalIds?.find((id) => id.system === 'isbn')?.identifier;
+  if (doi) result.doi = doi;
+  if (isbn) result.isbn = isbn;
+
+  if (metadata?.imageUrl) result.imageUrl = metadata.imageUrl;
+  if (metadata?.publishedDate) result.publishedDate = metadata.publishedDate;
 
   switch (subkind) {
     case 'eprint':
+      result.type = 'research';
       if (metadata?.authors?.length) {
         result.author = metadata.authors.join(', ');
       }
-      result.type = 'article';
+      if (metadata?.description) {
+        // Short plaintext excerpt of the abstract if present.
+        result.description = truncate(metadata.description, 500);
+      }
+      if (metadata?.journalTitle) {
+        result.siteName = metadata.journalTitle;
+      }
+      break;
+    case 'reference':
+    case 'external-work':
+      // DOI-only graph nodes referencing external works.
+      result.type = 'research';
+      if (metadata?.authors?.length) {
+        result.author = metadata.authors.join(', ');
+      }
+      if (metadata?.description) {
+        result.description = truncate(metadata.description, 500);
+      }
+      break;
+    case 'person':
+      result.type = 'link';
+      if (metadata?.description) {
+        result.description = truncate(metadata.description, 500);
+      }
       break;
     case 'field':
-      result.description = metadata?.description || 'Research field';
+      result.type = 'link';
+      result.description = truncate(metadata?.description ?? 'Research field', 500);
       break;
     case 'institution':
-      result.description = metadata?.description || 'Research institution';
+      result.type = 'link';
+      result.description = truncate(metadata?.description ?? 'Research institution', 500);
       break;
     case 'event':
-      result.description = metadata?.description || 'Academic event';
+      result.type = 'link';
+      result.description = truncate(metadata?.description ?? 'Academic event', 500);
       break;
     case 'concept':
-      result.description = metadata?.description || 'Concept';
+      result.type = 'link';
+      result.description = truncate(metadata?.description ?? 'Concept', 500);
+      break;
+    case 'collection':
+      result.type = 'link';
+      if (metadata?.description) {
+        result.description = truncate(metadata.description, 500);
+      }
       break;
     default:
       if (metadata?.description) {
-        result.description = metadata.description;
+        result.description = truncate(metadata.description, 500);
       }
       break;
   }
 
   return result;
+}
+
+/**
+ * Truncates text to a maximum length, breaking on word boundaries where
+ * possible and appending an ellipsis.
+ *
+ * @internal
+ */
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  const slice = text.slice(0, maxLength);
+  const lastSpace = slice.lastIndexOf(' ');
+  const cut = lastSpace > maxLength * 0.6 ? slice.slice(0, lastSpace) : slice;
+  return `${cut.trimEnd()}…`;
 }
 
 /**

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -3198,6 +3198,12 @@ export interface PersonalNodeRecord {
   label: string;
   description?: string;
   metadata?: Record<string, unknown>;
+  externalIds?: Array<{
+    system: string;
+    identifier: string;
+    uri?: string;
+    matchType?: 'exact' | 'close' | 'broader' | 'narrower' | 'related';
+  }>;
   status: 'established';
   createdAt: string;
 }
@@ -3216,6 +3222,21 @@ export interface CreatePersonalNodeInput {
   description?: string;
   /** Optional metadata */
   metadata?: Record<string, unknown>;
+  /**
+   * External identifier mappings for cross-ecosystem references.
+   *
+   * @remarks
+   * Follows the same structure as community graph nodes. For relation-type
+   * nodes, entries declare how this relation maps to foreign vocabularies
+   * (e.g., `{ system: "cosmik", identifier: "REFERENCES" }` to say this
+   * relation corresponds to Semble's `REFERENCES` connection type).
+   */
+  externalIds?: Array<{
+    system: string;
+    identifier: string;
+    uri?: string;
+    matchType?: 'exact' | 'close' | 'broader' | 'narrower' | 'related';
+  }>;
 }
 
 /**
@@ -3316,6 +3337,9 @@ export async function createPersonalNode(
   }
   if (input.metadata) {
     record.metadata = input.metadata;
+  }
+  if (input.externalIds && input.externalIds.length > 0) {
+    record.externalIds = input.externalIds;
   }
 
   const response = await agent.com.atproto.repo.createRecord({
@@ -4461,6 +4485,368 @@ export async function deleteCosmikConnections(
         err,
       });
     }
+  }
+}
+
+// =============================================================================
+// EDGE-TO-COSMIK SYNC
+// =============================================================================
+
+/**
+ * Input for `syncEdgeToCosmik`.
+ */
+export interface SyncEdgeToCosmikInput {
+  /**
+   * AT-URI of the Chive collection the edge lives within. Must be the
+   * personal-graph collection node (`pub.chive.graph.node`). Sync is a
+   * no-op if the collection has no Cosmik mirror (`cosmikCollectionUri`
+   * absent from the node metadata).
+   */
+  collectionUri: string;
+  /** AT-URI of the Chive edge record (`pub.chive.graph.edge`). */
+  chiveEdgeUri: string;
+  /** AT-URI of the edge's source personal-graph node. */
+  chiveEdgeSourceUri: string;
+  /** AT-URI of the edge's target personal-graph node. */
+  chiveEdgeTargetUri: string;
+  /** Slug of the edge's relation. */
+  relationSlug: string;
+  /** AT-URI of the relation-type node (for externalIds-based Cosmik mapping). */
+  relationUri?: string;
+  /** Optional note attached to the edge. */
+  note?: string;
+}
+
+/**
+ * Options controlling how `cosmikConnections` metadata is stored.
+ *
+ * @internal
+ */
+interface EdgeSyncLookup {
+  /** Collection node record fetched fresh before mutation. */
+  node: CollectionNodeRecord;
+  /** Collection rkey. */
+  rkey: string;
+  /** Cosmik items metadata keyed by the original item URL. */
+  cosmikItems: Record<string, CosmikItemMapping>;
+  /** Cosmik connections metadata keyed by Chive edge URI. */
+  cosmikConnections: Record<string, CosmikConnectionMapping>;
+}
+
+/**
+ * Builds the `cosmikConnections` map key for an edge.
+ *
+ * @remarks
+ * We key by the Chive edge's AT-URI for correctness: every edge is a
+ * distinct record, and two edges with identical `(source, target, slug)`
+ * triples (rare but possible) must each have their own connection entry.
+ *
+ * @internal
+ */
+function cosmikConnectionKey(chiveEdgeUri: string): string {
+  return chiveEdgeUri;
+}
+
+/**
+ * Reads the collection node record and returns its Cosmik mirror state,
+ * or `null` if the collection isn't mirrored.
+ *
+ * @internal
+ */
+async function loadEdgeSyncLookup(
+  agent: Agent,
+  collectionUri: string
+): Promise<EdgeSyncLookup | null> {
+  const did = getAgentDid(agent);
+  if (!did) return null;
+
+  const parsed = parseAtUri(collectionUri);
+  if (!parsed || parsed.did !== did) return null;
+
+  const response = await agent.com.atproto.repo.getRecord({
+    repo: did,
+    collection: 'pub.chive.graph.node',
+    rkey: parsed.rkey,
+  });
+
+  const node = response.data.value as CollectionNodeRecord;
+  if (!node.metadata || !('cosmikCollectionUri' in node.metadata)) {
+    return null;
+  }
+
+  const cosmikItems =
+    ((node.metadata.cosmikItems ?? {}) as Record<string, CosmikItemMapping>) ?? {};
+  const cosmikConnections =
+    ((node.metadata.cosmikConnections ?? {}) as Record<string, CosmikConnectionMapping>) ?? {};
+
+  return { node, rkey: parsed.rkey, cosmikItems, cosmikConnections };
+}
+
+/**
+ * Writes back the collection node with an updated `cosmikConnections` map.
+ *
+ * @internal
+ */
+async function writeBackCosmikConnections(
+  agent: Agent,
+  did: string,
+  rkey: string,
+  node: CollectionNodeRecord,
+  cosmikConnections: Record<string, CosmikConnectionMapping>
+): Promise<void> {
+  const updated: CollectionNodeRecord = {
+    ...node,
+    metadata: {
+      ...node.metadata,
+      cosmikConnections,
+    },
+  };
+  await agent.com.atproto.repo.putRecord({
+    repo: did,
+    collection: 'pub.chive.graph.node',
+    rkey,
+    record: updated,
+  });
+}
+
+/**
+ * Resolves an item's Cosmik-visible URL for use as a connection endpoint.
+ *
+ * @remarks
+ * Semble's connection query layer only renders URL-typed endpoints
+ * (`sourceType = 'URL' AND targetType = 'URL'`). `at://` endpoints are
+ * stored but never rendered. We therefore use the Chive web URL that was
+ * emitted when the item's card was created. For edge endpoints pointing
+ * at items outside the collection (no card exists) we fall back to
+ * converting the item AT-URI via `toChiveUrl`.
+ *
+ * @internal
+ */
+function resolveEndpointUrl(
+  itemAtUri: string,
+  cosmikItems: Record<string, CosmikItemMapping>,
+  originalUriMap?: Map<string, string>
+): string {
+  // Prefer the URL used when the card was created (stored in cosmikItems keyed
+  // by original URL).
+  if (originalUriMap) {
+    for (const [originalUri, personalUri] of originalUriMap.entries()) {
+      if (personalUri === itemAtUri && cosmikItems[originalUri]) {
+        return originalUri;
+      }
+    }
+  }
+  // Fallback: direct lookup by the URI we were given.
+  const direct = cosmikItems[itemAtUri];
+  if (direct) {
+    // The stored key IS the URL we want to emit.
+    return itemAtUri;
+  }
+  // Last resort: synthesize a Chive URL from the AT-URI.
+  return toChiveUrl(itemAtUri);
+}
+
+/**
+ * Creates, updates, or deletes a `network.cosmik.connection` record to
+ * mirror a Chive inter-item edge.
+ *
+ * @remarks
+ * No-op when the parent collection isn't mirrored to Cosmik. For create:
+ * resolves the relation's declared Cosmik mapping from its node's
+ * `externalIds` (falls back to SCREAMING_SNAKE of the slug); creates the
+ * connection record in the user's PDS; updates the collection node's
+ * `cosmikConnections` metadata.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param input - Edge sync input
+ * @param originalUriMap - Optional map from wizard-original URIs to
+ *   personal-graph URIs; used to resolve card endpoint URLs without
+ *   guessing
+ * @returns Connection URI/CID on create, or undefined for update/delete
+ *
+ * @public
+ */
+export async function syncEdgeToCosmik(
+  agent: Agent,
+  action: 'create' | 'update' | 'delete',
+  input: SyncEdgeToCosmikInput,
+  originalUriMap?: Map<string, string>
+): Promise<CosmikConnectionMapping | undefined> {
+  const did = getAgentDid(agent);
+  if (!did) return undefined;
+
+  const lookup = await loadEdgeSyncLookup(agent, input.collectionUri);
+  if (!lookup) return undefined; // not mirrored
+
+  const key = cosmikConnectionKey(input.chiveEdgeUri);
+  const existing = lookup.cosmikConnections[key];
+
+  if (action === 'delete') {
+    if (!existing) return undefined;
+    try {
+      await deleteCosmikConnection(agent, existing.connectionUri);
+    } catch (err) {
+      recordLogger.warn('Cosmik connection delete failed', {
+        connectionUri: existing.connectionUri,
+        err,
+      });
+    }
+    const { [key]: _removed, ...rest } = lookup.cosmikConnections;
+    void _removed;
+    await writeBackCosmikConnections(agent, did, lookup.rkey, lookup.node, rest);
+    return undefined;
+  }
+
+  if (action === 'update') {
+    if (!existing) return undefined;
+    const connectionType = await resolveCosmikConnectionTypeViaAppView(
+      input.relationUri,
+      input.relationSlug
+    );
+    try {
+      await updateCosmikConnection(agent, existing.connectionUri, {
+        connectionType,
+        note: input.note,
+      });
+    } catch (err) {
+      recordLogger.warn('Cosmik connection update failed', {
+        connectionUri: existing.connectionUri,
+        err,
+      });
+    }
+    return existing;
+  }
+
+  // action === 'create'
+  if (existing) {
+    // Idempotent: already synced.
+    return existing;
+  }
+
+  const connectionType = await resolveCosmikConnectionTypeViaAppView(
+    input.relationUri,
+    input.relationSlug
+  );
+
+  const source = resolveEndpointUrl(input.chiveEdgeSourceUri, lookup.cosmikItems, originalUriMap);
+  const target = resolveEndpointUrl(input.chiveEdgeTargetUri, lookup.cosmikItems, originalUriMap);
+
+  let mapping: CosmikConnectionMapping;
+  try {
+    const result = await createCosmikConnection(agent, {
+      source,
+      target,
+      connectionType,
+      note: input.note,
+    });
+    mapping = {
+      connectionUri: result.uri,
+      connectionCid: result.cid,
+    };
+  } catch (err) {
+    recordLogger.warn('Cosmik connection create failed', {
+      source,
+      target,
+      relationSlug: input.relationSlug,
+      err,
+    });
+    return undefined;
+  }
+
+  const updatedConnections = { ...lookup.cosmikConnections, [key]: mapping };
+  await writeBackCosmikConnections(agent, did, lookup.rkey, lookup.node, updatedConnections);
+  return mapping;
+}
+
+/**
+ * Resolves a Cosmik connectionType via the AppView's relation-node lookup.
+ *
+ * @remarks
+ * Lazy-imports `relation-resolver` to keep this module usable from
+ * non-browser contexts (tests, Node scripts). The resolver hits the
+ * `pub.chive.graph.getNode` XRPC endpoint and reads `externalIds`.
+ *
+ * @internal
+ */
+async function resolveCosmikConnectionTypeViaAppView(
+  relationUri: string | undefined,
+  relationSlug: string
+): Promise<string> {
+  try {
+    const { resolveCosmikConnectionType } = await import('./relation-resolver.js');
+    return await resolveCosmikConnectionType(relationUri, relationSlug);
+  } catch {
+    // Fallback if dynamic import fails (e.g. in test harnesses)
+    return relationSlug.toUpperCase().replace(/-/g, '_');
+  }
+}
+
+/**
+ * Deletes all Cosmik connections that reference a removed item.
+ *
+ * @remarks
+ * Called when an item is removed from a mirrored collection. Scans the
+ * `cosmikConnections` metadata for entries whose `source` or `target`
+ * matches the removed item's URL, deletes those connection records, and
+ * removes them from the metadata map.
+ *
+ * @param agent - Authenticated ATProto Agent
+ * @param collectionUri - AT-URI of the collection node
+ * @param itemUrl - URL (or AT-URI) of the item being removed
+ *
+ * @public
+ */
+export async function deleteCosmikConnectionsForItem(
+  agent: Agent,
+  collectionUri: string,
+  itemUrl: string
+): Promise<void> {
+  const did = getAgentDid(agent);
+  if (!did) return;
+
+  const lookup = await loadEdgeSyncLookup(agent, collectionUri);
+  if (!lookup) return;
+
+  const keep: Record<string, CosmikConnectionMapping> = {};
+  const toDelete: CosmikConnectionMapping[] = [];
+
+  for (const [key, mapping] of Object.entries(lookup.cosmikConnections)) {
+    try {
+      const parsed = parseAtUri(mapping.connectionUri);
+      if (!parsed) {
+        keep[key] = mapping;
+        continue;
+      }
+      const response = await agent.com.atproto.repo.getRecord({
+        repo: parsed.did,
+        collection: 'network.cosmik.connection',
+        rkey: parsed.rkey,
+      });
+      const record = response.data.value as CosmikConnectionRecord;
+      if (record.source === itemUrl || record.target === itemUrl) {
+        toDelete.push(mapping);
+      } else {
+        keep[key] = mapping;
+      }
+    } catch {
+      // Treat read failures as "keep" — we can't verify, so don't delete.
+      keep[key] = mapping;
+    }
+  }
+
+  for (const mapping of toDelete) {
+    try {
+      await deleteCosmikConnection(agent, mapping.connectionUri);
+    } catch (err) {
+      recordLogger.warn('Failed to delete orphan Cosmik connection', {
+        connectionUri: mapping.connectionUri,
+        err,
+      });
+    }
+  }
+
+  if (toDelete.length > 0) {
+    await writeBackCosmikConnections(agent, did, lookup.rkey, lookup.node, keep);
   }
 }
 

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -4957,6 +4957,150 @@ export async function deleteCosmikConnectionsForItem(
 }
 
 // =============================================================================
+// CHIVE COLLABORATION (invites + acceptances)
+// =============================================================================
+
+/**
+ * `pub.chive.collaboration.invite` record.
+ *
+ * @public
+ */
+export interface CollaborationInviteRecord {
+  [key: string]: unknown;
+  $type: 'pub.chive.collaboration.invite';
+  subject: { uri: string; cid: string };
+  invitee: string;
+  role?: string;
+  message?: string;
+  createdAt: string;
+  expiresAt?: string;
+}
+
+/**
+ * `pub.chive.collaboration.inviteAcceptance` record.
+ *
+ * @public
+ */
+export interface CollaborationInviteAcceptanceRecord {
+  [key: string]: unknown;
+  $type: 'pub.chive.collaboration.inviteAcceptance';
+  invite: { uri: string; cid: string };
+  subject: { uri: string; cid: string };
+  createdAt: string;
+}
+
+/**
+ * Creates a collaboration invite in the subject-record author's PDS.
+ *
+ * @public
+ */
+export async function createInviteRecord(
+  agent: Agent,
+  input: {
+    subjectUri: string;
+    subjectCid: string;
+    invitee: string;
+    role?: string;
+    message?: string;
+    expiresAt?: string;
+  }
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const record: CollaborationInviteRecord = {
+    $type: 'pub.chive.collaboration.invite',
+    subject: { uri: input.subjectUri, cid: input.subjectCid },
+    invitee: input.invitee,
+    createdAt: new Date().toISOString(),
+  };
+  if (input.role) record.role = input.role;
+  if (input.message) record.message = input.message;
+  if (input.expiresAt) record.expiresAt = input.expiresAt;
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'pub.chive.collaboration.invite',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+/**
+ * Deletes a collaboration invite record.
+ *
+ * @public
+ */
+export async function deleteInviteRecord(agent: Agent, inviteUri: string): Promise<void> {
+  const parsed = parseAtUri(inviteUri);
+  if (!parsed) return;
+  await agent.com.atproto.repo.deleteRecord({
+    repo: parsed.did,
+    collection: 'pub.chive.collaboration.invite',
+    rkey: parsed.rkey,
+  });
+}
+
+/**
+ * Creates a collaboration acceptance in the invitee's PDS.
+ *
+ * @public
+ */
+export async function createInviteAcceptance(
+  agent: Agent,
+  input: {
+    inviteUri: string;
+    inviteCid: string;
+    subjectUri: string;
+    subjectCid: string;
+  }
+): Promise<CreateRecordResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const record: CollaborationInviteAcceptanceRecord = {
+    $type: 'pub.chive.collaboration.inviteAcceptance',
+    invite: { uri: input.inviteUri, cid: input.inviteCid },
+    subject: { uri: input.subjectUri, cid: input.subjectCid },
+    createdAt: new Date().toISOString(),
+  };
+
+  const response = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'pub.chive.collaboration.inviteAcceptance',
+    record,
+  });
+
+  return {
+    uri: response.data.uri,
+    cid: response.data.cid,
+  };
+}
+
+/**
+ * Deletes a collaboration acceptance record.
+ *
+ * @public
+ */
+export async function deleteInviteAcceptance(agent: Agent, acceptanceUri: string): Promise<void> {
+  const parsed = parseAtUri(acceptanceUri);
+  if (!parsed) return;
+  await agent.com.atproto.repo.deleteRecord({
+    repo: parsed.did,
+    collection: 'pub.chive.collaboration.inviteAcceptance',
+    rkey: parsed.rkey,
+  });
+}
+
+// =============================================================================
 // COSMIK COLLECTION LINK REMOVAL (tombstones for collaborative collections)
 // =============================================================================
 

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -3181,6 +3181,8 @@ export interface PersonalEdgeRecord {
   sourceUri: string;
   targetUri: string;
   relationSlug: string;
+  /** AT-URI of the relation-type node (graph lookup for inverse, externalIds). */
+  relationUri?: string;
   metadata: Record<string, unknown>;
   status: 'established';
   createdAt: string;
@@ -3365,6 +3367,12 @@ export interface CreatePersonalEdgeInput {
   targetUri: string;
   /** Relation type slug (e.g., 'related-to', 'depends-on') */
   relationSlug: string;
+  /**
+   * AT-URI of the relation-type node. Written to the edge record so
+   * consumers can look up the relation's `externalIds` for cross-app
+   * translations without re-resolving by slug.
+   */
+  relationUri?: string;
   /** Optional metadata */
   metadata?: Record<string, unknown>;
 }
@@ -3408,6 +3416,9 @@ export async function createPersonalEdge(
     status: 'established',
     createdAt: new Date().toISOString(),
   };
+  if (input.relationUri) {
+    record.relationUri = input.relationUri;
+  }
 
   const response = await agent.com.atproto.repo.createRecord({
     repo: did,
@@ -4518,11 +4529,11 @@ export interface SyncEdgeToCosmikInput {
 }
 
 /**
- * Options controlling how `cosmikConnections` metadata is stored.
+ * Snapshot of a mirrored collection's state used by edge sync and repair.
  *
- * @internal
+ * @public
  */
-interface EdgeSyncLookup {
+export interface EdgeSyncLookup {
   /** Collection node record fetched fresh before mutation. */
   node: CollectionNodeRecord;
   /** Collection rkey. */
@@ -4551,9 +4562,13 @@ function cosmikConnectionKey(chiveEdgeUri: string): string {
  * Reads the collection node record and returns its Cosmik mirror state,
  * or `null` if the collection isn't mirrored.
  *
- * @internal
+ * @remarks
+ * Exported for use by repair flows that need access to the raw mirror
+ * metadata (e.g., `useRepairCosmikMirror`).
+ *
+ * @public
  */
-async function loadEdgeSyncLookup(
+export async function loadEdgeSyncLookup(
   agent: Agent,
   collectionUri: string
 ): Promise<EdgeSyncLookup | null> {
@@ -4585,9 +4600,9 @@ async function loadEdgeSyncLookup(
 /**
  * Writes back the collection node with an updated `cosmikConnections` map.
  *
- * @internal
+ * @public
  */
-async function writeBackCosmikConnections(
+export async function writeBackCosmikConnections(
   agent: Agent,
   did: string,
   rkey: string,

--- a/web/lib/atproto/relation-resolver.ts
+++ b/web/lib/atproto/relation-resolver.ts
@@ -1,0 +1,203 @@
+/**
+ * Relation type resolver.
+ *
+ * @remarks
+ * Resolves knowledge graph relation-type nodes to their declared external
+ * vocabulary mappings. Relations in Chive's knowledge graph carry
+ * {@link https://www.w3.org/TR/skos-reference/ SKOS}-style `externalIds`
+ * entries pointing at equivalent concepts in other vocabularies (Wikidata,
+ * CiTO, Cosmik connection types, Dublin Core, etc.). This module reads
+ * those mappings so dual-write code can emit foreign-ecosystem
+ * representations without hard-coded enum tables.
+ *
+ * @packageDocumentation
+ */
+
+import { api } from '@/lib/api/client';
+
+/**
+ * In-process cache of relation node lookups.
+ *
+ * @remarks
+ * Relation nodes are approximately immutable after publication, so caching
+ * per-page-load is safe. Cache keyed by `relationUri`. The cached value is
+ * the full `externalIds` array so a single fetch supports lookups against
+ * multiple ecosystems.
+ *
+ * @internal
+ */
+const relationExternalIdCache = new Map<string, ExternalIdEntry[]>();
+
+/**
+ * Single external-id entry as returned by the API.
+ *
+ * @public
+ */
+export interface ExternalIdEntry {
+  system: string;
+  identifier: string;
+  uri?: string;
+  matchType?: 'exact' | 'close' | 'broader' | 'narrower' | 'related';
+}
+
+/**
+ * Fetches a relation node's external-id mappings from the AppView.
+ *
+ * @param relationUri - AT-URI of the relation node
+ * @returns Array of external-id entries, or `null` if the node cannot be
+ *   resolved
+ *
+ * @public
+ */
+export async function getRelationExternalIds(
+  relationUri: string
+): Promise<ExternalIdEntry[] | null> {
+  const cached = relationExternalIdCache.get(relationUri);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  try {
+    const response = await api.pub.chive.graph.getNode({ id: relationUri });
+    const externalIds = ((response.data.externalIds ?? []) as ExternalIdEntry[]) ?? [];
+    relationExternalIdCache.set(relationUri, externalIds);
+    return externalIds;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Looks up the identifier value for a specific ecosystem on a relation node.
+ *
+ * @remarks
+ * Example: `getRelationExternalId(relationUri, 'cosmik')` returns
+ * `"REFERENCES"` for the curated `cites` relation.
+ *
+ * @param relationUri - AT-URI of the relation node
+ * @param system - External-id system name (e.g., `"cosmik"`, `"skos"`,
+ *   `"wikidata"`, `"schema-org"`)
+ * @returns Identifier string, or `null` if the relation has no mapping
+ *   declared for that system
+ *
+ * @public
+ */
+export async function getRelationExternalId(
+  relationUri: string,
+  system: string
+): Promise<string | null> {
+  const entries = await getRelationExternalIds(relationUri);
+  if (!entries) return null;
+  return entries.find((entry) => entry.system === system)?.identifier ?? null;
+}
+
+/**
+ * Derives a Cosmik `connectionType` value for a Chive relation.
+ *
+ * @remarks
+ * Resolution order:
+ * 1. If the relation node declares a `cosmik` external-id, return that value.
+ * 2. Otherwise, derive from the slug by converting kebab-case to
+ *    SCREAMING_SNAKE_CASE. This is a naming convention, not an enum.
+ *
+ * Personal relations (user-created) can declare their own Cosmik mapping
+ * via the "Cosmik connection type" field in the new-relation wizard form.
+ *
+ * @param relationUri - AT-URI of the relation node (may be undefined for
+ *   ad-hoc slug-only edges)
+ * @param relationSlug - Relation slug used on the edge record
+ * @returns Cosmik `connectionType` string suitable for
+ *   `network.cosmik.connection.connectionType`
+ *
+ * @public
+ */
+export async function resolveCosmikConnectionType(
+  relationUri: string | undefined,
+  relationSlug: string
+): Promise<string> {
+  if (relationUri) {
+    const mapped = await getRelationExternalId(relationUri, 'cosmik');
+    if (mapped) return mapped;
+  }
+  return slugToScreamingSnake(relationSlug);
+}
+
+/**
+ * Reverse resolver: finds the Chive relation node whose `externalIds` match
+ * a given foreign `(system, identifier)` pair.
+ *
+ * @remarks
+ * Used when indexing or displaying incoming foreign records (e.g., a
+ * `network.cosmik.connection` with `connectionType: "REFERENCES"`) so we
+ * can surface the matching Chive relation to users.
+ *
+ * @param system - External-id system (e.g., `"cosmik"`, `"skos"`)
+ * @param identifier - Identifier value in that system
+ * @returns The relation node's AT-URI and slug, or `null` if none match
+ *
+ * @public
+ */
+export async function findChiveRelationByExternalId(
+  system: string,
+  identifier: string
+): Promise<{ uri: string; slug: string; label: string } | null> {
+  try {
+    const response = await api.pub.chive.graph.listNodes({
+      kind: 'type',
+      subkind: 'relation',
+      externalIdSystem: system,
+      externalIdIdentifier: identifier,
+      limit: 1,
+    });
+    const nodes = (response.data.nodes ?? []) as Array<{
+      uri: string;
+      label: string;
+      metadata?: { slug?: string };
+    }>;
+    const first = nodes[0];
+    if (!first) return null;
+    const slug =
+      (first.metadata?.slug as string | undefined) ??
+      first.label.toLowerCase().replace(/\s+/g, '-');
+    return { uri: first.uri, slug, label: first.label };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Converts a kebab-case slug to SCREAMING_SNAKE_CASE.
+ *
+ * @param slug - Slug like `"has-part"`
+ * @returns SCREAMING_SNAKE identifier like `"HAS_PART"`
+ *
+ * @internal
+ */
+function slugToScreamingSnake(slug: string): string {
+  return slug.toUpperCase().replace(/-/g, '_');
+}
+
+/**
+ * Converts a SCREAMING_SNAKE identifier to a kebab-case slug.
+ *
+ * @param value - SCREAMING_SNAKE identifier like `"HAS_PART"`
+ * @returns Slug like `"has-part"`
+ *
+ * @public
+ */
+export function screamingSnakeToSlug(value: string): string {
+  return value.toLowerCase().replace(/_/g, '-');
+}
+
+/**
+ * Clears the in-process relation cache.
+ *
+ * @remarks
+ * Useful in tests and after a long-running session where relation records
+ * may have been updated (though relations are rarely mutated in practice).
+ *
+ * @public
+ */
+export function clearRelationCache(): void {
+  relationExternalIdCache.clear();
+}

--- a/web/lib/hooks/use-collaboration.ts
+++ b/web/lib/hooks/use-collaboration.ts
@@ -1,0 +1,250 @@
+/**
+ * React hooks for collaboration invites and acceptances.
+ *
+ * @remarks
+ * Backed by `pub.chive.collaboration.*` records. These hooks wrap:
+ *
+ * - {@link createInvite} / {@link deleteInvite}: owner-side mutations
+ * - {@link createInviteAcceptance} / {@link deleteInviteAcceptance}: invitee-side
+ * - {@link useListInvites}: invitee inbox / inviter dashboard
+ * - {@link useListCollaborators}: current active collaborators on a subject
+ *
+ * Collaboration is generic over any Chive-authored subject record
+ * (collections, eprints, reviews, ...). v1 consumers are collections; UI
+ * for other subject types is additive.
+ *
+ * @packageDocumentation
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api/client';
+import {
+  createInviteRecord,
+  deleteInviteRecord,
+  createInviteAcceptance,
+  deleteInviteAcceptance,
+} from '@/lib/atproto/record-creator';
+import { getCurrentAgent } from '@/lib/auth/oauth-client';
+import { APIError } from '@/lib/errors';
+import { createLogger } from '@/lib/observability/logger';
+
+const logger = createLogger({ context: { component: 'use-collaboration' } });
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Invite view as returned by the API.
+ *
+ * @public
+ */
+export interface CollaborationInviteView {
+  uri: string;
+  inviter: string;
+  invitee: string;
+  subjectUri: string;
+  subjectCollection?: string;
+  role?: string;
+  message?: string;
+  state: 'pending' | 'accepted' | 'rejected' | 'expired';
+  acceptanceUri?: string;
+  createdAt: string;
+  expiresAt?: string;
+  acceptedAt?: string;
+}
+
+/**
+ * Active collaborator view as returned by the API.
+ *
+ * @public
+ */
+export interface CollaboratorView {
+  did: string;
+  inviteUri: string;
+  acceptanceUri: string;
+  role?: string;
+  acceptedAt: string;
+}
+
+// =============================================================================
+// QUERY KEYS
+// =============================================================================
+
+export const collaborationKeys = {
+  all: ['collaboration'] as const,
+  invites: (filters: Record<string, unknown>) =>
+    [...collaborationKeys.all, 'invites', filters] as const,
+  collaborators: (subjectUri: string) =>
+    [...collaborationKeys.all, 'collaborators', subjectUri] as const,
+};
+
+// =============================================================================
+// QUERIES
+// =============================================================================
+
+/**
+ * Lists collaboration invites matching the given filters.
+ *
+ * @public
+ */
+export function useListInvites(
+  filters: {
+    invitee?: string;
+    inviter?: string;
+    subjectUri?: string;
+    subjectCollection?: string;
+    state?: 'pending' | 'accepted' | 'rejected' | 'expired' | 'all';
+  },
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: collaborationKeys.invites(filters),
+    queryFn: async (): Promise<{ invites: CollaborationInviteView[] }> => {
+      const response = await api.pub.chive.collaboration.listInvites(filters);
+      return response.data as unknown as { invites: CollaborationInviteView[] };
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: 30 * 1000,
+  });
+}
+
+/**
+ * Lists active collaborators on a subject record.
+ *
+ * @public
+ */
+export function useListCollaborators(subjectUri: string, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: collaborationKeys.collaborators(subjectUri),
+    queryFn: async (): Promise<{ collaborators: CollaboratorView[] }> => {
+      const response = await api.pub.chive.collaboration.listCollaborators({
+        subjectUri,
+      });
+      return response.data as unknown as { collaborators: CollaboratorView[] };
+    },
+    enabled: !!subjectUri && (options?.enabled ?? true),
+    staleTime: 30 * 1000,
+  });
+}
+
+// =============================================================================
+// MUTATIONS
+// =============================================================================
+
+/**
+ * Mutation hook for creating a collaboration invite.
+ *
+ * @public
+ */
+export function useCreateInvite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: {
+      subjectUri: string;
+      subjectCid: string;
+      invitee: string;
+      role?: string;
+      message?: string;
+      expiresAt?: string;
+    }): Promise<{ inviteUri: string; inviteCid: string }> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError('Not authenticated. Please log in again.', 401, 'createInvite');
+      }
+      const result = await createInviteRecord(agent, input);
+      return { inviteUri: result.uri, inviteCid: result.cid };
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: collaborationKeys.all });
+      queryClient.invalidateQueries({
+        queryKey: collaborationKeys.collaborators(variables.subjectUri),
+      });
+    },
+  });
+}
+
+/**
+ * Mutation hook for revoking (deleting) an invite.
+ *
+ * @public
+ */
+export function useRevokeInvite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: { inviteUri: string; subjectUri: string }): Promise<void> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError('Not authenticated. Please log in again.', 401, 'revokeInvite');
+      }
+      await deleteInviteRecord(agent, input.inviteUri);
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: collaborationKeys.all });
+      queryClient.invalidateQueries({
+        queryKey: collaborationKeys.collaborators(variables.subjectUri),
+      });
+    },
+  });
+}
+
+/**
+ * Mutation hook for accepting an invite.
+ *
+ * @public
+ */
+export function useAcceptInvite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: {
+      inviteUri: string;
+      inviteCid: string;
+      subjectUri: string;
+      subjectCid: string;
+    }): Promise<{ acceptanceUri: string; acceptanceCid: string }> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError('Not authenticated. Please log in again.', 401, 'acceptInvite');
+      }
+      const result = await createInviteAcceptance(agent, input);
+      return { acceptanceUri: result.uri, acceptanceCid: result.cid };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collaborationKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation hook for withdrawing an acceptance (leaving a collaboration).
+ *
+ * @public
+ */
+export function useWithdrawAcceptance() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: { acceptanceUri: string }): Promise<void> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError('Not authenticated. Please log in again.', 401, 'withdrawAcceptance');
+      }
+      try {
+        await deleteInviteAcceptance(agent, input.acceptanceUri);
+      } catch (err) {
+        logger.warn('Withdraw acceptance failed', {
+          acceptanceUri: input.acceptanceUri,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collaborationKeys.all });
+    },
+  });
+}

--- a/web/lib/hooks/use-collections.ts
+++ b/web/lib/hooks/use-collections.ts
@@ -498,6 +498,17 @@ export interface CreateCollectionMutationInput extends CreateCollectionNodeInput
       kind?: string;
       avatarUrl?: string;
       isPersonal?: boolean;
+      doi?: string;
+      isbn?: string;
+      publishedDate?: string;
+      imageUrl?: string;
+      journalTitle?: string;
+      externalIds?: Array<{
+        system: string;
+        identifier: string;
+        uri?: string;
+        matchType?: 'exact' | 'close' | 'broader' | 'narrower' | 'related';
+      }>;
     };
   }>;
   /** Inter-item edges to mirror as Cosmik connections when enableCosmikMirror is true */

--- a/web/lib/hooks/use-collections.ts
+++ b/web/lib/hooks/use-collections.ts
@@ -55,10 +55,6 @@ import {
   deleteCosmikMirror,
   addCosmikItem,
   removeCosmikItem,
-  createCosmikConnection,
-  deleteCosmikConnection,
-  createCosmikConnectionsForEdges,
-  deleteCosmikConnections,
   createCosmikFollow,
   deleteCosmikFollow,
   createCosmikCollectionLinkRemoval,
@@ -1004,6 +1000,20 @@ export function useRemoveFromCollection() {
             linkUri: cosmikLinkUri,
           });
 
+          // Also prune any orphan inter-item Cosmik connections that
+          // referenced the removed item. Without this, Semble would still
+          // display edges pointing at a card that no longer exists.
+          try {
+            const { deleteCosmikConnectionsForItem } = await import('@/lib/atproto/record-creator');
+            await deleteCosmikConnectionsForItem(agent, collectionUri, cosmikItemUrl);
+          } catch (connectionErr) {
+            logger.warn('Failed to prune orphan Cosmik connections', {
+              collectionUri,
+              cosmikItemUrl,
+              error: connectionErr instanceof Error ? connectionErr.message : String(connectionErr),
+            });
+          }
+
           // Re-index so server picks up updated metadata
           try {
             await authApi.pub.chive.sync.indexRecord({ uri: collectionUri });
@@ -1514,89 +1524,6 @@ export function useUnfollowCollection() {
 }
 
 // =============================================================================
-// COSMIK CONNECTION HOOKS (edges between links)
-// =============================================================================
-
-/**
- * Mutation hook for creating a Cosmik connection (edge between links).
- *
- * @remarks
- * Used when adding an inter-item edge to a collection that has Cosmik mirroring enabled.
- *
- * @returns Mutation object for creating connections
- */
-export function useCreateCosmikConnection() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async (input: {
-      collectionUri: string;
-      source: string;
-      target: string;
-      connectionType?: string;
-      note?: string;
-    }): Promise<{ connectionUri: string; connectionCid: string }> => {
-      const agent = getCurrentAgent();
-      if (!agent) {
-        throw new APIError(
-          'Not authenticated. Please log in again.',
-          401,
-          'createCosmikConnection'
-        );
-      }
-
-      const result = await createCosmikConnection(agent, {
-        source: input.source,
-        target: input.target,
-        connectionType: input.connectionType,
-        note: input.note,
-      });
-
-      return { connectionUri: result.uri, connectionCid: result.cid };
-    },
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: collectionKeys.detail(variables.collectionUri),
-      });
-    },
-  });
-}
-
-/**
- * Mutation hook for deleting a Cosmik connection.
- *
- * @returns Mutation object for deleting connections
- */
-export function useDeleteCosmikConnection() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async ({
-      connectionUri,
-    }: {
-      connectionUri: string;
-      collectionUri: string;
-    }): Promise<void> => {
-      const agent = getCurrentAgent();
-      if (!agent) {
-        throw new APIError(
-          'Not authenticated. Please log in again.',
-          401,
-          'deleteCosmikConnection'
-        );
-      }
-
-      await deleteCosmikConnection(agent, connectionUri);
-    },
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: collectionKeys.detail(variables.collectionUri),
-      });
-    },
-  });
-}
-
-// =============================================================================
 // MARGIN ANNOTATION HOOKS
 // =============================================================================
 
@@ -1700,4 +1627,174 @@ export function useCreateMarginBookmark() {
       return { bookmarkUri: result.uri, bookmarkCid: result.cid };
     },
   });
+}
+
+// =============================================================================
+// REPAIR MIRROR HOOK
+// =============================================================================
+
+/**
+ * Mutation hook for repairing an existing Cosmik mirror.
+ *
+ * @remarks
+ * Reconciles the collection's `cosmikConnections` metadata with the actual
+ * state of the graph: creates Cosmik connection records for inter-item
+ * edges that should be mirrored but aren't, and deletes orphan connections
+ * whose endpoints are no longer in the collection.
+ *
+ * Used to recover from pre-rigorous-integration mirrors that were created
+ * without connections, and from drift introduced by partial-failure edge
+ * operations.
+ *
+ * @returns Mutation object; input takes the collection URI, inter-item
+ *   edges returned from the collection query, and the items currently in
+ *   the collection.
+ *
+ * @public
+ */
+export function useRepairCosmikMirror() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: {
+      collectionUri: string;
+      interItemEdges: Array<{
+        edgeUri?: string;
+        sourceUri: string;
+        targetUri: string;
+        relationSlug: string;
+      }>;
+      itemUrls: string[];
+    }): Promise<{ created: number; pruned: number }> => {
+      const agent = getCurrentAgent();
+      if (!agent) {
+        throw new APIError('Not authenticated. Please log in again.', 401, 'repairCosmikMirror');
+      }
+
+      const { syncEdgeToCosmik, deleteCosmikConnectionsForItem } =
+        await import('@/lib/atproto/record-creator');
+
+      let created = 0;
+      for (const edge of input.interItemEdges) {
+        if (!edge.edgeUri) continue;
+        try {
+          const mapping = await syncEdgeToCosmik(agent, 'create', {
+            collectionUri: input.collectionUri,
+            chiveEdgeUri: edge.edgeUri,
+            chiveEdgeSourceUri: edge.sourceUri,
+            chiveEdgeTargetUri: edge.targetUri,
+            relationSlug: edge.relationSlug,
+          });
+          if (mapping) created++;
+        } catch (err) {
+          logger.warn('Repair: failed to sync edge', {
+            edgeUri: edge.edgeUri,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      // Prune Cosmik connections whose endpoints are no longer in the
+      // collection. We look up each connection record, check whether either
+      // endpoint URL matches a current item, and delete if neither does.
+      const itemUrlSet = new Set(input.itemUrls);
+      const pruned = await pruneOrphanConnections(agent, input.collectionUri, itemUrlSet);
+
+      return { created, pruned };
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: collectionKeys.detail(variables.collectionUri),
+      });
+    },
+  });
+}
+
+/**
+ * Helper for `useRepairCosmikMirror`: deletes Cosmik connections whose
+ * source and target are both absent from the current item set.
+ *
+ * @remarks
+ * Reads the collection node's `cosmikConnections` metadata, fetches each
+ * connection record to inspect its `source` and `target`, and deletes any
+ * connection whose endpoints no longer correspond to items in the
+ * collection. Updates the `cosmikConnections` metadata to reflect the
+ * surviving set.
+ *
+ * @internal
+ */
+async function pruneOrphanConnections(
+  agent: import('@atproto/api').Agent,
+  collectionUri: string,
+  itemUrlSet: Set<string>
+): Promise<number> {
+  const { loadEdgeSyncLookup, writeBackCosmikConnections, deleteCosmikConnection } =
+    await import('@/lib/atproto/record-creator');
+
+  const lookup = await loadEdgeSyncLookup(agent, collectionUri);
+  if (!lookup) return 0;
+
+  const did = (agent as unknown as { did?: string }).did;
+  if (!did) return 0;
+
+  const keep: Record<string, import('@/lib/atproto/record-creator').CosmikConnectionMapping> = {};
+  const toDelete: import('@/lib/atproto/record-creator').CosmikConnectionMapping[] = [];
+
+  for (const [key, mapping] of Object.entries(lookup.cosmikConnections)) {
+    try {
+      const parsed = parseAtUri(mapping.connectionUri);
+      if (!parsed) {
+        keep[key] = mapping;
+        continue;
+      }
+      const response = await agent.com.atproto.repo.getRecord({
+        repo: parsed.did,
+        collection: 'network.cosmik.connection',
+        rkey: parsed.rkey,
+      });
+      const record = response.data.value as {
+        source?: string;
+        target?: string;
+      };
+      if (
+        (record.source && itemUrlSet.has(record.source)) ||
+        (record.target && itemUrlSet.has(record.target))
+      ) {
+        keep[key] = mapping;
+      } else {
+        toDelete.push(mapping);
+      }
+    } catch {
+      // Can't read the record — err on the side of keeping it.
+      keep[key] = mapping;
+    }
+  }
+
+  for (const mapping of toDelete) {
+    try {
+      await deleteCosmikConnection(agent, mapping.connectionUri);
+    } catch (err) {
+      logger.warn('Repair: failed to delete orphan connection', {
+        connectionUri: mapping.connectionUri,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (toDelete.length > 0) {
+    await writeBackCosmikConnections(agent, did, lookup.rkey, lookup.node, keep);
+  }
+
+  return toDelete.length;
+}
+
+/**
+ * Minimal AT-URI parser used by the repair helper.
+ *
+ * @internal
+ */
+function parseAtUri(uri: string): { did: string; collection: string; rkey: string } | null {
+  const match = /^at:\/\/([^/]+)\/([^/]+)\/(.+)$/.exec(uri);
+  if (!match) return null;
+  return { did: match[1]!, collection: match[2]!, rkey: match[3]! };
 }

--- a/web/lib/hooks/use-personal-graph.ts
+++ b/web/lib/hooks/use-personal-graph.ts
@@ -304,7 +304,31 @@ export function useCreatePersonalEdge() {
 
   return useMutation({
     mutationFn: async (
-      input: CreatePersonalEdgeInput & { ownerDid: string }
+      input: CreatePersonalEdgeInput & {
+        ownerDid: string;
+        /**
+         * AT-URI of the relation-type node. Passed to the edge record so
+         * downstream consumers (e.g., Cosmik dual-write) can resolve the
+         * relation's `externalIds` for cross-ecosystem mappings.
+         */
+        relationUri?: string;
+        /**
+         * When set and the parent collection has a Cosmik mirror, the edge
+         * is also dual-written as a `network.cosmik.connection` record. The
+         * resulting connection URI is stored in the collection node's
+         * `cosmikConnections` metadata keyed by the Chive edge URI.
+         */
+        collectionUri?: string;
+        /**
+         * Optional: the edge's source URI as it appeared before mapping into
+         * the personal-graph namespace (e.g., the eprint AT-URI from the
+         * wizard). Used to look up the corresponding Cosmik card endpoint
+         * URL precisely. Falls back to converting the personal-graph URI.
+         */
+        originalSourceUri?: string;
+        /** Counterpart to `originalSourceUri`. */
+        originalTargetUri?: string;
+      }
     ): Promise<PersonalEdgeView> => {
       const agent = getCurrentAgent();
       if (!agent) {
@@ -322,6 +346,47 @@ export function useCreatePersonalEdge() {
           uri: result.uri,
           error: indexError instanceof Error ? indexError.message : String(indexError),
         });
+      }
+
+      // Dual-write to Cosmik when the edge sits inside a mirrored collection
+      if (input.collectionUri) {
+        try {
+          const { syncEdgeToCosmik } = await import('@/lib/atproto/record-creator');
+          const originalUriMap =
+            input.originalSourceUri || input.originalTargetUri
+              ? new Map<string, string>([
+                  ...(input.originalSourceUri
+                    ? [[input.originalSourceUri, input.sourceUri] as const]
+                    : []),
+                  ...(input.originalTargetUri
+                    ? [[input.originalTargetUri, input.targetUri] as const]
+                    : []),
+                ])
+              : undefined;
+          await syncEdgeToCosmik(
+            agent,
+            'create',
+            {
+              collectionUri: input.collectionUri,
+              chiveEdgeUri: result.uri,
+              chiveEdgeSourceUri: input.sourceUri,
+              chiveEdgeTargetUri: input.targetUri,
+              relationSlug: input.relationSlug,
+              relationUri: input.relationUri,
+              note:
+                input.metadata && typeof input.metadata === 'object' && 'note' in input.metadata
+                  ? (input.metadata.note as string | undefined)
+                  : undefined,
+            },
+            originalUriMap
+          );
+        } catch (syncErr) {
+          logger.warn('Cosmik edge sync failed', {
+            edgeUri: result.uri,
+            collectionUri: input.collectionUri,
+            error: syncErr instanceof Error ? syncErr.message : String(syncErr),
+          });
+        }
       }
 
       return {

--- a/web/lib/metadata/EntityHeadTags.tsx
+++ b/web/lib/metadata/EntityHeadTags.tsx
@@ -1,0 +1,60 @@
+/**
+ * Renders {@link EntityHeadTag} descriptors into the document head.
+ *
+ * @remarks
+ * Next.js's `Metadata` API covers OpenGraph, Twitter card, and canonical
+ * alternates but lacks first-class support for Highwire `citation_*`
+ * meta tags, Schema.org JSON-LD, and AT-URI `<link rel="alternate">`. We
+ * emit those via a small React component that lives in the page's tree
+ * and writes into `<head>` via Next's head-hoisting.
+ *
+ * @packageDocumentation
+ */
+
+import type { EntityHeadTag } from './entity-metadata';
+
+/**
+ * Props for {@link EntityHeadTags}.
+ *
+ * @public
+ */
+export interface EntityHeadTagsProps {
+  tags: EntityHeadTag[];
+}
+
+/**
+ * Renders a list of {@link EntityHeadTag}s into the document head.
+ *
+ * @public
+ */
+export function EntityHeadTags({ tags }: EntityHeadTagsProps) {
+  return (
+    <>
+      {tags.map((tag, i) => {
+        if (tag.kind === 'link') {
+          return (
+            <link
+              key={`link-${i}-${tag.href}`}
+              rel={tag.rel}
+              type={tag.type}
+              href={tag.href}
+              title={tag.title}
+            />
+          );
+        }
+        if (tag.kind === 'meta') {
+          return <meta key={`meta-${i}-${tag.name}`} name={tag.name} content={tag.content} />;
+        }
+        // script (JSON-LD)
+        return (
+          <script
+            key={`ldjson-${i}`}
+            type={tag.type}
+            // eslint-disable-next-line react/no-danger -- JSON-LD payload is built server-side from trusted sources
+            dangerouslySetInnerHTML={{ __html: tag.content }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/web/lib/metadata/entity-metadata.ts
+++ b/web/lib/metadata/entity-metadata.ts
@@ -1,0 +1,348 @@
+/**
+ * Shared helpers for building rich server-rendered metadata on Chive
+ * entity pages.
+ *
+ * @remarks
+ * Centralizes the construction of OpenGraph, Twitter card, Zotero/Highwire
+ * `citation_*` meta tags, Schema.org JSON-LD, and `<link rel="alternate">`
+ * convention tags so every entity page (eprints, graph nodes, authors,
+ * collections, and the canonical external-ID routes) emits consistent,
+ * Citoid-scrapable HTML. This is how Chive pages become first-class
+ * citizens in the Semble/Margin/Citoid ecosystems, where HTML scraping
+ * (rather than ATProto lookup) is how cross-app card previews are
+ * constructed today.
+ *
+ * See also:
+ *
+ * - W3C Zotero / Highwire-press citation_* convention:
+ *   https://www.zotero.org/support/dev/exposing_metadata
+ * - Wikipedia Citoid: https://en.wikipedia.org/api/rest_v1/#/Citation
+ * - Semble `<link rel="alternate">` AT-URI aggregation plan.
+ *
+ * @packageDocumentation
+ */
+
+import type { Metadata } from 'next';
+
+/**
+ * One W3C-style external identifier for an entity.
+ *
+ * @public
+ */
+export interface EntityExternalId {
+  system: string;
+  identifier: string;
+  uri?: string;
+}
+
+/**
+ * Minimal input for building entity metadata.
+ *
+ * @remarks
+ * Fields are optional because different entity kinds expose different
+ * subsets. Missing fields are simply omitted from the resulting tags.
+ *
+ * @public
+ */
+export interface EntityMetadataInput {
+  /** AT-URI of the entity (e.g., `at://did:.../pub.chive.graph.node/abc`). */
+  atUri: string;
+  /** Chive canonical web URL of the entity. */
+  canonicalUrl: string;
+  /** Display title. */
+  title: string;
+  /** Short description for OG/Twitter (≤300 chars recommended). */
+  description?: string;
+  /** OG image URL (absolute or relative path). */
+  ogImageUrl?: string;
+  /**
+   * Entity type for Schema.org / OG type discrimination.
+   * - `research`: `ScholarlyArticle`, OG `article`
+   * - `author`: `Person`, OG `profile`
+   * - `collection`: `Collection`, OG `website`
+   * - `concept` / `field` / `institution` / `event`: `Thing`, OG `website`
+   */
+  entityType: 'research' | 'author' | 'collection' | 'concept' | 'field' | 'institution' | 'event';
+  /** Authors for scholarly artifacts (name only is fine). */
+  authors?: string[];
+  /** Publication date (ISO 8601). */
+  publishedDate?: string;
+  /** Journal / venue title for scholarly artifacts. */
+  journalTitle?: string;
+  /** URL to the full-text PDF when available. */
+  pdfUrl?: string;
+  /** External identifiers (DOI, arXiv, ORCID, ROR, ISBN, PMID, etc.). */
+  externalIds?: EntityExternalId[];
+  /** Handle for author pages (e.g., `alice.bsky.social`). */
+  authorHandle?: string;
+}
+
+/**
+ * Builds the Next.js `Metadata` object for an entity page.
+ *
+ * @remarks
+ * Covers OpenGraph, Twitter card, canonical URL, and keywords. Does NOT
+ * cover `<link rel="alternate">` or `citation_*` tags — those are emitted
+ * as raw HTML via {@link renderEntityHeadTags}.
+ *
+ * @param input - Entity metadata input
+ * @returns Next.js `Metadata` object
+ *
+ * @public
+ */
+export function buildEntityMetadata(input: EntityMetadataInput): Metadata {
+  const ogType: 'article' | 'profile' | 'website' =
+    input.entityType === 'research'
+      ? 'article'
+      : input.entityType === 'author'
+        ? 'profile'
+        : 'website';
+
+  const metadata: Metadata = {
+    title: input.title,
+    description: input.description,
+    alternates: {
+      canonical: input.canonicalUrl,
+    },
+    openGraph: {
+      title: input.title,
+      description: input.description,
+      type: ogType,
+      url: input.canonicalUrl,
+      siteName: 'Chive',
+      images: input.ogImageUrl
+        ? [
+            {
+              url: input.ogImageUrl,
+              width: 1200,
+              height: 630,
+              alt: input.title,
+            },
+          ]
+        : undefined,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: input.title,
+      description: input.description,
+      images: input.ogImageUrl ? [input.ogImageUrl] : undefined,
+    },
+  };
+
+  if (input.authors && input.authors.length > 0 && metadata.openGraph) {
+    (metadata.openGraph as { authors?: string[] }).authors = input.authors;
+  }
+  if (input.publishedDate && metadata.openGraph) {
+    (metadata.openGraph as { publishedTime?: string }).publishedTime = input.publishedDate;
+  }
+
+  return metadata;
+}
+
+/**
+ * Builds the collection of raw `<meta>` / `<link>` / `<script>` tag
+ * descriptors that `generateMetadata` cannot express but that the entity
+ * page should render into `<head>`.
+ *
+ * @remarks
+ * Call sites render these via a small component:
+ *
+ * ```tsx
+ * {renderEntityHeadTags(descriptors).map((t, i) => <EntityHeadTag key={i} {...t} />)}
+ * ```
+ *
+ * Emitted tags:
+ *
+ * - `<link rel="alternate" type="application/at-uri" href="...">` —
+ *   Wes/Semble convention for AT-URI aggregation.
+ * - `<link rel="alternate" href="https://doi.org/...">` — canonical DOI
+ *   resolver link so Semble / Citoid / Zotero can aggregate by DOI.
+ * - `<link rel="alternate" href="https://orcid.org/...">` etc.
+ * - `<meta name="citation_title">` family (Highwire / Zotero convention).
+ * - `<script type="application/ld+json">` — Schema.org JSON-LD.
+ *
+ * @param input - Entity metadata input
+ * @returns Array of tag descriptors
+ *
+ * @public
+ */
+export function buildEntityHeadTags(input: EntityMetadataInput): EntityHeadTag[] {
+  const tags: EntityHeadTag[] = [];
+
+  // 1. `<link rel="alternate">` for AT-URI aggregation (Wes/Semble convention)
+  tags.push({
+    kind: 'link',
+    rel: 'alternate',
+    type: 'application/at-uri',
+    href: input.atUri,
+  });
+
+  // 2. `<link rel="alternate">` for each external identifier (DOI, ORCID, etc.)
+  for (const ext of input.externalIds ?? []) {
+    const href = ext.uri ?? canonicalExternalIdUrl(ext.system, ext.identifier);
+    if (!href) continue;
+    tags.push({
+      kind: 'link',
+      rel: 'alternate',
+      href,
+      title: `${ext.system.toUpperCase()}: ${ext.identifier}`,
+    });
+  }
+
+  // 3. Highwire `citation_*` meta tags (scholarly)
+  if (input.entityType === 'research') {
+    tags.push({ kind: 'meta', name: 'citation_title', content: input.title });
+    for (const author of input.authors ?? []) {
+      tags.push({ kind: 'meta', name: 'citation_author', content: author });
+    }
+    if (input.publishedDate) {
+      const date = new Date(input.publishedDate);
+      if (!isNaN(date.getTime())) {
+        const yyyy = date.getUTCFullYear();
+        const mm = String(date.getUTCMonth() + 1).padStart(2, '0');
+        const dd = String(date.getUTCDate()).padStart(2, '0');
+        tags.push({
+          kind: 'meta',
+          name: 'citation_publication_date',
+          content: `${yyyy}/${mm}/${dd}`,
+        });
+      }
+    }
+    const doi = input.externalIds?.find((id) => id.system === 'doi')?.identifier;
+    if (doi) {
+      tags.push({ kind: 'meta', name: 'citation_doi', content: doi });
+    }
+    const arxiv = input.externalIds?.find((id) => id.system === 'arxiv')?.identifier;
+    if (arxiv) {
+      tags.push({ kind: 'meta', name: 'citation_arxiv_id', content: arxiv });
+    }
+    const pmid = input.externalIds?.find((id) => id.system === 'pmid')?.identifier;
+    if (pmid) {
+      tags.push({ kind: 'meta', name: 'citation_pmid', content: pmid });
+    }
+    if (input.journalTitle) {
+      tags.push({ kind: 'meta', name: 'citation_journal_title', content: input.journalTitle });
+    }
+    tags.push({
+      kind: 'meta',
+      name: 'citation_abstract_html_url',
+      content: input.canonicalUrl,
+    });
+    if (input.pdfUrl) {
+      tags.push({ kind: 'meta', name: 'citation_pdf_url', content: input.pdfUrl });
+    }
+  }
+
+  // 4. Schema.org JSON-LD
+  tags.push({
+    kind: 'script',
+    type: 'application/ld+json',
+    content: JSON.stringify(buildSchemaOrg(input)),
+  });
+
+  return tags;
+}
+
+/**
+ * Tag descriptor emitted by {@link buildEntityHeadTags}.
+ *
+ * @public
+ */
+export type EntityHeadTag =
+  | {
+      kind: 'link';
+      rel: string;
+      type?: string;
+      href: string;
+      title?: string;
+    }
+  | {
+      kind: 'meta';
+      name: string;
+      content: string;
+    }
+  | {
+      kind: 'script';
+      type: 'application/ld+json';
+      content: string;
+    };
+
+/**
+ * Derives a canonical resolver URL for a known external-ID system.
+ *
+ * @internal
+ */
+function canonicalExternalIdUrl(system: string, identifier: string): string | undefined {
+  switch (system) {
+    case 'doi':
+      return `https://doi.org/${identifier}`;
+    case 'arxiv':
+      return `https://arxiv.org/abs/${identifier}`;
+    case 'orcid':
+      return `https://orcid.org/${identifier}`;
+    case 'ror':
+      return `https://ror.org/${identifier}`;
+    case 'isbn':
+      return `https://www.worldcat.org/isbn/${identifier}`;
+    case 'pmid':
+      return `https://pubmed.ncbi.nlm.nih.gov/${identifier}`;
+    case 'wikidata':
+      return `https://www.wikidata.org/wiki/${identifier}`;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Builds a Schema.org JSON-LD object for the entity.
+ *
+ * @internal
+ */
+function buildSchemaOrg(input: EntityMetadataInput): Record<string, unknown> {
+  const ldType =
+    input.entityType === 'research'
+      ? 'ScholarlyArticle'
+      : input.entityType === 'author'
+        ? 'Person'
+        : input.entityType === 'collection'
+          ? 'Collection'
+          : 'Thing';
+
+  const base: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': ldType,
+    name: input.title,
+    url: input.canonicalUrl,
+  };
+
+  if (input.description) base.description = input.description;
+  if (input.ogImageUrl) base.image = input.ogImageUrl;
+
+  if (input.entityType === 'research') {
+    if (input.authors && input.authors.length > 0) {
+      base.author = input.authors.map((name) => ({ '@type': 'Person', name }));
+    }
+    if (input.publishedDate) base.datePublished = input.publishedDate;
+    const doi = input.externalIds?.find((id) => id.system === 'doi')?.identifier;
+    if (doi) {
+      base.identifier = [
+        {
+          '@type': 'PropertyValue',
+          propertyID: 'doi',
+          value: doi,
+          url: `https://doi.org/${doi}`,
+        },
+      ];
+    }
+    if (input.journalTitle) {
+      base.isPartOf = {
+        '@type': 'Periodical',
+        name: input.journalTitle,
+      };
+    }
+  } else if (input.entityType === 'author' && input.authorHandle) {
+    base.alternateName = `@${input.authorHandle}`;
+  }
+
+  return base;
+}


### PR DESCRIPTION
## Summary

Rework of the Chive↔Semble integration, grounded in Chive's native knowledge-graph architecture. Fixes all four issues surfaced during testing, and addresses the underlying design gaps they revealed.

**Critical bug fix:** edges created in the collection wizard are now actually dual-written to Semble as `network.cosmik.connection` records. The previous integration had a bug where `values.edges` was never passed to `createCosmikMirror`; additionally, there was no dual-write path for edges added, updated, or deleted after mirror creation.

## Phases

### 1. Connection type mapping via knowledge graph

Chive relation types are graph nodes (`kind: 'type', subkind: 'relation'`). Their existing `externalIds` array — already used for SKOS/Wikidata mappings — now also carries Cosmik connection-type values (system: `"cosmik"`). A small frontend resolver (`web/lib/atproto/relation-resolver.ts`) reads `externalIds` on the relation node and emits the declared value as `connectionType`. No code-level enum; the knowledge graph is self-describing.

- Added `cosmik`, `skos`, `schema-org`, `dublin-core` to `externalId.system.knownValues`
- Seeded ~20 curated academic relations (`cites`, `builds-on`, `contradicts`, `supports`, `supplements`, `explains`, etc.) with Cosmik mappings and CiTO URIs
- Extended `listNodes` with `externalIdSystem`/`externalIdIdentifier` filters so incoming Cosmik connections can be reverse-resolved to Chive relations
- Personal relations get an optional "Semble connection type" field in the wizard's new-relation form

### 2. Edge dual-write parity

`syncEdgeToCosmik(agent, action, input)` is now wired into every inter-item edge CRUD path:

- Initial wizard creation → connections are emitted alongside cards
- `useCreatePersonalEdge` → dual-writes when the edge sits inside a mirrored collection
- `useRemoveFromCollection` → deletes orphan connections via `deleteCosmikConnectionsForItem`
- `useRepairCosmikMirror` (new) + "Repair mirror" button on the collection detail page → reconciles existing mirrors (creates missing connections, prunes orphans)

Orphan hooks `useCreateCosmikConnection` / `useDeleteCosmikConnection` removed — connection CRUD flows through edge CRUD only.

### 3. Card metadata enrichment

`buildSembleCardMetadata` now populates `doi`, `isbn`, `author`, `description`, `publishedDate`, `imageUrl`, `type` (research/link) per subkind. Eprint search hits propagate abstract + authors + date; graph node picks carry through `externalIds`.

### 4. Server-rendered metadata + canonical external-ID routes

Chive pages now emit full metadata for Citoid/Zotero/Semble scraping:

- `<link rel="alternate" type="application/at-uri" href="at://...">` (Wes/Semble AT-URI aggregation convention)
- `<link rel="alternate" href="https://doi.org/...">` for each external ID
- Highwire `citation_*` meta tags (Citoid scraping)
- Schema.org JSON-LD (`ScholarlyArticle`, `Person`, etc.)

New canonical external-ID routes: `/doi/<doi>`, `/arxiv/<id>`, `/orcid/<id>`, `/ror/<id>`, `/pmid/<id>`, `/isbn/<id>`. Each 302s to the Chive entity declaring that identifier via the new `pub.chive.resolve.byExternalId` XRPC endpoint.

Shared helper: `web/lib/metadata/entity-metadata.ts`.

### 5. Chive-native collaboration

New `pub.chive.collaboration.*` lexicons — generic over any Chive-authored subject record (collections in v1; eprints and reviews later with no schema changes):

- `invite.json` — lives in subject-author's PDS
- `inviteAcceptance.json` — lives in invitee's PDS
- `listInvites.json`, `listCollaborators.json` — XRPC queries

New service (`CollaborationService`), AppView plugin, invite/accept indexing in the event processor, invitation inbox page (`/invitations`), invite picker in the wizard's Semble step. Active collaborators are derived from `(non-deleted invite) ∧ (non-deleted acceptance)` — mirroring the governance consensus model. Out-of-order firehose delivery handled via `collaboration_pending_state`.

Active-collaborator DIDs are translated to Semble's `network.cosmik.collection.collaborators[]` array at mirror creation; subsequent invite/accept events will be synced in a follow-up once Semble's scoped-collaboration UI lands (per Wes).

### 6. Firehose plugin bridge

The previous PR's cosmik/margin plugins were effectively dead code — never loaded, never receiving events. Now:

- Indexer subscribes Jetstream to `network.cosmik.*` and `at.margin.*` in addition to `pub.chive.*`
- Event processor bridges non-chive records to the plugin eventBus
- `CosmikBacklinksPlugin`, `CosmikConnectionsPlugin`, `CosmikFollowsPlugin`, `CosmikLinkRemovalsPlugin`, and the four Margin plugins are loaded with backlink/collection/node service context
- `CosmikConnectionsPlugin` reverse-resolves `connectionType` to Chive relation slugs via `NodeService.findRelationByExternalId` and indexes into `cosmik_connections_index` with both the raw Cosmik type and the resolved Chive slug

### 7. Eprint search

Out of scope for this PR (requires staging ES inspection). Separate issue to file.

### 8. Tests

- `CollaborationService` unit tests (7 tests, all passing): indexInvite, isCollaborator, getActiveCollaborators, deleteInvite, out-of-order delivery
- Existing 4000+ unit tests pass

## Write-authority philosophy

Unified model for both governance and collaboration: write authority follows data ownership, cross-party coordination is expressed as records in each party's own PDS, the AppView computes derived state. Documented in the plan file.

## Lexicon additions

- `pub.chive.collaboration.invite`
- `pub.chive.collaboration.inviteAcceptance`
- `pub.chive.collaboration.listInvites`
- `pub.chive.collaboration.listCollaborators`
- `pub.chive.resolve.byExternalId`
- Extended `pub.chive.graph.node` `externalId.system` and `listNodes` filters

## Migrations

- `1741300000000_cosmik-relation-slug`: adds `chive_relation_slug` / `chive_relation_uri` to `cosmik_connections_index`
- `1741400000000_collaboration`: invites/acceptances indexes, pending-state table, pending collection-edges table

## Test plan

- [ ] Migration dry-run
- [ ] Edge create/edit/delete cycle on a mirrored collection — verify connections in PDS
- [ ] Owner "Repair mirror" button on an existing un-synced mirror
- [ ] Create collection with invites — verify `pub.chive.collaboration.invite` records
- [ ] Invitee accept flow from `/invitations` page
- [ ] DOI resolver: `/doi/10.22541/essoar.176538364.45030502/v1` → correct entity
- [ ] `<link rel="alternate">` tags visible on eprint pages
- [ ] Citoid scrape returns rich CSL JSON for a Chive eprint
- [ ] Ronen re-runs his original test