### PR TITLE
Enable granular ATProto OAuth scopes

### DIFF
--- a/lexicons/pub/chive/auth/authorAccess.json
+++ b/lexicons/pub/chive/auth/authorAccess.json
@@ -51,7 +51,22 @@
         {
           "type": "permission",
           "resource": "repo",
+          "collection": "pub.chive.actor.mute"
+        },
+        {
+          "type": "permission",
+          "resource": "repo",
           "collection": "pub.chive.discovery.settings"
+        },
+        {
+          "type": "permission",
+          "resource": "repo",
+          "collection": "pub.chive.collaboration.invite"
+        },
+        {
+          "type": "permission",
+          "resource": "repo",
+          "collection": "pub.chive.collaboration.inviteAcceptance"
         },
         {
           "type": "permission",
@@ -202,6 +217,16 @@
           "type": "permission",
           "resource": "rpc",
           "lxm": "pub.chive.discovery.recordInteraction"
+        },
+        {
+          "type": "permission",
+          "resource": "rpc",
+          "lxm": "pub.chive.collaboration.listInvites"
+        },
+        {
+          "type": "permission",
+          "resource": "rpc",
+          "lxm": "pub.chive.collaboration.listCollaborators"
         }
       ]
     }

--- a/src/auth/scopes/chive-scopes.ts
+++ b/src/auth/scopes/chive-scopes.ts
@@ -27,6 +27,7 @@ export const REPO_SCOPES = {
   // Actor collections
   ACTOR_PROFILE: 'repo:pub.chive.actor.profile',
   ACTOR_PROFILE_CONFIG: 'repo:pub.chive.actor.profileConfig',
+  ACTOR_MUTE: 'repo:pub.chive.actor.mute',
 
   // Discovery collections
   DISCOVERY_SETTINGS: 'repo:pub.chive.discovery.settings',
@@ -46,6 +47,10 @@ export const REPO_SCOPES = {
   GRAPH_VOTE: 'repo:pub.chive.graph.vote',
   GRAPH_NODE: 'repo:pub.chive.graph.node',
   GRAPH_EDGE: 'repo:pub.chive.graph.edge',
+
+  // Collaboration collections
+  COLLABORATION_INVITE: 'repo:pub.chive.collaboration.invite',
+  COLLABORATION_INVITE_ACCEPTANCE: 'repo:pub.chive.collaboration.inviteAcceptance',
 } as const;
 
 /**
@@ -56,12 +61,26 @@ export const REPO_SCOPES = {
  * as individual scopes alongside the Chive permission sets.
  */
 export const EXTERNAL_REPO_SCOPES = {
+  // Bluesky
   BLUESKY_POST: 'repo:app.bsky.feed.post',
   BLUESKY_PROFILE: 'repo:app.bsky.actor.profile',
+
+  // Standard (site.standard)
   STANDARD_DOCUMENT: 'repo:site.standard.document',
+
+  // Semble (network.cosmik)
   COSMIK_CARD: 'repo:network.cosmik.card',
-  COSMIK_COLLECTION_LINK: 'repo:network.cosmik.collectionLink',
   COSMIK_COLLECTION: 'repo:network.cosmik.collection',
+  COSMIK_COLLECTION_LINK: 'repo:network.cosmik.collectionLink',
+  COSMIK_COLLECTION_LINK_REMOVAL: 'repo:network.cosmik.collectionLinkRemoval',
+  COSMIK_CONNECTION: 'repo:network.cosmik.connection',
+  COSMIK_FOLLOW: 'repo:network.cosmik.follow',
+
+  // Margin (at.margin)
+  MARGIN_ANNOTATION: 'repo:at.margin.annotation',
+  MARGIN_BOOKMARK: 'repo:at.margin.bookmark',
+  MARGIN_REPLY: 'repo:at.margin.reply',
+  MARGIN_LIKE: 'repo:at.margin.like',
 } as const;
 
 /** Blob scopes for file uploads. */

--- a/tests/unit/auth/scopes/chive-scopes.test.ts
+++ b/tests/unit/auth/scopes/chive-scopes.test.ts
@@ -56,8 +56,9 @@ describe('chive-scopes', () => {
       }
     });
 
-    it('covers exactly nineteen collections', () => {
-      expect(Object.keys(REPO_SCOPES)).toHaveLength(19);
+    it('covers all pub.chive.* collections that the app writes to', () => {
+      // 19 original + actor.mute + collaboration.invite + collaboration.inviteAcceptance
+      expect(Object.keys(REPO_SCOPES)).toHaveLength(22);
     });
   });
 
@@ -85,8 +86,9 @@ describe('chive-scopes', () => {
       }
     });
 
-    it('covers exactly six external collections', () => {
-      expect(Object.keys(EXTERNAL_REPO_SCOPES)).toHaveLength(6);
+    it('covers all external namespace collections that the app writes to', () => {
+      // 2 Bluesky + 1 Standard + 6 Cosmik + 4 Margin = 13
+      expect(Object.keys(EXTERNAL_REPO_SCOPES)).toHaveLength(13);
     });
   });
 

--- a/web/app/oauth/client-metadata.json/route.ts
+++ b/web/app/oauth/client-metadata.json/route.ts
@@ -47,9 +47,29 @@ export async function GET(request: NextRequest) {
     // Response types this client uses
     response_types: ['code'],
 
-    // Scopes this client requests
-    // TODO: Re-enable granular permission sets when PDS support lands
-    scope: 'atproto transition:generic',
+    // Maximum set of scopes this client may request.
+    // Individual login flows request subsets via getScopesForIntent().
+    // Includes transition:generic for backward compatibility with PDSes
+    // that don't yet support granular permission sets.
+    scope: [
+      'atproto',
+      'transition:generic',
+      'include:pub.chive.auth.fullAccess',
+      'repo:app.bsky.feed.post',
+      'repo:app.bsky.actor.profile',
+      'repo:site.standard.document',
+      'repo:network.cosmik.card',
+      'repo:network.cosmik.collection',
+      'repo:network.cosmik.collectionLink',
+      'repo:network.cosmik.collectionLinkRemoval',
+      'repo:network.cosmik.connection',
+      'repo:network.cosmik.follow',
+      'repo:at.margin.annotation',
+      'repo:at.margin.bookmark',
+      'repo:at.margin.reply',
+      'repo:at.margin.like',
+      'blob:*/*',
+    ].join(' '),
 
     // DPoP (Demonstrating Proof of Possession) - required by ATProto
     dpop_bound_access_tokens: true,

--- a/web/lib/auth/auth-context.tsx
+++ b/web/lib/auth/auth-context.tsx
@@ -35,6 +35,7 @@ import {
   initializeOAuth,
   restoreSession,
   getCurrentAgent,
+  getSessionScopes,
   setE2EMockAgent,
 } from './oauth-client';
 import { clearServiceAuthTokens, getServiceAuthToken } from './service-auth';
@@ -224,7 +225,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
               accessToken: '',
               refreshToken: '',
               expiresAt: 0,
-              scope: ['atproto', 'transition:generic'],
+              scope: await getSessionScopes(callbackResult.session),
             },
             error: null,
           });
@@ -267,7 +268,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
               accessToken: '',
               refreshToken: '',
               expiresAt: 0,
-              scope: ['atproto', 'transition:generic'],
+              scope: await getSessionScopes(restoredSession.session),
             },
             error: null,
           });

--- a/web/lib/auth/oauth-client.ts
+++ b/web/lib/auth/oauth-client.ts
@@ -271,10 +271,11 @@ export async function startLogin(options: LoginOptions): Promise<string> {
   const client = await getOAuthClient();
 
   try {
-    // TODO: Re-enable granular scopes when PDS support for permission sets lands
-    // const granularScope = getScopesForIntent(intent);
-    // const scope = `${granularScope} transition:generic`;
-    const scope = 'atproto transition:generic';
+    // Request granular scopes based on the user's intent, plus
+    // transition:generic for backward compatibility with PDSes that
+    // don't yet support granular permission sets.
+    const granularScope = getScopesForIntent(intent);
+    const scope = `${granularScope} transition:generic blob:*/*`;
 
     const url = await client.authorize(handle, { scope });
 
@@ -403,6 +404,24 @@ async function tryRestoreAnySession(client: BrowserOAuthClient): Promise<OAuthSe
  * @returns PDS endpoint URL string
  * @throws Error if session has no server information
  */
+/**
+ * Extracts the granted scope strings from an OAuth session.
+ *
+ * @param session - The authenticated OAuth session
+ * @returns Array of individual scope strings
+ */
+export async function getSessionScopes(session: OAuthSession): Promise<string[]> {
+  try {
+    const tokenInfo = await session.getTokenInfo(false);
+    if (tokenInfo.scope) {
+      return String(tokenInfo.scope).split(' ').filter(Boolean);
+    }
+  } catch {
+    // Fall back to legacy scopes if token info is unavailable
+  }
+  return ['atproto', 'transition:generic'];
+}
+
 function getPdsEndpoint(session: OAuthSession): string {
   const server = session.server;
 

--- a/web/lib/auth/scopes.ts
+++ b/web/lib/auth/scopes.ts
@@ -25,12 +25,26 @@ export const PERMISSION_SETS = {
  * as individual scopes alongside the Chive permission sets.
  */
 export const EXTERNAL_REPO_SCOPES = {
+  // Bluesky
   BLUESKY_POST: 'repo:app.bsky.feed.post',
   BLUESKY_PROFILE: 'repo:app.bsky.actor.profile',
+
+  // Standard (site.standard)
   STANDARD_DOCUMENT: 'repo:site.standard.document',
+
+  // Semble (network.cosmik)
   COSMIK_CARD: 'repo:network.cosmik.card',
-  COSMIK_COLLECTION_LINK: 'repo:network.cosmik.collectionLink',
   COSMIK_COLLECTION: 'repo:network.cosmik.collection',
+  COSMIK_COLLECTION_LINK: 'repo:network.cosmik.collectionLink',
+  COSMIK_COLLECTION_LINK_REMOVAL: 'repo:network.cosmik.collectionLinkRemoval',
+  COSMIK_CONNECTION: 'repo:network.cosmik.connection',
+  COSMIK_FOLLOW: 'repo:network.cosmik.follow',
+
+  // Margin (at.margin)
+  MARGIN_ANNOTATION: 'repo:at.margin.annotation',
+  MARGIN_BOOKMARK: 'repo:at.margin.bookmark',
+  MARGIN_REPLY: 'repo:at.margin.reply',
+  MARGIN_LIKE: 'repo:at.margin.like',
 } as const;
 
 /** Legacy scope for backward compatibility. */

--- a/web/tests/unit/auth/scopes.test.ts
+++ b/web/tests/unit/auth/scopes.test.ts
@@ -56,11 +56,12 @@ describe('frontend scopes', () => {
       expect(parts).toHaveLength(2);
     });
 
-    it('returns eight tokens for submit, review, and full intents', () => {
+    it('returns correct token count for submit, review, and full intents', () => {
+      // 1 (atproto) + 1 (permission set) + 13 (external repo scopes) = 15
       const intents: AuthIntent[] = ['submit', 'review', 'full'];
       for (const intent of intents) {
         const parts = getScopesForIntent(intent).split(' ');
-        expect(parts).toHaveLength(8);
+        expect(parts).toHaveLength(15);
       }
     });
 


### PR DESCRIPTION
## Summary

Enables granular ATProto permission sets and repo scopes, replacing the blanket `transition:generic` scope. The OAuth flow now requests intent-appropriate scopes (browse/submit/review/full) with all record collections the app writes to declared: `pub.chive.*`, `network.cosmik.*`, `at.margin.*`, `site.standard.*`, and `app.bsky.*`. `transition:generic` is still included alongside granular scopes for backward compatibility with PDSes that don't yet support permission sets.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

- Unit tests for scope definitions updated and passing (29/29)
- TypeScript compilation passes for both frontend and backend
- `transition:generic` fallback ensures existing sessions continue to work

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [ ] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes