### PR TITLE
Authenticate and scope listInvites to the caller

### DIFF
--- a/src/api/handlers/xrpc/collaboration/listInvites.ts
+++ b/src/api/handlers/xrpc/collaboration/listInvites.ts
@@ -1,6 +1,15 @@
 /**
  * XRPC handler for pub.chive.collaboration.listInvites.
  *
+ * @remarks
+ * Authorization: requires authentication and scopes the result to invites
+ * the caller is a party to. The query must satisfy at least one of:
+ * - `invitee` equals the caller's DID (inbox view)
+ * - `inviter` equals the caller's DID (sent dashboard)
+ * - `subjectUri` is authored by the caller (subject owner viewing invites)
+ *
+ * Without this gate, anyone could enumerate invites for any DID or subject.
+ *
  * @packageDocumentation
  * @public
  */
@@ -10,6 +19,7 @@ import type {
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/collaboration/listInvites.js';
 import type { AtUri, DID } from '../../../../types/atproto.js';
+import { AuthenticationError, AuthorizationError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 /** Re-exported params. */
@@ -19,22 +29,51 @@ export type ListInvitesParams = QueryParams;
 export type ListInvitesOutput = OutputSchema;
 
 /**
+ * Extracts the authoring DID from an AT-URI's authority component.
+ */
+function authorityFromAtUri(uri: string): string | null {
+  const match = /^at:\/\/([^/]+)\//.exec(uri);
+  return match?.[1] ?? null;
+}
+
+/**
  * XRPC method for pub.chive.collaboration.listInvites query.
  *
  * @public
  */
 export const listInvites: XRPCMethod<QueryParams, void, OutputSchema> = {
-  auth: 'optional',
+  auth: true,
   handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
     const { collaborationService } = c.get('services');
+    const user = c.get('user');
+
+    if (!user) {
+      throw new AuthenticationError('Authentication required');
+    }
+
+    const inviteeParam = params.invitee as DID | undefined;
+    const inviterParam = params.inviter as DID | undefined;
+    const subjectUriParam = params.subjectUri as AtUri | undefined;
+
+    const isInviteeMe = inviteeParam !== undefined && inviteeParam === user.did;
+    const isInviterMe = inviterParam !== undefined && inviterParam === user.did;
+    const isSubjectMine =
+      subjectUriParam !== undefined && authorityFromAtUri(subjectUriParam) === user.did;
+
+    if (!isInviteeMe && !isInviterMe && !isSubjectMine) {
+      throw new AuthorizationError(
+        'Query must be scoped to the caller (invitee, inviter, or subject owner)'
+      );
+    }
+
     if (!collaborationService) {
       return { encoding: 'application/json', body: { invites: [] } };
     }
 
     const result = await collaborationService.listInvites({
-      invitee: params.invitee as DID | undefined,
-      inviter: params.inviter as DID | undefined,
-      subjectUri: params.subjectUri as AtUri | undefined,
+      invitee: inviteeParam,
+      inviter: inviterParam,
+      subjectUri: subjectUriParam,
       subjectCollection: params.subjectCollection,
       state: params.state as 'pending' | 'accepted' | 'rejected' | 'expired' | 'all' | undefined,
       limit: params.limit,

--- a/web/lib/hooks/use-collaboration.ts
+++ b/web/lib/hooks/use-collaboration.ts
@@ -18,7 +18,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { api } from '@/lib/api/client';
+import { api, authApi } from '@/lib/api/client';
 import {
   createInviteRecord,
   deleteInviteRecord,
@@ -104,7 +104,7 @@ export function useListInvites(
   return useQuery({
     queryKey: collaborationKeys.invites(filters),
     queryFn: async (): Promise<{ invites: CollaborationInviteView[] }> => {
-      const response = await api.pub.chive.collaboration.listInvites(filters);
+      const response = await authApi.pub.chive.collaboration.listInvites(filters);
       return response.data as unknown as { invites: CollaborationInviteView[] };
     },
     enabled: options?.enabled ?? true,


### PR DESCRIPTION
## Summary

- `pub.chive.collaboration.listInvites` was `auth: 'optional'` and ignored auth context, so callers could enumerate any DID's invites or any subject's invites by passing the relevant query parameters.
- Switched to `auth: true` and added a caller-scope check: the request must satisfy at least one of `invitee = me`, `inviter = me`, or `subjectUri` authored by me. Anything else returns `AuthorizationError`.
- `useListInvites` on the frontend now uses `authApi` so the bearer token is attached.

Hardening follow-up to #80.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- \`pnpm typecheck\` passes (root + web).
- The only existing caller (\`InvitationsPanel\`) uses \`invitee = viewerDid\`, which still satisfies the gate.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings