### PR TITLE
Disable permission-sets flag on staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -147,7 +147,7 @@ jobs:
             NEXT_PUBLIC_FARO_URL=https://faro.${{ vars.STAGING_DOMAIN }}/collect
             NEXT_PUBLIC_APP_VERSION=staging-${{ env.DEPLOY_SHA }}
             NEXT_PUBLIC_CHIVE_SERVICE_DID=did:web:${{ vars.STAGING_DOMAIN }}
-            NEXT_PUBLIC_USE_PERMISSION_SETS=true
+            NEXT_PUBLIC_USE_PERMISSION_SETS=false
           cache-from: type=gha,scope=web-staging
           cache-to: type=gha,mode=max,scope=web-staging
 


### PR DESCRIPTION
## Summary

Staging is currently broken: OAuth login fails with \`OAuth \"invalid_scope\" error: Could not resolve Lexicon for NSID (pub.chive.auth.fullAccess)\`.

DNS TXT records for the four permission sets were just added (\`_lexicon.{basicReader,authorAccess,reviewerAccess,fullAccess}.auth.chive.pub\`) and the lexicon schema records are published on \`did:web:chive.pub\`, but bsky.social's resolver is still rejecting the scope. Could be DNS negative-cache (SOA TTL 300s) or a lexicon-shape validation issue I can't diagnose without seeing bsky.social's server-side error.

To unblock sign-in on staging immediately, this flips the build-time flag from \`true\` → \`false\`. Reverts to legacy \`repo:pub.chive.*\` scopes. Re-enable once we've confirmed the permission-set resolution works end-to-end (e.g., via a local @atproto/oauth test against the published lexicons).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- Pure config change in the staging deploy workflow.

## Checklist

- [x] My code follows the style guidelines of this project