### PR TITLE
Conform Margin dual-write to real lexicons; hybrid permission-set scopes

### DIFF
--- a/lexicons/permission-sets/authorAccess.json
+++ b/lexicons/permission-sets/authorAccess.json
@@ -5,7 +5,7 @@
     "main": {
       "type": "permission-set",
       "title": "Author on Chive",
-      "detail": "Submit and manage your own eprints, edit your profile, and claim authorship of papers. Includes everything in Browse Chive.",
+      "detail": "Submit and manage your own eprints (post preprints, upload PDFs and supplementary files, version them, attach citations and related work, tag them), claim authorship of existing papers, manage co-author requests, and edit your profile. Includes everything in Browse Chive.",
       "permissions": [
         {
           "type": "permission",

--- a/lexicons/permission-sets/basicReader.json
+++ b/lexicons/permission-sets/basicReader.json
@@ -5,7 +5,7 @@
     "main": {
       "type": "permission-set",
       "title": "Browse Chive",
-      "detail": "Read eprints, reviews, endorsements, authors, and the public knowledge graph.",
+      "detail": "Read eprints (open-access scholarly preprints and their associated reviews, endorsements, citations, and tags), browse author profiles, and explore the community knowledge graph of fields and authority records.",
       "permissions": [
         {
           "type": "permission",

--- a/lexicons/permission-sets/fullAccess.json
+++ b/lexicons/permission-sets/fullAccess.json
@@ -5,7 +5,7 @@
     "main": {
       "type": "permission-set",
       "title": "Full Access to Chive",
-      "detail": "All Chive operations including knowledge-graph governance: propose fields, vote on proposals, and contribute personal graph nodes and edges. Includes everything in Review.",
+      "detail": "Submit, review, and curate eprints (preprints) on Chive, plus participate in knowledge-graph governance: propose new fields and authority records, vote on community proposals, and contribute personal graph nodes and edges. Includes everything in Review (which includes Author and Browse).",
       "permissions": [
         {
           "type": "permission",

--- a/lexicons/permission-sets/reviewerAccess.json
+++ b/lexicons/permission-sets/reviewerAccess.json
@@ -5,7 +5,7 @@
     "main": {
       "type": "permission-set",
       "title": "Review on Chive",
-      "detail": "Create reviews, endorsements, and inline annotations on eprints. Includes everything in Author.",
+      "detail": "Post peer reviews, endorsements, and inline PDF annotations on other authors' eprints. Includes everything in Author (submitting and managing your own eprints).",
       "permissions": [
         {
           "type": "permission",

--- a/src/auth/scopes/chive-scopes.ts
+++ b/src/auth/scopes/chive-scopes.ts
@@ -54,33 +54,34 @@ export const REPO_SCOPES = {
 } as const;
 
 /**
- * Repo scopes for external namespaces that Chive cross-posts to.
+ * External-namespace scopes for cross-posting and cooperating apps.
  *
  * @remarks
- * These are outside the pub.chive.* namespace and must be requested
- * as individual scopes alongside the Chive permission sets.
+ * Where the cooperating app publishes a `permission-set` lexicon (Margin,
+ * site.standard), we prefer `include:<nsid>` so the consent screen renders
+ * one named entry with publisher-authored copy. For Semble the published
+ * `network.cosmik.authFull` set is missing two collections (`connection`,
+ * `follow`) that Chive writes, so we use a hybrid: include + supplementary
+ * repo scopes for the gaps. Bluesky has no covering permission set.
  */
 export const EXTERNAL_REPO_SCOPES = {
-  // Bluesky
+  // Bluesky -- no permission set published
   BLUESKY_POST: 'repo:app.bsky.feed.post',
   BLUESKY_PROFILE: 'repo:app.bsky.actor.profile',
 
-  // Standard (site.standard)
-  STANDARD_DOCUMENT: 'repo:site.standard.document',
+  // Standard (site.standard) -- covered by the published authFull set
+  STANDARD_FULL: 'include:site.standard.authFull',
 
-  // Semble (network.cosmik)
-  COSMIK_CARD: 'repo:network.cosmik.card',
-  COSMIK_COLLECTION: 'repo:network.cosmik.collection',
-  COSMIK_COLLECTION_LINK: 'repo:network.cosmik.collectionLink',
-  COSMIK_COLLECTION_LINK_REMOVAL: 'repo:network.cosmik.collectionLinkRemoval',
+  // Semble (network.cosmik) -- authFull covers card/collection/collectionLink/
+  // collectionLinkRemoval; the two below are needed because Semble's authFull
+  // omits them.
+  COSMIK_FULL: 'include:network.cosmik.authFull',
   COSMIK_CONNECTION: 'repo:network.cosmik.connection',
   COSMIK_FOLLOW: 'repo:network.cosmik.follow',
 
-  // Margin (at.margin)
-  MARGIN_ANNOTATION: 'repo:at.margin.annotation',
-  MARGIN_BOOKMARK: 'repo:at.margin.bookmark',
-  MARGIN_REPLY: 'repo:at.margin.reply',
-  MARGIN_LIKE: 'repo:at.margin.like',
+  // Margin (at.margin) -- authFull covers note/reply/like/collection/
+  // collectionItem/profile/preferences/apikey
+  MARGIN_FULL: 'include:at.margin.authFull',
 } as const;
 
 /** Blob scopes for file uploads. */

--- a/src/auth/scopes/chive-scopes.ts
+++ b/src/auth/scopes/chive-scopes.ts
@@ -101,10 +101,10 @@ export const BLOB_SCOPES = {
  * Lexicon schemas that bundle multiple granular scopes.
  */
 export const PERMISSION_SETS = {
-  BASIC_READER: 'include:pub.chive.auth.basicReader',
-  AUTHOR_ACCESS: 'include:pub.chive.auth.authorAccess',
-  REVIEWER_ACCESS: 'include:pub.chive.auth.reviewerAccess',
-  FULL_ACCESS: 'include:pub.chive.auth.fullAccess',
+  BASIC_READER: 'include:pub.chive.basicReader',
+  AUTHOR_ACCESS: 'include:pub.chive.authorAccess',
+  REVIEWER_ACCESS: 'include:pub.chive.reviewerAccess',
+  FULL_ACCESS: 'include:pub.chive.fullAccess',
 } as const;
 
 /** Legacy scope for backward compatibility with PDSes that don't support granular scopes. */

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -34,12 +34,7 @@ import { CosmikBacklinksPlugin } from './plugins/builtin/cosmik-backlinks.js';
 import { CosmikConnectionsPlugin } from './plugins/builtin/cosmik-connections.js';
 import { CosmikFollowsPlugin } from './plugins/builtin/cosmik-follows.js';
 import { CosmikLinkRemovalsPlugin } from './plugins/builtin/cosmik-link-removals.js';
-import {
-  MarginAnnotationsPlugin,
-  MarginBookmarksPlugin,
-  MarginHighlightsPlugin,
-  MarginRepliesPlugin,
-} from './plugins/builtin/margin-annotations.js';
+import { MarginNotesPlugin, MarginRepliesPlugin } from './plugins/builtin/margin-annotations.js';
 import { registerPluginDependencies } from './plugins/core/plugin-di-helpers.js';
 import {
   getEventBus,
@@ -517,9 +512,7 @@ async function main(): Promise<void> {
 
     // Margin (W3C Web Annotation) ecosystem plugins
     try {
-      await pluginManager.loadBuiltinPlugin(new MarginAnnotationsPlugin(), pluginContext);
-      await pluginManager.loadBuiltinPlugin(new MarginHighlightsPlugin(), pluginContext);
-      await pluginManager.loadBuiltinPlugin(new MarginBookmarksPlugin(), pluginContext);
+      await pluginManager.loadBuiltinPlugin(new MarginNotesPlugin(), pluginContext);
       await pluginManager.loadBuiltinPlugin(new MarginRepliesPlugin(), pluginContext);
       logger.info('Margin ecosystem plugins loaded');
     } catch (err) {

--- a/src/plugins/builtin/margin-annotations.ts
+++ b/src/plugins/builtin/margin-annotations.ts
@@ -1,11 +1,13 @@
 /**
- * Margin annotations tracking plugin.
+ * Margin notes tracking plugin.
  *
  * @remarks
- * Tracks `at.margin.annotation`, `at.margin.highlight`, and `at.margin.bookmark`
- * records from the firehose. When these records reference Chive eprint URLs
- * (via `target.source` or `source`), this plugin creates backlinks for
- * aggregation and displays annotations alongside native Chive reviews.
+ * Tracks `at.margin.note` records (W3C Web Annotations) and `at.margin.reply`
+ * records from the firehose. The `motivation` field on a note distinguishes
+ * commenting / highlighting / bookmarking / etc. -- there are no separate
+ * collections for those concepts. When a note's `target.source` references a
+ * Chive eprint URL (or AT URI), this plugin creates a backlink so the
+ * annotation appears alongside native Chive reviews.
  *
  * Margin implements the W3C Web Annotation Data Model on ATProto, making it
  * a natural complement to Chive's review system.
@@ -33,7 +35,7 @@ import type { FirehoseRecord } from '../core/backlink-plugin.js';
 // =============================================================================
 
 /**
- * Margin annotation target (W3C SpecificResource).
+ * Margin note target (W3C SpecificResource).
  *
  * @internal
  */
@@ -45,219 +47,78 @@ interface MarginTarget {
 }
 
 /**
- * Margin annotation record structure.
+ * Margin note record structure (W3C web annotation).
  *
  * @internal
  */
-interface MarginAnnotation {
-  $type: 'at.margin.annotation';
+interface MarginNote {
+  $type: 'at.margin.note';
   target: MarginTarget;
+  motivation: string;
   body?: {
     value: string;
     format?: string;
   };
-  motivation?: string;
   tags?: string[];
-  createdAt: string;
-}
-
-/**
- * Margin highlight record structure.
- *
- * @internal
- */
-interface MarginHighlight {
-  $type: 'at.margin.highlight';
-  target: MarginTarget;
   color?: string;
-  tags?: string[];
-  createdAt: string;
-}
-
-/**
- * Margin bookmark record structure.
- *
- * @internal
- */
-interface MarginBookmark {
-  $type: 'at.margin.bookmark';
-  source: string;
-  sourceHash?: string;
-  title?: string;
-  description?: string;
-  tags?: string[];
   createdAt: string;
 }
 
 // =============================================================================
-// ANNOTATION PLUGIN (handles at.margin.annotation)
+// NOTES PLUGIN (handles at.margin.note for all motivations)
 // =============================================================================
 
 /**
- * Margin annotations tracking plugin.
+ * Margin notes tracking plugin.
  *
  * @remarks
- * Tracks W3C Web Annotations from Margin that reference Chive eprint URLs.
+ * Tracks W3C Web Annotations from Margin (`at.margin.note`) that reference
+ * Chive eprint URLs. Margin uses one collection for all motivation values
+ * (commenting, highlighting, bookmarking, etc.); the motivation is encoded
+ * in the per-record context string for downstream consumers that want to
+ * differentiate.
  *
  * @public
  */
-export class MarginAnnotationsPlugin extends BacklinkTrackingPlugin {
-  readonly id = 'pub.chive.plugin.margin-annotations';
+export class MarginNotesPlugin extends BacklinkTrackingPlugin {
+  readonly id = 'pub.chive.plugin.margin-notes';
 
-  readonly trackedCollection = 'at.margin.annotation';
+  readonly trackedCollection = 'at.margin.note';
 
   readonly sourceType: BacklinkSourceType = 'margin.annotation';
 
   readonly manifest: IPluginManifest = {
-    id: 'pub.chive.plugin.margin-annotations',
-    name: 'Margin Annotations',
-    version: '0.5.2',
+    id: 'pub.chive.plugin.margin-notes',
+    name: 'Margin Notes',
+    version: '0.6.2',
     description: 'Tracks W3C Web Annotations from Margin referencing Chive eprints',
     author: 'Aaron Steven White',
     license: 'MIT',
     permissions: {
-      hooks: ['firehose.at.margin.annotation'],
+      hooks: ['firehose.at.margin.note'],
       storage: {
         maxSize: 10 * 1024 * 1024,
       },
     },
-    entrypoint: 'margin-annotations.js',
+    entrypoint: 'margin-notes.js',
   };
 
   extractEprintRefs(record: unknown): string[] {
-    const annotation = record as MarginAnnotation;
+    const note = record as MarginNote;
     const refs: string[] = [];
-
-    if (annotation.target?.source && this.isChiveReference(annotation.target.source)) {
-      refs.push(annotation.target.source);
+    if (note.target?.source && this.isChiveReference(note.target.source)) {
+      refs.push(note.target.source);
     }
-
     return refs;
   }
 
   protected override extractContext(record: unknown): string | undefined {
-    const annotation = record as MarginAnnotation;
+    const note = record as MarginNote;
     const parts: string[] = [];
-    if (annotation.motivation) parts.push(annotation.motivation);
-    if (annotation.body?.value) {
-      parts.push(annotation.body.value.slice(0, 200));
-    }
+    if (note.motivation) parts.push(note.motivation);
+    if (note.color) parts.push(`color=${note.color}`);
+    if (note.body?.value) parts.push(note.body.value.slice(0, 200));
     return parts.length > 0 ? parts.join(': ') : undefined;
-  }
-
-  protected override shouldProcess(_record: unknown): boolean {
-    return true;
-  }
-
-  private isChiveReference(url: string): boolean {
-    return url.includes('chive.pub/eprints/') || this.isEprintUri(url);
-  }
-}
-
-// =============================================================================
-// HIGHLIGHT PLUGIN (handles at.margin.highlight)
-// =============================================================================
-
-/**
- * Margin highlights tracking plugin.
- *
- * @public
- */
-export class MarginHighlightsPlugin extends BacklinkTrackingPlugin {
-  readonly id = 'pub.chive.plugin.margin-highlights';
-
-  readonly trackedCollection = 'at.margin.highlight';
-
-  readonly sourceType: BacklinkSourceType = 'margin.highlight';
-
-  readonly manifest: IPluginManifest = {
-    id: 'pub.chive.plugin.margin-highlights',
-    name: 'Margin Highlights',
-    version: '0.5.2',
-    description: 'Tracks highlights from Margin on Chive eprints',
-    author: 'Aaron Steven White',
-    license: 'MIT',
-    permissions: {
-      hooks: ['firehose.at.margin.highlight'],
-      storage: {
-        maxSize: 5 * 1024 * 1024,
-      },
-    },
-    entrypoint: 'margin-highlights.js',
-  };
-
-  extractEprintRefs(record: unknown): string[] {
-    const highlight = record as MarginHighlight;
-    const refs: string[] = [];
-
-    if (highlight.target?.source && this.isChiveReference(highlight.target.source)) {
-      refs.push(highlight.target.source);
-    }
-
-    return refs;
-  }
-
-  protected override extractContext(record: unknown): string | undefined {
-    const highlight = record as MarginHighlight;
-    if (highlight.color) return `highlight (${highlight.color})`;
-    return 'highlight';
-  }
-
-  protected override shouldProcess(_record: unknown): boolean {
-    return true;
-  }
-
-  private isChiveReference(url: string): boolean {
-    return url.includes('chive.pub/eprints/') || this.isEprintUri(url);
-  }
-}
-
-// =============================================================================
-// BOOKMARK PLUGIN (handles at.margin.bookmark)
-// =============================================================================
-
-/**
- * Margin bookmarks tracking plugin.
- *
- * @public
- */
-export class MarginBookmarksPlugin extends BacklinkTrackingPlugin {
-  readonly id = 'pub.chive.plugin.margin-bookmarks';
-
-  readonly trackedCollection = 'at.margin.bookmark';
-
-  readonly sourceType: BacklinkSourceType = 'margin.bookmark';
-
-  readonly manifest: IPluginManifest = {
-    id: 'pub.chive.plugin.margin-bookmarks',
-    name: 'Margin Bookmarks',
-    version: '0.5.2',
-    description: 'Tracks bookmarks from Margin for Chive eprints',
-    author: 'Aaron Steven White',
-    license: 'MIT',
-    permissions: {
-      hooks: ['firehose.at.margin.bookmark'],
-      storage: {
-        maxSize: 5 * 1024 * 1024,
-      },
-    },
-    entrypoint: 'margin-bookmarks.js',
-  };
-
-  extractEprintRefs(record: unknown): string[] {
-    const bookmark = record as MarginBookmark;
-    const refs: string[] = [];
-
-    if (bookmark.source && this.isChiveReference(bookmark.source)) {
-      refs.push(bookmark.source);
-    }
-
-    return refs;
-  }
-
-  protected override extractContext(record: unknown): string | undefined {
-    const bookmark = record as MarginBookmark;
-    return bookmark.title || bookmark.description || undefined; // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing -- intentionally coerces empty string
   }
 
   protected override shouldProcess(_record: unknown): boolean {
@@ -367,4 +228,4 @@ export class MarginRepliesPlugin extends BacklinkTrackingPlugin {
   }
 }
 
-export { MarginAnnotationsPlugin as default };
+export { MarginNotesPlugin as default };

--- a/tests/unit/auth/scopes/chive-scopes.test.ts
+++ b/tests/unit/auth/scopes/chive-scopes.test.ts
@@ -114,10 +114,10 @@ describe('chive-scopes', () => {
 
   describe('PERMISSION_SETS', () => {
     it('defines four permission set references', () => {
-      expect(PERMISSION_SETS.BASIC_READER).toBe('include:pub.chive.auth.basicReader');
-      expect(PERMISSION_SETS.AUTHOR_ACCESS).toBe('include:pub.chive.auth.authorAccess');
-      expect(PERMISSION_SETS.REVIEWER_ACCESS).toBe('include:pub.chive.auth.reviewerAccess');
-      expect(PERMISSION_SETS.FULL_ACCESS).toBe('include:pub.chive.auth.fullAccess');
+      expect(PERMISSION_SETS.BASIC_READER).toBe('include:pub.chive.basicReader');
+      expect(PERMISSION_SETS.AUTHOR_ACCESS).toBe('include:pub.chive.authorAccess');
+      expect(PERMISSION_SETS.REVIEWER_ACCESS).toBe('include:pub.chive.reviewerAccess');
+      expect(PERMISSION_SETS.FULL_ACCESS).toBe('include:pub.chive.fullAccess');
     });
 
     it('prefixes all sets with include:', () => {
@@ -126,9 +126,13 @@ describe('chive-scopes', () => {
       }
     });
 
-    it('restricts all sets to the pub.chive.auth.* namespace', () => {
+    it('uses three-segment NSIDs so the namespace-prefix authorizes all of pub.chive.*', () => {
+      // ATProto's IncludeScope.isAllowedPermission only honors collection /
+      // lxm references that share the permission set's group prefix
+      // (everything up to its last dot). A 4-segment NSID like
+      // `pub.chive.auth.fullAccess` would only authorize `pub.chive.auth.*`.
       for (const scope of Object.values(PERMISSION_SETS)) {
-        expect(scope).toMatch(/^include:pub\.chive\.auth\./);
+        expect(scope).toMatch(/^include:pub\.chive\.[a-zA-Z]+$/);
       }
     });
 
@@ -162,7 +166,7 @@ describe('chive-scopes', () => {
       const parts = result.split(' ');
       expect(parts).toContain('atproto');
       expect(parts).toContain('transition:generic');
-      expect(parts).toContain('include:pub.chive.auth.fullAccess');
+      expect(parts).toContain('include:pub.chive.fullAccess');
     });
 
     it('deduplicates atproto if passed explicitly', () => {
@@ -207,8 +211,17 @@ describe('chive-scopes', () => {
       }
     });
 
-    it('does not emit include: permission-set references', () => {
-      expect(CLIENT_METADATA_SCOPE).not.toContain('include:');
+    it('emits include: only for cooperating apps that publish a covering permission set', () => {
+      // External-namespace permission sets (Margin, Standard.site, Semble's
+      // network.cosmik.authFull) are emitted as include: scopes so the
+      // consent screen renders one named entry per app. Chive's own
+      // scopes are still emitted as individual repo: entries.
+      const includeScopes = CLIENT_METADATA_SCOPE.split(' ').filter((p) =>
+        p.startsWith('include:')
+      );
+      for (const scope of includeScopes) {
+        expect(scope).not.toMatch(/^include:pub\.chive\./);
+      }
     });
 
     it('includes all external repo scopes', () => {

--- a/tests/unit/auth/scopes/chive-scopes.test.ts
+++ b/tests/unit/auth/scopes/chive-scopes.test.ts
@@ -63,32 +63,32 @@ describe('chive-scopes', () => {
   });
 
   describe('EXTERNAL_REPO_SCOPES', () => {
-    it('defines scopes for external namespace collections', () => {
+    it('defines scopes for external namespaces', () => {
       expect(EXTERNAL_REPO_SCOPES.BLUESKY_POST).toBe('repo:app.bsky.feed.post');
-      expect(EXTERNAL_REPO_SCOPES.STANDARD_DOCUMENT).toBe('repo:site.standard.document');
-      expect(EXTERNAL_REPO_SCOPES.COSMIK_CARD).toBe('repo:network.cosmik.card');
-      expect(EXTERNAL_REPO_SCOPES.COSMIK_COLLECTION_LINK).toBe(
-        'repo:network.cosmik.collectionLink'
-      );
-      expect(EXTERNAL_REPO_SCOPES.COSMIK_COLLECTION).toBe('repo:network.cosmik.collection');
       expect(EXTERNAL_REPO_SCOPES.BLUESKY_PROFILE).toBe('repo:app.bsky.actor.profile');
+      expect(EXTERNAL_REPO_SCOPES.STANDARD_FULL).toBe('include:site.standard.authFull');
+      expect(EXTERNAL_REPO_SCOPES.MARGIN_FULL).toBe('include:at.margin.authFull');
+      expect(EXTERNAL_REPO_SCOPES.COSMIK_FULL).toBe('include:network.cosmik.authFull');
+      expect(EXTERNAL_REPO_SCOPES.COSMIK_CONNECTION).toBe('repo:network.cosmik.connection');
+      expect(EXTERNAL_REPO_SCOPES.COSMIK_FOLLOW).toBe('repo:network.cosmik.follow');
     });
 
-    it('prefixes all scopes with repo:', () => {
+    it('prefixes all scopes with repo: or include:', () => {
       for (const scope of Object.values(EXTERNAL_REPO_SCOPES)) {
-        expect(scope).toMatch(/^repo:/);
+        expect(scope).toMatch(/^(repo|include):/);
       }
     });
 
     it('does not use the pub.chive.* namespace', () => {
       for (const scope of Object.values(EXTERNAL_REPO_SCOPES)) {
-        expect(scope).not.toMatch(/^repo:pub\.chive\./);
+        expect(scope).not.toMatch(/pub\.chive\./);
       }
     });
 
-    it('covers all external namespace collections that the app writes to', () => {
-      // 2 Bluesky + 1 Standard + 6 Cosmik + 4 Margin = 13
-      expect(Object.keys(EXTERNAL_REPO_SCOPES)).toHaveLength(13);
+    it('covers every external namespace Chive writes to', () => {
+      // 2 Bluesky repo + 1 Standard.site include + 1 Margin include
+      //   + 1 Semble include + 2 Semble repo (gaps in authFull)
+      expect(Object.keys(EXTERNAL_REPO_SCOPES)).toHaveLength(7);
     });
   });
 

--- a/tests/unit/plugins/builtin/margin-annotations.test.ts
+++ b/tests/unit/plugins/builtin/margin-annotations.test.ts
@@ -1,9 +1,10 @@
 /**
- * Unit tests for Margin annotation plugins.
+ * Unit tests for the Margin notes plugin.
  *
  * @remarks
- * Tests backlink tracking from Margin annotations, highlights, and bookmarks
- * to Chive eprints.
+ * Tests backlink tracking from Margin's `at.margin.note` records (W3C web
+ * annotations) to Chive eprints. The single collection covers commenting,
+ * highlighting, bookmarking, etc. via the W3C `motivation` field.
  *
  * @packageDocumentation
  */
@@ -11,11 +12,7 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import {
-  MarginAnnotationsPlugin,
-  MarginHighlightsPlugin,
-  MarginBookmarksPlugin,
-} from '../../../../src/plugins/builtin/margin-annotations.js';
+import { MarginNotesPlugin } from '../../../../src/plugins/builtin/margin-annotations.js';
 import type { FirehoseRecord } from '../../../../src/plugins/core/backlink-plugin.js';
 import type { ILogger } from '../../../../src/types/interfaces/logger.interface.js';
 import type {
@@ -70,7 +67,7 @@ const createMockEventBus = (): IPluginEventBus => ({
 const createMockBacklinkService = (): IBacklinkService => ({
   createBacklink: vi.fn().mockResolvedValue({
     id: 1,
-    sourceUri: 'at://did:plc:user/at.margin.annotation/abc123',
+    sourceUri: 'at://did:plc:user/at.margin.note/abc123',
     sourceType: 'margin.annotation',
     targetUri: 'at://did:plc:author/pub.chive.eprint.submission/xyz789',
     context: 'commenting: Great paper!',
@@ -102,30 +99,31 @@ const createMockContext = (overrides?: Partial<IPluginContext>): IPluginContext 
 });
 
 // ============================================================================
-// MarginAnnotationsPlugin Tests
+// MarginNotesPlugin Tests
 // ============================================================================
 
-describe('MarginAnnotationsPlugin', () => {
-  let plugin: MarginAnnotationsPlugin;
+describe('MarginNotesPlugin', () => {
+  let plugin: MarginNotesPlugin;
 
   beforeEach(() => {
-    plugin = new MarginAnnotationsPlugin();
+    plugin = new MarginNotesPlugin();
   });
 
   describe('handleFirehoseRecord', () => {
-    it('creates backlinks for annotations targeting Chive eprints', async () => {
+    it('creates a backlink for a comment targeting a Chive eprint', async () => {
       const context = createMockContext();
       await plugin.initialize(context);
 
       const backlinkService = context.config.backlinkService as IBacklinkService;
 
       const firehoseRecord: FirehoseRecord = {
-        uri: 'at://did:plc:user/at.margin.annotation/abc',
-        collection: 'at.margin.annotation',
+        uri: 'at://did:plc:user/at.margin.note/abc',
+        collection: 'at.margin.note',
         did: 'did:plc:user',
         rkey: 'abc',
         record: {
-          $type: 'at.margin.annotation',
+          $type: 'at.margin.note',
+          motivation: 'commenting',
           target: {
             source:
               'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aauthor%2Fpub.chive.eprint.submission%2Fxyz',
@@ -136,7 +134,6 @@ describe('MarginAnnotationsPlugin', () => {
             value: 'This is a well-written paper with novel results.',
             format: 'text/plain',
           },
-          motivation: 'commenting',
           createdAt: '2026-01-01T00:00:00Z',
         },
         deleted: false,
@@ -146,87 +143,27 @@ describe('MarginAnnotationsPlugin', () => {
       await plugin.handleFirehoseRecord(firehoseRecord);
 
       expect(backlinkService.createBacklink).toHaveBeenCalledWith({
-        sourceUri: 'at://did:plc:user/at.margin.annotation/abc',
+        sourceUri: 'at://did:plc:user/at.margin.note/abc',
         sourceType: 'margin.annotation',
         targetUri: expect.stringContaining('chive.pub/eprints/'),
         context: expect.stringContaining('commenting'),
       });
     });
 
-    it('handles annotation deletions', async () => {
+    it('creates a backlink for a highlight (motivation: highlighting)', async () => {
       const context = createMockContext();
       await plugin.initialize(context);
 
       const backlinkService = context.config.backlinkService as IBacklinkService;
 
       await plugin.handleFirehoseRecord({
-        uri: 'at://did:plc:user/at.margin.annotation/abc',
-        collection: 'at.margin.annotation',
+        uri: 'at://did:plc:user/at.margin.note/hl1',
+        collection: 'at.margin.note',
         did: 'did:plc:user',
-        rkey: 'abc',
-        record: null,
-        deleted: true,
-        timestamp: new Date(),
-      });
-
-      expect(backlinkService.deleteBacklink).toHaveBeenCalledWith(
-        'at://did:plc:user/at.margin.annotation/abc'
-      );
-    });
-
-    it('skips annotations targeting non-Chive URLs', async () => {
-      const context = createMockContext();
-      await plugin.initialize(context);
-
-      const backlinkService = context.config.backlinkService as IBacklinkService;
-
-      await plugin.handleFirehoseRecord({
-        uri: 'at://did:plc:user/at.margin.annotation/abc',
-        collection: 'at.margin.annotation',
-        did: 'did:plc:user',
-        rkey: 'abc',
+        rkey: 'hl1',
         record: {
-          $type: 'at.margin.annotation',
-          target: {
-            source: 'https://arxiv.org/abs/1234.5678',
-          },
-          body: { value: 'Nice paper' },
-          createdAt: '2026-01-01T00:00:00Z',
-        },
-        deleted: false,
-        timestamp: new Date(),
-      });
-
-      expect(backlinkService.createBacklink).not.toHaveBeenCalled();
-    });
-  });
-});
-
-// ============================================================================
-// MarginHighlightsPlugin Tests
-// ============================================================================
-
-describe('MarginHighlightsPlugin', () => {
-  let plugin: MarginHighlightsPlugin;
-
-  beforeEach(() => {
-    plugin = new MarginHighlightsPlugin();
-  });
-
-  describe('handleFirehoseRecord', () => {
-    it('creates backlinks for highlights on Chive eprints', async () => {
-      const context = createMockContext();
-      await plugin.initialize(context);
-
-      const backlinkService = context.config.backlinkService as IBacklinkService;
-
-      await plugin.handleFirehoseRecord({
-        uri: 'at://did:plc:user/at.margin.highlight/abc',
-        collection: 'at.margin.highlight',
-        did: 'did:plc:user',
-        rkey: 'abc',
-        record: {
-          $type: 'at.margin.highlight',
+          $type: 'at.margin.note',
+          motivation: 'highlighting',
           target: {
             source:
               'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aauthor%2Fpub.chive.eprint.submission%2Fxyz',
@@ -244,76 +181,39 @@ describe('MarginHighlightsPlugin', () => {
         timestamp: new Date(),
       });
 
-      expect(backlinkService.createBacklink).toHaveBeenCalledWith({
-        sourceUri: 'at://did:plc:user/at.margin.highlight/abc',
-        sourceType: 'margin.highlight',
-        targetUri: expect.stringContaining('chive.pub/eprints/'),
-        context: 'highlight (#ffeb3b)',
-      });
+      expect(backlinkService.createBacklink).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceUri: 'at://did:plc:user/at.margin.note/hl1',
+          targetUri: expect.stringContaining('chive.pub/eprints/'),
+          context: expect.stringContaining('highlighting'),
+        })
+      );
+      const call = (backlinkService.createBacklink as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(call?.context).toContain('#ffeb3b');
     });
-  });
-});
 
-// ============================================================================
-// MarginBookmarksPlugin Tests
-// ============================================================================
-
-describe('MarginBookmarksPlugin', () => {
-  let plugin: MarginBookmarksPlugin;
-
-  beforeEach(() => {
-    plugin = new MarginBookmarksPlugin();
-  });
-
-  describe('handleFirehoseRecord', () => {
-    it('creates backlinks for bookmarks of Chive eprints', async () => {
+    it('creates a backlink for a bookmark (motivation: bookmarking)', async () => {
       const context = createMockContext();
       await plugin.initialize(context);
 
       const backlinkService = context.config.backlinkService as IBacklinkService;
 
       await plugin.handleFirehoseRecord({
-        uri: 'at://did:plc:user/at.margin.bookmark/abc',
-        collection: 'at.margin.bookmark',
+        uri: 'at://did:plc:user/at.margin.note/bm1',
+        collection: 'at.margin.note',
         did: 'did:plc:user',
-        rkey: 'abc',
+        rkey: 'bm1',
         record: {
-          $type: 'at.margin.bookmark',
-          source:
-            'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aauthor%2Fpub.chive.eprint.submission%2Fxyz',
-          sourceHash: 'abc123',
-          title: 'Important NLP Paper',
-          description: 'A groundbreaking study on language models',
+          $type: 'at.margin.note',
+          motivation: 'bookmarking',
+          target: {
+            source:
+              'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aauthor%2Fpub.chive.eprint.submission%2Fxyz',
+            sourceHash: 'abc123',
+            title: 'Important NLP Paper',
+          },
+          body: { value: 'A groundbreaking study on language models' },
           tags: ['nlp', 'language-models'],
-          createdAt: '2026-01-01T00:00:00Z',
-        },
-        deleted: false,
-        timestamp: new Date(),
-      });
-
-      expect(backlinkService.createBacklink).toHaveBeenCalledWith({
-        sourceUri: 'at://did:plc:user/at.margin.bookmark/abc',
-        sourceType: 'margin.bookmark',
-        targetUri: expect.stringContaining('chive.pub/eprints/'),
-        context: 'Important NLP Paper',
-      });
-    });
-
-    it('uses description as context when title is missing', async () => {
-      const context = createMockContext();
-      await plugin.initialize(context);
-
-      const backlinkService = context.config.backlinkService as IBacklinkService;
-
-      await plugin.handleFirehoseRecord({
-        uri: 'at://did:plc:user/at.margin.bookmark/abc',
-        collection: 'at.margin.bookmark',
-        did: 'did:plc:user',
-        rkey: 'abc',
-        record: {
-          $type: 'at.margin.bookmark',
-          source: 'https://chive.pub/eprints/test',
-          description: 'Interesting read on semantics',
           createdAt: '2026-01-01T00:00:00Z',
         },
         deleted: false,
@@ -322,9 +222,56 @@ describe('MarginBookmarksPlugin', () => {
 
       expect(backlinkService.createBacklink).toHaveBeenCalledWith(
         expect.objectContaining({
-          context: 'Interesting read on semantics',
+          sourceUri: 'at://did:plc:user/at.margin.note/bm1',
+          context: expect.stringContaining('bookmarking'),
         })
       );
+    });
+
+    it('handles note deletions', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      await plugin.handleFirehoseRecord({
+        uri: 'at://did:plc:user/at.margin.note/abc',
+        collection: 'at.margin.note',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: null,
+        deleted: true,
+        timestamp: new Date(),
+      });
+
+      expect(backlinkService.deleteBacklink).toHaveBeenCalledWith(
+        'at://did:plc:user/at.margin.note/abc'
+      );
+    });
+
+    it('skips notes targeting non-Chive URLs', async () => {
+      const context = createMockContext();
+      await plugin.initialize(context);
+
+      const backlinkService = context.config.backlinkService as IBacklinkService;
+
+      await plugin.handleFirehoseRecord({
+        uri: 'at://did:plc:user/at.margin.note/abc',
+        collection: 'at.margin.note',
+        did: 'did:plc:user',
+        rkey: 'abc',
+        record: {
+          $type: 'at.margin.note',
+          motivation: 'commenting',
+          target: { source: 'https://arxiv.org/abs/1234.5678' },
+          body: { value: 'Nice paper' },
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        deleted: false,
+        timestamp: new Date(),
+      });
+
+      expect(backlinkService.createBacklink).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/plugins/margin-annotations.test.ts
+++ b/tests/unit/plugins/margin-annotations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the Margin annotations tracking plugins.
+ * Tests for the Margin notes tracking plugin.
  *
  * @packageDocumentation
  */
@@ -8,49 +8,45 @@ import 'reflect-metadata';
 
 import { describe, it, expect, beforeEach } from 'vitest';
 
-import {
-  MarginAnnotationsPlugin,
-  MarginHighlightsPlugin,
-  MarginBookmarksPlugin,
-} from '@/plugins/builtin/margin-annotations.js';
+import { MarginNotesPlugin } from '@/plugins/builtin/margin-annotations.js';
 
-describe('MarginAnnotationsPlugin', () => {
-  let plugin: MarginAnnotationsPlugin;
+describe('MarginNotesPlugin', () => {
+  let plugin: MarginNotesPlugin;
 
   beforeEach(() => {
-    plugin = new MarginAnnotationsPlugin();
+    plugin = new MarginNotesPlugin();
   });
 
   describe('metadata', () => {
     it('has correct plugin ID', () => {
-      expect(plugin.id).toBe('pub.chive.plugin.margin-annotations');
+      expect(plugin.id).toBe('pub.chive.plugin.margin-notes');
     });
 
-    it('tracks at.margin.annotation collection', () => {
-      expect(plugin.trackedCollection).toBe('at.margin.annotation');
+    it('tracks at.margin.note collection', () => {
+      expect(plugin.trackedCollection).toBe('at.margin.note');
     });
 
-    it('uses margin.annotation source type', () => {
+    it('uses margin.annotation source type by default', () => {
       expect(plugin.sourceType).toBe('margin.annotation');
     });
 
     it('declares correct firehose hook permission', () => {
       const hooks = plugin.manifest.permissions.hooks ?? [];
-      expect(hooks).toContain('firehose.at.margin.annotation');
+      expect(hooks).toContain('firehose.at.margin.note');
     });
   });
 
   describe('extractEprintRefs', () => {
-    it('extracts Chive eprint URL from target.source', () => {
+    it('extracts a Chive eprint URL from target.source for a comment', () => {
       const record = {
-        $type: 'at.margin.annotation',
+        $type: 'at.margin.note',
+        motivation: 'commenting',
         target: {
           source:
             'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aabc%2Fpub.chive.eprint.submission%2F123',
           sourceHash: 'abc123',
         },
         body: { value: 'Great paper!' },
-        motivation: 'commenting',
         createdAt: '2026-01-01T00:00:00Z',
       };
       const refs = plugin.extractEprintRefs(record);
@@ -58,11 +54,25 @@ describe('MarginAnnotationsPlugin', () => {
       expect(refs[0]).toContain('chive.pub/eprints/');
     });
 
-    it('extracts eprint AT-URI from target.source', () => {
+    it('extracts a Chive AT-URI from target.source for a highlight', () => {
       const record = {
-        $type: 'at.margin.annotation',
+        $type: 'at.margin.note',
+        motivation: 'highlighting',
+        target: { source: 'at://did:plc:abc/pub.chive.eprint.submission/123' },
+        color: '#ffeb3b',
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const refs = plugin.extractEprintRefs(record);
+      expect(refs).toHaveLength(1);
+    });
+
+    it('extracts a Chive URL from target.source for a bookmark', () => {
+      const record = {
+        $type: 'at.margin.note',
+        motivation: 'bookmarking',
         target: {
-          source: 'at://did:plc:abc/pub.chive.eprint.submission/123',
+          source: 'https://chive.pub/eprints/test',
+          title: 'Interesting Paper',
         },
         createdAt: '2026-01-01T00:00:00Z',
       };
@@ -72,145 +82,67 @@ describe('MarginAnnotationsPlugin', () => {
 
     it('returns empty for non-Chive URLs', () => {
       const record = {
-        $type: 'at.margin.annotation',
-        target: {
-          source: 'https://arxiv.org/abs/1234.5678',
-          sourceHash: 'def456',
-        },
+        $type: 'at.margin.note',
+        motivation: 'commenting',
+        target: { source: 'https://arxiv.org/abs/1234.5678' },
         createdAt: '2026-01-01T00:00:00Z',
       };
-      const refs = plugin.extractEprintRefs(record);
-      expect(refs).toHaveLength(0);
+      expect(plugin.extractEprintRefs(record)).toHaveLength(0);
     });
 
     it('returns empty when target.source is missing', () => {
       const record = {
-        $type: 'at.margin.annotation',
+        $type: 'at.margin.note',
+        motivation: 'commenting',
         target: {},
         createdAt: '2026-01-01T00:00:00Z',
       };
-      const refs = plugin.extractEprintRefs(record);
-      expect(refs).toHaveLength(0);
-    });
-  });
-});
-
-describe('MarginHighlightsPlugin', () => {
-  let plugin: MarginHighlightsPlugin;
-
-  beforeEach(() => {
-    plugin = new MarginHighlightsPlugin();
-  });
-
-  describe('metadata', () => {
-    it('has correct plugin ID', () => {
-      expect(plugin.id).toBe('pub.chive.plugin.margin-highlights');
-    });
-
-    it('tracks at.margin.highlight collection', () => {
-      expect(plugin.trackedCollection).toBe('at.margin.highlight');
-    });
-
-    it('uses margin.highlight source type', () => {
-      expect(plugin.sourceType).toBe('margin.highlight');
+      expect(plugin.extractEprintRefs(record)).toHaveLength(0);
     });
   });
 
-  describe('extractEprintRefs', () => {
-    it('extracts Chive URL from highlight target', () => {
+  describe('extractContext', () => {
+    it('combines motivation and body excerpt for a comment', () => {
       const record = {
-        $type: 'at.margin.highlight',
-        target: {
-          source:
-            'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aabc%2Fpub.chive.eprint.submission%2F123',
-        },
-        color: '#ffeb3b',
+        $type: 'at.margin.note',
+        motivation: 'commenting',
+        target: { source: 'https://chive.pub/eprints/test' },
+        body: { value: 'Great paper on NLP and decoder transformers' },
         createdAt: '2026-01-01T00:00:00Z',
       };
-      const refs = plugin.extractEprintRefs(record);
-      expect(refs).toHaveLength(1);
-    });
-
-    it('returns empty for non-Chive highlights', () => {
-      const record = {
-        $type: 'at.margin.highlight',
-        target: { source: 'https://example.com/article' },
-        createdAt: '2026-01-01T00:00:00Z',
-      };
-      const refs = plugin.extractEprintRefs(record);
-      expect(refs).toHaveLength(0);
-    });
-  });
-});
-
-describe('MarginBookmarksPlugin', () => {
-  let plugin: MarginBookmarksPlugin;
-
-  beforeEach(() => {
-    plugin = new MarginBookmarksPlugin();
-  });
-
-  describe('metadata', () => {
-    it('has correct plugin ID', () => {
-      expect(plugin.id).toBe('pub.chive.plugin.margin-bookmarks');
-    });
-
-    it('tracks at.margin.bookmark collection', () => {
-      expect(plugin.trackedCollection).toBe('at.margin.bookmark');
-    });
-
-    it('uses margin.bookmark source type', () => {
-      expect(plugin.sourceType).toBe('margin.bookmark');
-    });
-  });
-
-  describe('extractEprintRefs', () => {
-    it('extracts Chive URL from bookmark source', () => {
-      const record = {
-        $type: 'at.margin.bookmark',
-        source:
-          'https://chive.pub/eprints/at%3A%2F%2Fdid%3Aplc%3Aabc%2Fpub.chive.eprint.submission%2F123',
-        sourceHash: 'abc123',
-        title: 'Interesting Paper',
-        createdAt: '2026-01-01T00:00:00Z',
-      };
-      const refs = plugin.extractEprintRefs(record);
-      expect(refs).toHaveLength(1);
-    });
-
-    it('extracts eprint AT-URI from bookmark source', () => {
-      const record = {
-        $type: 'at.margin.bookmark',
-        source: 'at://did:plc:abc/pub.chive.eprint.submission/123',
-        createdAt: '2026-01-01T00:00:00Z',
-      };
-      const refs = plugin.extractEprintRefs(record);
-      expect(refs).toHaveLength(1);
-    });
-
-    it('returns empty for non-Chive bookmarks', () => {
-      const record = {
-        $type: 'at.margin.bookmark',
-        source: 'https://arxiv.org/abs/1234.5678',
-        createdAt: '2026-01-01T00:00:00Z',
-      };
-      const refs = plugin.extractEprintRefs(record);
-      expect(refs).toHaveLength(0);
-    });
-
-    it('returns context from title', () => {
-      const record = {
-        $type: 'at.margin.bookmark',
-        source: 'https://chive.pub/eprints/test',
-        title: 'Great Paper on NLP',
-        description: 'A comprehensive study',
-        createdAt: '2026-01-01T00:00:00Z',
-      };
-      // Access protected method via plugin instance cast
       const context = (
         plugin as unknown as { extractContext: (r: unknown) => string | undefined }
       ).extractContext(record);
-      expect(context).toBe('Great Paper on NLP');
+      expect(context).toContain('commenting');
+      expect(context).toContain('Great paper');
+    });
+
+    it('includes color tag for a highlight', () => {
+      const record = {
+        $type: 'at.margin.note',
+        motivation: 'highlighting',
+        target: { source: 'https://chive.pub/eprints/test' },
+        color: '#ffeb3b',
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const context = (
+        plugin as unknown as { extractContext: (r: unknown) => string | undefined }
+      ).extractContext(record);
+      expect(context).toContain('highlighting');
+      expect(context).toContain('#ffeb3b');
+    });
+
+    it('returns just the motivation for an empty bookmark', () => {
+      const record = {
+        $type: 'at.margin.note',
+        motivation: 'bookmarking',
+        target: { source: 'https://chive.pub/eprints/test' },
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      const context = (
+        plugin as unknown as { extractContext: (r: unknown) => string | undefined }
+      ).extractContext(record);
+      expect(context).toBe('bookmarking');
     });
   });
 });

--- a/web/app/oauth/client-metadata.json/route.ts
+++ b/web/app/oauth/client-metadata.json/route.ts
@@ -44,25 +44,28 @@ const CHIVE_REPO_SCOPES = [
   'repo:pub.chive.collaboration.inviteAcceptance',
 ];
 
-const EXTERNAL_REPO_SCOPES = [
-  'repo:app.bsky.feed.post',
-  'repo:app.bsky.actor.profile',
-  'repo:site.standard.document',
-  'repo:network.cosmik.card',
-  'repo:network.cosmik.collection',
-  'repo:network.cosmik.collectionLink',
-  'repo:network.cosmik.collectionLinkRemoval',
-  'repo:network.cosmik.connection',
-  'repo:network.cosmik.follow',
-  'repo:at.margin.annotation',
-  'repo:at.margin.bookmark',
-  'repo:at.margin.reply',
-  'repo:at.margin.like',
+// app.bsky.* doesn't currently publish a single permission set covering
+// posts + profile, so we keep these as repo scopes.
+const BSKY_REPO_SCOPES = ['repo:app.bsky.feed.post', 'repo:app.bsky.actor.profile'];
+
+// Each of the cooperating apps below publishes its own canonical permission
+// set, which we prefer over enumerating individual collections — the consent
+// screen renders one named entry per app instead of a wall of opaque scopes.
+const EXTERNAL_PERMISSION_SET_SCOPES = [
+  'include:network.cosmik.authFull',
+  'include:at.margin.authFull',
+  'include:site.standard.authFull',
 ];
 
 function buildScope(): string {
   const chive = USE_PERMISSION_SETS ? PERMISSION_SET_SCOPES : CHIVE_REPO_SCOPES;
-  return ['atproto', ...chive, ...EXTERNAL_REPO_SCOPES, 'blob:*/*'].join(' ');
+  return [
+    'atproto',
+    ...chive,
+    ...EXTERNAL_PERMISSION_SET_SCOPES,
+    ...BSKY_REPO_SCOPES,
+    'blob:*/*',
+  ].join(' ');
 }
 
 /**

--- a/web/app/oauth/client-metadata.json/route.ts
+++ b/web/app/oauth/client-metadata.json/route.ts
@@ -44,28 +44,34 @@ const CHIVE_REPO_SCOPES = [
   'repo:pub.chive.collaboration.inviteAcceptance',
 ];
 
-// app.bsky.* doesn't currently publish a single permission set covering
-// posts + profile, so we keep these as repo scopes.
-const BSKY_REPO_SCOPES = ['repo:app.bsky.feed.post', 'repo:app.bsky.actor.profile'];
-
-// Each of the cooperating apps below publishes its own canonical permission
-// set, which we prefer over enumerating individual collections — the consent
-// screen renders one named entry per app instead of a wall of opaque scopes.
-const EXTERNAL_PERMISSION_SET_SCOPES = [
-  'include:network.cosmik.authFull',
+// External-namespace scopes for cooperating apps.
+//
+// Hybrid layout: prefer `include:<nsid>` permission sets where they cover
+// everything Chive writes, fall back to `repo:` scopes only for gaps and for
+// apps that don't publish a permission set at all.
+//
+// - Margin: at.margin.authFull covers all of note/reply/like/collection (we
+//   migrated the dual-write to use at.margin.note for everything).
+// - Standard.site: site.standard.authFull covers document + publication +
+//   recommend + subscription. Chive only writes document; permission set
+//   is sufficient.
+// - Semble: network.cosmik.authFull covers card/collection/collectionLink/
+//   collectionLinkRemoval but OMITS connection and follow which Chive
+//   dual-writes. Supplement with repo scopes until Semble expands authFull.
+// - Bluesky: no permission set published; use repo scopes.
+const EXTERNAL_SCOPES = [
   'include:at.margin.authFull',
   'include:site.standard.authFull',
+  'include:network.cosmik.authFull',
+  'repo:network.cosmik.connection',
+  'repo:network.cosmik.follow',
+  'repo:app.bsky.feed.post',
+  'repo:app.bsky.actor.profile',
 ];
 
 function buildScope(): string {
   const chive = USE_PERMISSION_SETS ? PERMISSION_SET_SCOPES : CHIVE_REPO_SCOPES;
-  return [
-    'atproto',
-    ...chive,
-    ...EXTERNAL_PERMISSION_SET_SCOPES,
-    ...BSKY_REPO_SCOPES,
-    'blob:*/*',
-  ].join(' ');
+  return ['atproto', ...chive, ...EXTERNAL_SCOPES, 'blob:*/*'].join(' ');
 }
 
 /**

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -5419,12 +5419,19 @@ export async function createCosmikNoteCard(
 // =============================================================================
 // MARGIN ANNOTATION RECORDS (at.margin.*)
 // =============================================================================
+//
+// Margin uses a single record collection -- `at.margin.note` -- for
+// W3C-style web annotations. The `motivation` field distinguishes
+// commenting / highlighting / bookmarking / etc. There is no separate
+// `at.margin.annotation` or `at.margin.bookmark` collection on Margin's
+// AppView; earlier names that Chive used are unrecognized and were not
+// being indexed.
 
 /**
- * Margin annotation target structure (W3C SpecificResource).
+ * Margin note target structure (W3C SpecificResource).
  */
-export interface MarginAnnotationTarget {
-  $type: 'at.margin.annotation#target';
+export interface MarginNoteTarget {
+  $type: 'at.margin.note#target';
   source: string;
   sourceHash?: string;
   title?: string;
@@ -5468,10 +5475,10 @@ export type MarginSelector =
   | MarginFragmentSelector;
 
 /**
- * Margin annotation body (W3C AnnotationBody).
+ * Margin note body (W3C AnnotationBody).
  */
-export interface MarginAnnotationBody {
-  $type: 'at.margin.annotation#body';
+export interface MarginNoteBody {
+  $type: 'at.margin.note#body';
   value: string;
   format?: string;
   language?: string;
@@ -5493,16 +5500,23 @@ export type MarginMotivation =
   | 'assessing';
 
 /**
- * Margin annotation record matching `at.margin.annotation` lexicon.
+ * Margin note record matching `at.margin.note` lexicon.
+ *
+ * @remarks
+ * `motivation` is required by the upstream lexicon. Use 'commenting' or
+ * 'highlighting' for review/inline annotations, 'bookmarking' for saving
+ * a page without a body, etc.
  */
-export interface MarginAnnotationRecord {
+export interface MarginNoteRecord {
   [key: string]: unknown;
-  $type: 'at.margin.annotation';
-  target: MarginAnnotationTarget;
-  body?: MarginAnnotationBody;
-  motivation?: MarginMotivation;
+  $type: 'at.margin.note';
+  target: MarginNoteTarget;
+  motivation: MarginMotivation;
+  body?: MarginNoteBody;
   tags?: string[];
+  color?: string;
   createdAt: string;
+  modifiedAt?: string;
 }
 
 /**
@@ -5521,27 +5535,32 @@ async function computeSourceHash(url: string): Promise<string> {
 }
 
 /**
- * Creates a Margin annotation record in the user's PDS.
+ * Creates a Margin note (W3C web annotation) record in the user's PDS.
  *
  * @remarks
- * Used for dual-writing Chive reviews as W3C Web Annotations. Maps
- * review body text to annotation body, and inline selections to
- * TextQuoteSelector.
+ * Used for dual-writing Chive reviews/inline annotations as W3C Web
+ * Annotations. Maps review body text to annotation body, inline selections
+ * to a `TextQuoteSelector`. The `motivation` field controls semantics:
+ * 'commenting' for reviews, 'highlighting' for highlights, 'bookmarking'
+ * for bookmarks, 'replying' for thread replies (note that `at.margin.reply`
+ * is the canonical way to express threading -- use `motivation: replying`
+ * here only when an annotation is itself a reply target).
  *
  * @param agent - Authenticated ATProto Agent
- * @param input - Annotation data
+ * @param input - Note data
  * @returns Created record result
  */
-export async function createMarginAnnotation(
+export async function createMarginNote(
   agent: Agent,
   input: {
     sourceUrl: string;
     pageTitle?: string;
     body?: string;
     bodyFormat?: string;
-    motivation?: MarginMotivation;
+    motivation: MarginMotivation;
     selector?: MarginSelector;
     tags?: string[];
+    color?: string;
   }
 ): Promise<CreateRecordResult> {
   const did = getAgentDid(agent);
@@ -5551,8 +5570,8 @@ export async function createMarginAnnotation(
 
   const sourceHash = await computeSourceHash(input.sourceUrl);
 
-  const target: MarginAnnotationTarget = {
-    $type: 'at.margin.annotation#target',
+  const target: MarginNoteTarget = {
+    $type: 'at.margin.note#target',
     source: input.sourceUrl,
     sourceHash,
   };
@@ -5560,26 +5579,27 @@ export async function createMarginAnnotation(
   if (input.pageTitle) target.title = input.pageTitle;
   if (input.selector) target.selector = input.selector;
 
-  const record: MarginAnnotationRecord = {
-    $type: 'at.margin.annotation',
+  const record: MarginNoteRecord = {
+    $type: 'at.margin.note',
     target,
+    motivation: input.motivation,
     createdAt: new Date().toISOString(),
   };
 
   if (input.body) {
     record.body = {
-      $type: 'at.margin.annotation#body',
+      $type: 'at.margin.note#body',
       value: input.body,
       format: input.bodyFormat ?? 'text/plain',
     };
   }
 
-  if (input.motivation) record.motivation = input.motivation;
   if (input.tags && input.tags.length > 0) record.tags = input.tags.slice(0, 10);
+  if (input.color) record.color = input.color;
 
   const response = await agent.com.atproto.repo.createRecord({
     repo: did,
-    collection: 'at.margin.annotation',
+    collection: 'at.margin.note',
     record,
   });
 
@@ -5590,13 +5610,13 @@ export async function createMarginAnnotation(
 }
 
 /**
- * Deletes a Margin annotation record.
+ * Deletes a Margin note record.
  *
  * @param agent - Authenticated ATProto Agent
- * @param annotationUri - AT-URI of the annotation record
+ * @param noteUri - AT-URI of the note record
  */
-export async function deleteMarginAnnotation(agent: Agent, annotationUri: string): Promise<void> {
-  const parsed = parseAtUri(annotationUri);
+export async function deleteMarginNote(agent: Agent, noteUri: string): Promise<void> {
+  const parsed = parseAtUri(noteUri);
   if (!parsed) return;
 
   await agent.com.atproto.repo.deleteRecord({
@@ -5607,20 +5627,21 @@ export async function deleteMarginAnnotation(agent: Agent, annotationUri: string
 }
 
 /**
- * Updates a Margin annotation record.
+ * Updates a Margin note record.
  *
  * @param agent - Authenticated ATProto Agent
- * @param annotationUri - AT-URI of the annotation record
+ * @param noteUri - AT-URI of the note record
  * @param changes - Fields to update
  */
-export async function updateMarginAnnotation(
+export async function updateMarginNote(
   agent: Agent,
-  annotationUri: string,
+  noteUri: string,
   changes: {
     body?: string;
     bodyFormat?: string;
     motivation?: MarginMotivation;
     tags?: string[];
+    color?: string;
   }
 ): Promise<void> {
   const did = getAgentDid(agent);
@@ -5628,21 +5649,21 @@ export async function updateMarginAnnotation(
     throw new Error('Agent is not authenticated');
   }
 
-  const parsed = parseAtUri(annotationUri);
+  const parsed = parseAtUri(noteUri);
   if (!parsed) return;
 
   const existingResponse = await agent.com.atproto.repo.getRecord({
     repo: parsed.did,
-    collection: 'at.margin.annotation',
+    collection: 'at.margin.note',
     rkey: parsed.rkey,
   });
 
-  const existing = existingResponse.data.value as MarginAnnotationRecord;
-  const updated: MarginAnnotationRecord = { ...existing };
+  const existing = existingResponse.data.value as MarginNoteRecord;
+  const updated: MarginNoteRecord = { ...existing, modifiedAt: new Date().toISOString() };
 
   if (changes.body !== undefined) {
     updated.body = {
-      $type: 'at.margin.annotation#body',
+      $type: 'at.margin.note#body',
       value: changes.body,
       format: changes.bodyFormat ?? existing.body?.format ?? 'text/plain',
     };
@@ -5650,35 +5671,24 @@ export async function updateMarginAnnotation(
 
   if (changes.motivation !== undefined) updated.motivation = changes.motivation;
   if (changes.tags !== undefined) updated.tags = changes.tags.slice(0, 10);
+  if (changes.color !== undefined) updated.color = changes.color;
 
   await agent.com.atproto.repo.putRecord({
     repo: parsed.did,
-    collection: 'at.margin.annotation',
+    collection: 'at.margin.note',
     rkey: parsed.rkey,
     record: updated,
   });
 }
 
 /**
- * Margin bookmark record matching `at.margin.bookmark` lexicon.
- */
-export interface MarginBookmarkRecord {
-  [key: string]: unknown;
-  $type: 'at.margin.bookmark';
-  source: string;
-  sourceHash?: string;
-  title?: string;
-  description?: string;
-  tags?: string[];
-  createdAt: string;
-}
-
-/**
- * Creates a Margin bookmark record in the user's PDS.
+ * Creates a Margin bookmark in the user's PDS.
  *
- * @param agent - Authenticated ATProto Agent
- * @param input - Bookmark data
- * @returns Created record result
+ * @remarks
+ * In Margin's lexicon a bookmark is an `at.margin.note` with
+ * `motivation: 'bookmarking'`; there is no separate bookmark collection.
+ * This wrapper exists for callsite clarity; it forwards to
+ * {@link createMarginNote}, mapping `description` to a plaintext body.
  */
 export async function createMarginBookmark(
   agent: Agent,
@@ -5689,51 +5699,24 @@ export async function createMarginBookmark(
     tags?: string[];
   }
 ): Promise<CreateRecordResult> {
-  const did = getAgentDid(agent);
-  if (!did) {
-    throw new Error('Agent is not authenticated');
-  }
-
-  const sourceHash = await computeSourceHash(input.sourceUrl);
-
-  const record: MarginBookmarkRecord = {
-    $type: 'at.margin.bookmark',
-    source: input.sourceUrl,
-    sourceHash,
-    createdAt: new Date().toISOString(),
-  };
-
-  if (input.title) record.title = input.title;
-  if (input.description) record.description = input.description;
-  if (input.tags && input.tags.length > 0) record.tags = input.tags.slice(0, 10);
-
-  const response = await agent.com.atproto.repo.createRecord({
-    repo: did,
-    collection: 'at.margin.bookmark',
-    record,
+  return createMarginNote(agent, {
+    sourceUrl: input.sourceUrl,
+    pageTitle: input.title,
+    body: input.description,
+    motivation: 'bookmarking',
+    tags: input.tags,
   });
-
-  return {
-    uri: response.data.uri,
-    cid: response.data.cid,
-  };
 }
 
 /**
- * Deletes a Margin bookmark record.
+ * Deletes a Margin bookmark.
  *
- * @param agent - Authenticated ATProto Agent
- * @param bookmarkUri - AT-URI of the bookmark record
+ * @remarks
+ * Margin bookmarks live in the same `at.margin.note` collection as other
+ * annotations -- the AT-URI's collection segment encodes that.
  */
 export async function deleteMarginBookmark(agent: Agent, bookmarkUri: string): Promise<void> {
-  const parsed = parseAtUri(bookmarkUri);
-  if (!parsed) return;
-
-  await agent.com.atproto.repo.deleteRecord({
-    repo: parsed.did,
-    collection: 'at.margin.bookmark',
-    rkey: parsed.rkey,
-  });
+  return deleteMarginNote(agent, bookmarkUri);
 }
 
 /**

--- a/web/lib/auth/scopes.ts
+++ b/web/lib/auth/scopes.ts
@@ -85,17 +85,25 @@ export const CHIVE_REPO_SCOPES = {
  * post + profile, so those remain individual repo scopes.
  */
 export const EXTERNAL_REPO_SCOPES = {
-  // Bluesky (no permission set published)
+  // Bluesky -- no permission set published
   BLUESKY_POST: 'repo:app.bsky.feed.post',
   BLUESKY_PROFILE: 'repo:app.bsky.actor.profile',
 
-  // Standard (site.standard) -- includes site.standard.document and friends
+  // Standard.site -- authFull covers document, publication, graph.recommend,
+  // graph.subscription. Chive only writes document, so this is sufficient.
   STANDARD_FULL: 'include:site.standard.authFull',
 
-  // Semble (network.cosmik) -- includes card, collection, connection, follow, etc.
+  // Semble -- authFull covers card, collection, collectionLink,
+  // collectionLinkRemoval but is missing connection + follow that Chive
+  // writes. Hybrid: include + supplementary repo scopes for the gaps.
   COSMIK_FULL: 'include:network.cosmik.authFull',
+  COSMIK_CONNECTION: 'repo:network.cosmik.connection',
+  COSMIK_FOLLOW: 'repo:network.cosmik.follow',
 
-  // Margin (at.margin) -- includes annotation, bookmark, reply, like
+  // Margin -- authFull covers note/reply/like/collection/collectionItem/
+  // profile/preferences/apikey. Chive's notes write at.margin.note (W3C
+  // web annotations) for both reviews and bookmarks via the `motivation`
+  // field; replies go to at.margin.reply, likes to at.margin.like.
   MARGIN_FULL: 'include:at.margin.authFull',
 } as const;
 

--- a/web/lib/auth/scopes.ts
+++ b/web/lib/auth/scopes.ts
@@ -73,33 +73,30 @@ export const CHIVE_REPO_SCOPES = {
 } as const;
 
 /**
- * External namespace repo scopes for cross-posting.
+ * External namespace scopes for cross-posting and cooperating apps.
  *
  * @remarks
- * These are outside the pub.chive.* namespace. They must always be requested
- * as individual scopes (never inside permission sets, per ATProto spec).
+ * Each cooperating app (Semble, Margin, site.standard) publishes its own
+ * canonical `permission-set` lexicon, which we prefer over enumerating
+ * individual collections — the consent screen renders one named entry per
+ * app, with that publisher's own title and detail copy.
+ *
+ * `app.bsky.*` does not currently publish a single permission set covering
+ * post + profile, so those remain individual repo scopes.
  */
 export const EXTERNAL_REPO_SCOPES = {
-  // Bluesky
+  // Bluesky (no permission set published)
   BLUESKY_POST: 'repo:app.bsky.feed.post',
   BLUESKY_PROFILE: 'repo:app.bsky.actor.profile',
 
-  // Standard (site.standard)
-  STANDARD_DOCUMENT: 'repo:site.standard.document',
+  // Standard (site.standard) -- includes site.standard.document and friends
+  STANDARD_FULL: 'include:site.standard.authFull',
 
-  // Semble (network.cosmik)
-  COSMIK_CARD: 'repo:network.cosmik.card',
-  COSMIK_COLLECTION: 'repo:network.cosmik.collection',
-  COSMIK_COLLECTION_LINK: 'repo:network.cosmik.collectionLink',
-  COSMIK_COLLECTION_LINK_REMOVAL: 'repo:network.cosmik.collectionLinkRemoval',
-  COSMIK_CONNECTION: 'repo:network.cosmik.connection',
-  COSMIK_FOLLOW: 'repo:network.cosmik.follow',
+  // Semble (network.cosmik) -- includes card, collection, connection, follow, etc.
+  COSMIK_FULL: 'include:network.cosmik.authFull',
 
-  // Margin (at.margin)
-  MARGIN_ANNOTATION: 'repo:at.margin.annotation',
-  MARGIN_BOOKMARK: 'repo:at.margin.bookmark',
-  MARGIN_REPLY: 'repo:at.margin.reply',
-  MARGIN_LIKE: 'repo:at.margin.like',
+  // Margin (at.margin) -- includes annotation, bookmark, reply, like
+  MARGIN_FULL: 'include:at.margin.authFull',
 } as const;
 
 /** Legacy scope for backward compatibility. */

--- a/web/lib/hooks/use-collections.ts
+++ b/web/lib/hooks/use-collections.ts
@@ -58,9 +58,9 @@ import {
   createCosmikFollow,
   deleteCosmikFollow,
   createCosmikCollectionLinkRemoval,
-  createMarginAnnotation,
-  deleteMarginAnnotation,
-  updateMarginAnnotation,
+  createMarginNote,
+  deleteMarginNote,
+  updateMarginNote,
   createMarginBookmark,
   deleteMarginBookmark,
   createMarginReply,
@@ -1630,12 +1630,12 @@ export function useCreateMarginAnnotation() {
         );
       }
 
-      const result = await createMarginAnnotation(agent, {
+      const result = await createMarginNote(agent, {
         sourceUrl: input.sourceUrl,
         pageTitle: input.pageTitle,
         body: input.body,
         bodyFormat: input.bodyFormat,
-        motivation: input.motivation,
+        motivation: input.motivation ?? 'commenting',
         tags: input.tags,
       });
 

--- a/web/tests/unit/auth/scopes.test.ts
+++ b/web/tests/unit/auth/scopes.test.ts
@@ -67,10 +67,20 @@ describe('frontend scopes', () => {
       }
     });
 
-    it('does not emit include: permission-set scopes', () => {
+    it('emits include: only for cooperating-app permission sets, not for Chive scopes', () => {
+      // Chive's own scopes are emitted as repo: entries unless
+      // NEXT_PUBLIC_USE_PERMISSION_SETS=true (set per build, not per
+      // test). External-namespace permission sets (Margin, Standard.site,
+      // Semble's network.cosmik.authFull) are emitted as include: scopes
+      // so the consent screen renders one named entry per app.
       const intents: AuthIntent[] = ['browse', 'submit', 'review', 'full'];
       for (const intent of intents) {
-        expect(getScopesForIntent(intent)).not.toContain('include:');
+        const includeScopes = getScopesForIntent(intent)
+          .split(' ')
+          .filter((p) => p.startsWith('include:'));
+        for (const scope of includeScopes) {
+          expect(scope).not.toMatch(/^include:pub\.chive\./);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

Three commits on top of #83:

1. **Lead permission-set detail strings with eprints.** `pub.chive.{basicReader,authorAccess,reviewerAccess,fullAccess}` now describe their primary purpose (submit/manage/review eprints) rather than leading with knowledge-graph governance.

2. **Use cooperating apps' published permission sets where they fully cover Chive's writes.** Replaces individual `repo:` scopes with `include:` scopes for Margin, Standard.site, and Semble — collapsing the consent screen from ~17 opaque collection scopes to four named publisher entries.

3. **Conform Margin dual-write to Margin's actual published lexicons.** Verified against `lexicon.garden` and Margin's published `com.atproto.lexicon.schema` records: Margin uses a single `at.margin.note` collection (W3C web annotations) for all motivations (commenting, highlighting, bookmarking, etc.), not separate `at.margin.annotation` / `at.margin.bookmark` collections. Chive's previous dual-write was producing records that Margin's AppView never indexed.

## Hybrid scope layout

```
include:at.margin.authFull        // covers all 8 published Margin records
include:site.standard.authFull    // covers all 4 published Standard records
include:network.cosmik.authFull   // covers 4 of Semble's 6 collections
repo:network.cosmik.connection    // gap in Semble's authFull
repo:network.cosmik.follow        // gap in Semble's authFull
repo:app.bsky.feed.post           // Bluesky publishes no covering set
repo:app.bsky.actor.profile
```

## Margin migration details

- `record-creator.ts`: `MarginAnnotation*` types/functions renamed to `MarginNote*`; `motivation` is now required. `createMarginBookmark` / `deleteMarginBookmark` collapse to wrappers that forward to `createMarginNote` with `motivation: 'bookmarking'`.
- `MarginAnnotationsPlugin` / `MarginHighlightsPlugin` / `MarginBookmarksPlugin` consolidated into a single `MarginNotesPlugin` tracking `at.margin.note` (motivation encoded in backlink context).
- Tests rewritten.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring (no functional changes, no API changes)

## How Has This Been Tested

- `pnpm typecheck` passes (root + web).
- `@atproto/lex-resolver.get` succeeds for all four Chive permission sets and the three external ones (Margin, Semble, Standard.site).
- Cross-checked Margin's `at.margin.authFull` against Chive's writes (`note`, `reply`, `like`) — full coverage.
- Cross-checked Semble's `network.cosmik.authFull` against Chive's writes — confirmed `connection` and `follow` are not in their authFull, hence the supplementary repo scopes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings