### PR TITLE
Release 0.7.0: promote firehose recovery, eprint deletion, scope changes, and reindex prune to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-05-12
+
+### Fixed
+
+- OAuth permission sets now grant the rpc lexicons backing ORCID verification, admin endpoints, claiming flows, and profile-config writes. Production had been silently rejecting every `getServiceAuthToken` call since 0.6.0 dropped `transition:generic` without enumerating the rpc grants the corresponding lxm need. Closes #85.
+- Resolved the audience-format contradiction between `@atproto/oauth-scopes` (whose `isAtprotoAudience` validator requires `<did>#fragment`) and `com.atproto.server.getServiceAuth` (whose lexicon rejects an `aud` containing a fragment) by setting `aud: "*"` on the rpc permissions inside the four `pub.chive.{basicReader,authorAccess,reviewerAccess,fullAccess}` permission-set lexicons. Frontend now requests `getServiceAuth` with the plain DID and matches the wildcard rpc grant at the PDS.
+- Retry `com.atproto.server.getServiceAuth` once when the user's PDS responds with `use_dpop_nonce`. The OAuth client's auto-retry occasionally leaks the nonce-mismatch error through to caller code on the first request against a previously-unseen origin; the explicit retry consumes the freshly-issued `DPoP-Nonce` header on the second attempt.
+
+### Changed
+
+- Bumped `@atproto/oauth-client-browser` from 0.3.37 to 0.3.42 to pick up DPoP-handling fixes from `@atproto/oauth-client` 0.5.12–0.6.1.
+- Production now emits `include:pub.chive.*` permission-set references instead of individual `repo:pub.chive.*` scopes (`NEXT_PUBLIC_USE_PERMISSION_SETS=true`). The consent screen shows one named entry per Chive permission set rather than one row per collection.
+
 ## [0.6.2] - 2026-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-24
+
+### Added
+
+- Firehose consumer reconnects indefinitely with capped backoff and a WebSocket keepalive heartbeat, so a relay outage or a half-open socket can no longer wedge ingestion permanently. A single relay `503` on 2026-05-18 killed the production consumer for three weeks without surfacing anywhere.
+- Indexer health endpoint on `INDEXER_HEALTH_PORT` (default 3001) reporting per-relay connection state, with a watchdog that exits the process when the consumer stays unhealthy past its tolerance. The container healthcheck probes it instead of running `true`.
+- `scripts/publish-lexicons.ts` publishes the `pub.chive.*` lexicon schemas idempotently, so permission-set edits reach the PDS that resolves them.
+
+### Changed
+
+- The lexicon publisher targets the dedicated lexicon account on the governance PDS (`lexicons.governance.chive.pub`) rather than the `chive.pub` Bluesky bot account, which exists only for posts. `LEXICON_PDS_URL` and `LEXICON_PUBLISH_IDENTIFIER` still override both.
+- `transition:generic` is no longer requested anywhere. Scope resolution fails closed to the ATProto base scope when session scopes are unavailable, leaving authorization entirely on the `pub.chive.*` permission sets. Existing sessions keep their old scopes, so users must re-authenticate.
+
+### Fixed
+
+- Deleting an eprint removes it from Chive's index immediately rather than waiting on the firehose, and the frontend deletes the dual-written `site.standard.document` records alongside it.
+- The deploy's Elasticsearch reindex prunes eprints that are gone from their PDS instead of failing on orphaned index rows, which had made the production deploy unrunnable.
+- Backend services report their real release version. `npm_package_version` is unset when a container starts Node directly, so `/health`, structured logs, and OpenTelemetry resources had all reported `0.0.0` in every deployed environment.
+
 ## [0.6.3] - 2026-05-12
 
 ### Fixed
@@ -20,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `@atproto/oauth-client-browser` from 0.3.37 to 0.3.42 to pick up DPoP-handling fixes from `@atproto/oauth-client` 0.5.12–0.6.1.
 - Production now emits `include:pub.chive.*` permission-set references instead of individual `repo:pub.chive.*` scopes (`NEXT_PUBLIC_USE_PERMISSION_SETS=true`). The consent screen shows one named entry per Chive permission set rather than one row per collection.
 
-## [0.6.2] - 2026-05-06
+## [0.6.2] - 2026-05-07
 
 ### Added
 
@@ -38,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - "Created a new community/collection but it disappears on reload" (#79) for users who picked the `unlisted` visibility option in the wizard.
 
-## [0.6.1] - 2026-04-28
+## [0.6.1] - 2026-05-04
 
 ### Added
 
@@ -181,7 +200,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Description length limit (2000 chars) enforced on frontend and backend for content reports
 - ORCID client secret kept server-side only; state parameter is crypto-random, single-use, Redis-backed with TTL
 
-## [0.4.0] - 2026-03-11
+## [0.4.1] - 2026-03-19
+
+### Fixed
+
+- `pub.chive.eprint.listCitations` returned 500 when a citation carried structured author objects. Authors are formatted as strings, as the lexicon requires.
+
+## [0.4.0] - 2026-03-18
 
 ### Added
 
@@ -220,7 +245,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile record creator missing `institutionUri` and `children` fields, silently stripping tree structure on profile save
 - Eprint submission Zod schema missing `institutionUri`, stripping institution graph links on submit
 
-## [0.3.1] - 2026-03-10
+## [0.3.1] - 2026-03-11
 
 ### Fixed
 
@@ -644,7 +669,15 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/chive-pub/chive/compare/v0.6.3...v0.7.0
+[0.6.3]: https://github.com/chive-pub/chive/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/chive-pub/chive/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/chive-pub/chive/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/chive-pub/chive/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/chive-pub/chive/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/chive-pub/chive/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/chive-pub/chive/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/chive-pub/chive/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/chive-pub/chive/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/chive-pub/chive/compare/v0.2.0...v0.3.0

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -356,6 +356,7 @@ services:
       - OTEL_SERVICE_NAME=chive-indexer
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
       - GROBID_URL=http://grobid:8070
+      - INDEXER_HEALTH_PORT=3001
     depends_on:
       postgres:
         condition: service_healthy
@@ -377,10 +378,16 @@ services:
         reservations:
           cpus: '0.25'
           memory: 512M
-    # Disable inherited health check - indexer doesn't run HTTP server
+    # Liveness of the firehose consumer is exposed over HTTP by the indexer's
+    # health server. /health returns 503 once a relay has been disconnected
+    # past the watchdog's tolerance, so a wedged firehose is detected here
+    # instead of being silently reported "healthy".
     healthcheck:
-      test: ["CMD-SHELL", "true"]
-      interval: 60s
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
 
   # ---------------------------------------------------------------------------
   # PostgreSQL 16 - Primary metadata store

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/lexicons/permission-sets/basicReader.json
+++ b/lexicons/permission-sets/basicReader.json
@@ -25,6 +25,8 @@
             "pub.chive.endorsement.listForEprint",
             "pub.chive.author.getProfile",
             "pub.chive.author.searchAuthors",
+            "pub.chive.actor.getMyProfile",
+            "pub.chive.actor.getDiscoverySettings",
             "pub.chive.collection.get",
             "pub.chive.collection.getContaining",
             "pub.chive.collection.getFeed",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,8 +362,8 @@ importers:
         specifier: ^0.5.2
         version: 0.5.2
       '@atproto/oauth-client-browser':
-        specifier: ^0.3.37
-        version: 0.3.37
+        specifier: ^0.3.42
+        version: 0.3.42
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -895,6 +895,9 @@ packages:
   '@atproto-labs/did-resolver@0.2.4':
     resolution: {integrity: sha512-sbXxBnAJWsKv/FEGG6a/WLz7zQYUr1vA2TXvNnPwwJQJCjPwEJMOh1vM22wBr185Phy7D2GD88PcRokn7eUVyw==}
 
+  '@atproto-labs/did-resolver@0.2.6':
+    resolution: {integrity: sha512-2K1bC04nI2fmgNcvof+yA28IhGlpWn2JKYlPa7To9JTKI45FINCGkQSGiL2nyXlyzDJJ34fZ1aq6/IRFIOIiqg==}
+
   '@atproto-labs/fetch-node@0.2.0':
     resolution: {integrity: sha512-Krq09nH/aeoiU2s9xdHA0FjTEFWG9B5FFenipv1iRixCcPc7V3DhTNDawxG9gI8Ny0k4dBVS9WTRN/IDzBx86Q==}
     engines: {node: '>=18.7.0'}
@@ -909,8 +912,14 @@ packages:
   '@atproto-labs/handle-resolver@0.3.4':
     resolution: {integrity: sha512-wsNopfzfgO3uPvfnFDgNeXgDufXxSXhjBjp2WEiSzEiLrMy0Jodnqggw4OzD9MJKf0a4Iu2/ydd537qdy91LrQ==}
 
+  '@atproto-labs/handle-resolver@0.3.6':
+    resolution: {integrity: sha512-qnSTXvOBNj1EHhp2qTWSX8MS5q3AwYU5LKlt5fBvSbCjgmTr2j0URHCv+ydrwO55KvsojIkTMgeMOh4YuY4fCA==}
+
   '@atproto-labs/identity-resolver@0.3.4':
     resolution: {integrity: sha512-HNUEFQIo2ws6iATxmgHd5D5rAsWYupgxZucgwolVHPiMjE1SY+EmxEsfbEN1wDEzM8/u9AKUg/jrxxPEwsgbew==}
+
+  '@atproto-labs/identity-resolver@0.3.6':
+    resolution: {integrity: sha512-qoWqBDRobln0NR8L8dQjSp79E0chGkBhibEgxQa2f9WD+JbJdjQ0YvwwO5yeQn05pJoJmAwmI2wyJ45zjU7aWg==}
 
   '@atproto-labs/pipe@0.1.1':
     resolution: {integrity: sha512-hdNw2oUs2B6BN1lp+32pF7cp8EMKuIN5Qok2Vvv/aOpG/3tNSJ9YkvfI0k6Zd188LeDDYRUpYpxcoFIcGH/FNg==}
@@ -940,6 +949,9 @@ packages:
 
   '@atproto/did@0.2.3':
     resolution: {integrity: sha512-VI8JJkSizvM2cHYJa37WlbzeCm5tWpojyc1/Zy8q8OOjyoy6X4S4BEfoP941oJcpxpMTObamibQIXQDo7tnIjg==}
+
+  '@atproto/did@0.3.0':
+    resolution: {integrity: sha512-raUPzUGegtW/6OxwCmM8bhZvuIMzxG5t9oWsth6Tp91Kb5fTnHV2h/KKNF1C82doeA4BdXCErTyg7ISwLbQkzA==}
 
   '@atproto/identity@0.4.10':
     resolution: {integrity: sha512-nQbzDLXOhM8p/wo0cTh5DfMSOSHzj6jizpodX37LJ4S1TZzumSxAjHEZa5Rev3JaoD5uSWMVE0MmKEGWkPPvfQ==}
@@ -980,8 +992,8 @@ packages:
   '@atproto/lexicon@0.6.0':
     resolution: {integrity: sha512-5veb8aD+J5M0qszLJ+73KSFsFrJBgAY/nM1TSAJvGY7fNc9ZAT+PSUlmIyrdye9YznAZ07yktalls/TwNV7cHQ==}
 
-  '@atproto/oauth-client-browser@0.3.37':
-    resolution: {integrity: sha512-iU/sJeA0t10jEivQ/UcVlvIbApqyF7J967OPeKL37kwz4Dsd/WLfRo+LkCQQZmgt2uyVLAaXUSxGGirD1jHjlQ==}
+  '@atproto/oauth-client-browser@0.3.42':
+    resolution: {integrity: sha512-YRNMnZNid+ipBndpKbqZ+1uzb51Ci7Pit56iF2+hBljZkE6MAW/gkGwywJigVPlhkVKCO80PaXt8CHuON5kS8w==}
 
   '@atproto/oauth-client-node@0.3.13':
     resolution: {integrity: sha512-k2qT5QM6Mj5I412IZOnktShmI1A5YbwLmLM4BkeEcbcOm7kU1Cr/H/zUC/zniCIj641ZudiXU80Bsyw4A6tejA==}
@@ -990,8 +1002,14 @@ packages:
   '@atproto/oauth-client@0.5.11':
     resolution: {integrity: sha512-KyxKpnF988BI3m+4NNYDgkN6a2sPORD9uaOEGP4tnJLOvhMVHyATWwq3Jx4LOYotTFDOvLdheWcI1G9DozE88w==}
 
+  '@atproto/oauth-client@0.6.1':
+    resolution: {integrity: sha512-QTLbEFyv7EJuwJf4A8IZnsylK5wwrzrSsxy0INcZf9zktPVQvgckWhSvbfK8alp60M+rwWfQQAlodcCF4WB78A==}
+
   '@atproto/oauth-types@0.5.2':
     resolution: {integrity: sha512-9DCDvtvCanTwAaU5UakYDO0hzcOITS3RutK5zfLytE5Y9unj0REmTDdN8Xd8YCfUJl7T/9pYpf04Uyq7bFTASg==}
+
+  '@atproto/oauth-types@0.6.3':
+    resolution: {integrity: sha512-jdKuoPknJuh/WjI+mYk7agSbx9mNVMbS6Dr3k1z2YMY2oRiCQjxYBuo4MLKATbxj05nMQaZRWlHRUazoAu5Cng==}
 
   '@atproto/syntax@0.4.1':
     resolution: {integrity: sha512-CJdImtLAiFO+0z3BWTtxwk6aY5w4t8orHTMVJgkf++QRJWTxPbIFko/0hrkADB7n2EruDxDSeAgfUGehpH6ngw==}
@@ -14545,6 +14563,15 @@ snapshots:
       '@atproto/did': 0.2.3
       zod: 3.25.76
 
+  '@atproto-labs/did-resolver@0.2.6':
+    dependencies:
+      '@atproto-labs/fetch': 0.2.3
+      '@atproto-labs/pipe': 0.1.1
+      '@atproto-labs/simple-store': 0.3.0
+      '@atproto-labs/simple-store-memory': 0.1.4
+      '@atproto/did': 0.3.0
+      zod: 3.25.76
+
   '@atproto-labs/fetch-node@0.2.0':
     dependencies:
       '@atproto-labs/fetch': 0.2.3
@@ -14569,10 +14596,22 @@ snapshots:
       '@atproto/did': 0.2.3
       zod: 3.25.76
 
+  '@atproto-labs/handle-resolver@0.3.6':
+    dependencies:
+      '@atproto-labs/simple-store': 0.3.0
+      '@atproto-labs/simple-store-memory': 0.1.4
+      '@atproto/did': 0.3.0
+      zod: 3.25.76
+
   '@atproto-labs/identity-resolver@0.3.4':
     dependencies:
       '@atproto-labs/did-resolver': 0.2.4
       '@atproto-labs/handle-resolver': 0.3.4
+
+  '@atproto-labs/identity-resolver@0.3.6':
+    dependencies:
+      '@atproto-labs/did-resolver': 0.2.6
+      '@atproto-labs/handle-resolver': 0.3.6
 
   '@atproto-labs/pipe@0.1.1': {}
 
@@ -14622,6 +14661,10 @@ snapshots:
       uint8arrays: 3.0.0
 
   '@atproto/did@0.2.3':
+    dependencies:
+      zod: 3.25.76
+
+  '@atproto/did@0.3.0':
     dependencies:
       zod: 3.25.76
 
@@ -14705,16 +14748,16 @@ snapshots:
       multiformats: 9.9.0
       zod: 3.25.76
 
-  '@atproto/oauth-client-browser@0.3.37':
+  '@atproto/oauth-client-browser@0.3.42':
     dependencies:
-      '@atproto-labs/did-resolver': 0.2.4
-      '@atproto-labs/handle-resolver': 0.3.4
+      '@atproto-labs/did-resolver': 0.2.6
+      '@atproto-labs/handle-resolver': 0.3.6
       '@atproto-labs/simple-store': 0.3.0
-      '@atproto/did': 0.2.3
+      '@atproto/did': 0.3.0
       '@atproto/jwk': 0.6.0
       '@atproto/jwk-webcrypto': 0.2.0
-      '@atproto/oauth-client': 0.5.11
-      '@atproto/oauth-types': 0.5.2
+      '@atproto/oauth-client': 0.6.1
+      '@atproto/oauth-types': 0.6.3
       core-js: 3.47.0
 
   '@atproto/oauth-client-node@0.3.13':
@@ -14745,9 +14788,31 @@ snapshots:
       multiformats: 9.9.0
       zod: 3.25.76
 
+  '@atproto/oauth-client@0.6.1':
+    dependencies:
+      '@atproto-labs/did-resolver': 0.2.6
+      '@atproto-labs/fetch': 0.2.3
+      '@atproto-labs/handle-resolver': 0.3.6
+      '@atproto-labs/identity-resolver': 0.3.6
+      '@atproto-labs/simple-store': 0.3.0
+      '@atproto-labs/simple-store-memory': 0.1.4
+      '@atproto/did': 0.3.0
+      '@atproto/jwk': 0.6.0
+      '@atproto/oauth-types': 0.6.3
+      '@atproto/xrpc': 0.7.7
+      core-js: 3.47.0
+      multiformats: 9.9.0
+      zod: 3.25.76
+
   '@atproto/oauth-types@0.5.2':
     dependencies:
       '@atproto/did': 0.2.3
+      '@atproto/jwk': 0.6.0
+      zod: 3.25.76
+
+  '@atproto/oauth-types@0.6.3':
+    dependencies:
+      '@atproto/did': 0.3.0
       '@atproto/jwk': 0.6.0
       zod: 3.25.76
 

--- a/scripts/publish-lexicons.ts
+++ b/scripts/publish-lexicons.ts
@@ -1,20 +1,27 @@
 #!/usr/bin/env npx tsx
 /**
- * Publish Chive's lexicon schemas to the `chive.pub` account's PDS.
+ * Publish Chive's lexicon schemas to the dedicated lexicon account on the
+ * governance PDS.
  *
  * @remarks
- * `pub.chive.*` NSIDs resolve via DNS (`_lexicon.chive.pub`) to the `chive.pub`
- * account on a real PDS, which serves each schema as a `com.atproto.lexicon.schema`
- * record (rkey = the NSID). Editing a lexicon JSON file in this repo does NOT
- * update those records — they must be re-`putRecord`ed. This script does that,
+ * The `pub.chive.*` lexicons live in their own account on Chive's governance
+ * PDS (`governance.chive.pub`), NOT in the `chive.pub` Bluesky account on
+ * `pds.chive.pub` (that account is only for Bluesky posts; an earlier run
+ * mistakenly published the lexicons there). `_lexicon.chive.pub` must point at
+ * this lexicon account's DID so external services resolve `pub.chive.*` from
+ * the governance PDS.
+ *
+ * The PDS serves each schema as a `com.atproto.lexicon.schema` record
+ * (rkey = the NSID). Editing a lexicon JSON file in this repo does NOT update
+ * those records — they must be re-`putRecord`ed. This script does that,
  * idempotently: it reads the same files the lexicon server serves (via
- * {@link getLexiconRecords}), compares each against what the PDS currently holds,
- * and writes only the ones that changed.
+ * {@link getLexiconRecords}), compares each against what the PDS currently
+ * holds, and writes only the ones that changed.
  *
  * Configuration (env):
- * - `LEXICON_PDS_URL`           PDS endpoint (default `https://pds.chive.pub`)
- * - `LEXICON_PUBLISH_IDENTIFIER` account handle/DID (default `chive.pub`)
- * - `LEXICON_PUBLISH_PASSWORD`  app password (required unless `--dry-run`)
+ * - `LEXICON_PDS_URL`           PDS endpoint (default `https://governance.chive.pub`)
+ * - `LEXICON_PUBLISH_IDENTIFIER` account handle/DID (default `lexicons.governance.chive.pub`)
+ * - `LEXICON_PUBLISH_PASSWORD`  account/app password (required unless `--dry-run`)
  *
  * Usage:
  *   pnpm tsx scripts/publish-lexicons.ts [--dry-run] [nsid ...]
@@ -40,8 +47,8 @@ import {
   getLexiconRecords,
 } from '../src/atproto/lexicon-server/loader.js';
 
-const PDS_URL = process.env.LEXICON_PDS_URL ?? 'https://pds.chive.pub';
-const IDENTIFIER = process.env.LEXICON_PUBLISH_IDENTIFIER ?? 'chive.pub';
+const PDS_URL = process.env.LEXICON_PDS_URL ?? 'https://governance.chive.pub';
+const IDENTIFIER = process.env.LEXICON_PUBLISH_IDENTIFIER ?? 'lexicons.governance.chive.pub';
 const PASSWORD = process.env.LEXICON_PUBLISH_PASSWORD;
 
 interface Plan {
@@ -96,7 +103,7 @@ async function main(): Promise<void> {
   const dryRun = args.includes('--dry-run');
   const nsidFilter = new Set(args.filter((a) => !a.startsWith('--')));
 
-  // The `chive.pub` account is only the authority for `pub.chive.*` NSIDs.
+  // The lexicon account is only the authority for `pub.chive.*` NSIDs.
   // Other namespaces present in lexicons/ (com.atproto.*, site.standard.*) are
   // vendored copies for local codegen/validation and belong to other
   // authorities — publishing them under this account would be incorrect.

--- a/scripts/publish-lexicons.ts
+++ b/scripts/publish-lexicons.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env npx tsx
+/**
+ * Publish Chive's lexicon schemas to the `chive.pub` account's PDS.
+ *
+ * @remarks
+ * `pub.chive.*` NSIDs resolve via DNS (`_lexicon.chive.pub`) to the `chive.pub`
+ * account on a real PDS, which serves each schema as a `com.atproto.lexicon.schema`
+ * record (rkey = the NSID). Editing a lexicon JSON file in this repo does NOT
+ * update those records — they must be re-`putRecord`ed. This script does that,
+ * idempotently: it reads the same files the lexicon server serves (via
+ * {@link getLexiconRecords}), compares each against what the PDS currently holds,
+ * and writes only the ones that changed.
+ *
+ * Configuration (env):
+ * - `LEXICON_PDS_URL`           PDS endpoint (default `https://pds.chive.pub`)
+ * - `LEXICON_PUBLISH_IDENTIFIER` account handle/DID (default `chive.pub`)
+ * - `LEXICON_PUBLISH_PASSWORD`  app password (required unless `--dry-run`)
+ *
+ * Usage:
+ *   pnpm tsx scripts/publish-lexicons.ts [--dry-run] [nsid ...]
+ *
+ * Examples:
+ *   # Preview what would change against the live PDS (no credentials needed):
+ *   pnpm tsx scripts/publish-lexicons.ts --dry-run
+ *
+ *   # Publish every lexicon that has drifted:
+ *   LEXICON_PUBLISH_PASSWORD=xxxx pnpm tsx scripts/publish-lexicons.ts
+ *
+ *   # Publish only specific NSIDs:
+ *   LEXICON_PUBLISH_PASSWORD=xxxx pnpm tsx scripts/publish-lexicons.ts pub.chive.basicReader
+ *
+ * @packageDocumentation
+ */
+
+import { AtpAgent } from '@atproto/api';
+
+import {
+  CHIVE_LEXICON_DID,
+  LEXICON_COLLECTION,
+  getLexiconRecords,
+} from '../src/atproto/lexicon-server/loader.js';
+
+const PDS_URL = process.env.LEXICON_PDS_URL ?? 'https://pds.chive.pub';
+const IDENTIFIER = process.env.LEXICON_PUBLISH_IDENTIFIER ?? 'chive.pub';
+const PASSWORD = process.env.LEXICON_PUBLISH_PASSWORD;
+
+interface Plan {
+  nsid: string;
+  action: 'create' | 'update' | 'skip';
+  value: Record<string, unknown>;
+}
+
+/**
+ * Stable JSON stringify (recursively sorted keys) for order-independent
+ * structural comparison of two lexicon record values.
+ */
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonical).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${canonical(obj[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * Fetch the currently published record value for an NSID, or null if absent.
+ */
+async function fetchPublished(
+  agent: AtpAgent,
+  repo: string,
+  nsid: string
+): Promise<Record<string, unknown> | null> {
+  try {
+    const res = await agent.com.atproto.repo.getRecord({
+      repo,
+      collection: LEXICON_COLLECTION,
+      rkey: nsid,
+    });
+    return res.data.value as Record<string, unknown>;
+  } catch (error) {
+    const name = (error as { error?: string }).error;
+    const message = error instanceof Error ? error.message : String(error);
+    if (name === 'RecordNotFound' || /could not locate record/i.test(message)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const nsidFilter = new Set(args.filter((a) => !a.startsWith('--')));
+
+  // The `chive.pub` account is only the authority for `pub.chive.*` NSIDs.
+  // Other namespaces present in lexicons/ (com.atproto.*, site.standard.*) are
+  // vendored copies for local codegen/validation and belong to other
+  // authorities — publishing them under this account would be incorrect.
+  const PUBLISHABLE_PREFIX = 'pub.chive.';
+  const records = getLexiconRecords();
+  const selected = [...records.entries()].filter(
+    ([nsid]) =>
+      nsid.startsWith(PUBLISHABLE_PREFIX) && (nsidFilter.size === 0 || nsidFilter.has(nsid))
+  );
+
+  const skippedForeign = [...nsidFilter].filter((n) => !n.startsWith(PUBLISHABLE_PREFIX));
+  if (skippedForeign.length > 0) {
+    console.warn(
+      `Ignoring non-pub.chive NSIDs (other authorities own them): ${skippedForeign.join(', ')}`
+    );
+  }
+
+  if (selected.length === 0) {
+    console.error('No matching pub.chive.* lexicons found to publish.');
+    process.exit(1);
+  }
+
+  console.log(`Lexicon publish ${dryRun ? '(dry run)' : ''}`);
+  console.log(`  PDS:        ${PDS_URL}`);
+  console.log(`  Account:    ${IDENTIFIER}`);
+  console.log(`  Repo DID:   resolved at login (lexicon URIs use ${CHIVE_LEXICON_DID})`);
+  console.log(`  Candidates: ${selected.length}`);
+
+  // A logged-in agent is only needed to write. For comparison we read public
+  // records, so --dry-run works without credentials.
+  const agent = new AtpAgent({ service: PDS_URL });
+  let repo: string;
+
+  if (dryRun) {
+    repo = IDENTIFIER;
+  } else {
+    if (!PASSWORD) {
+      console.error('LEXICON_PUBLISH_PASSWORD is required (or pass --dry-run).');
+      process.exit(1);
+    }
+    await agent.login({ identifier: IDENTIFIER, password: PASSWORD });
+    repo = agent.session?.did ?? IDENTIFIER;
+    console.log(`  Logged in:  ${repo}`);
+  }
+
+  // Build the plan: compare each candidate against what the PDS holds.
+  const plan: Plan[] = [];
+  for (const [nsid, record] of selected) {
+    const published = await fetchPublished(agent, repo, nsid);
+    if (published === null) {
+      plan.push({ nsid, action: 'create', value: record.value });
+    } else if (canonical(published) !== canonical(record.value)) {
+      plan.push({ nsid, action: 'update', value: record.value });
+    } else {
+      plan.push({ nsid, action: 'skip', value: record.value });
+    }
+  }
+
+  const toWrite = plan.filter((p) => p.action !== 'skip');
+  for (const p of plan) {
+    if (p.action !== 'skip') console.log(`  ${p.action.toUpperCase()}: ${p.nsid}`);
+  }
+  console.log(`\n${toWrite.length} change(s), ${plan.length - toWrite.length} already in sync.`);
+
+  if (dryRun) {
+    console.log('Dry run: no records written.');
+    return;
+  }
+
+  if (toWrite.length === 0) {
+    console.log('Nothing to publish.');
+    return;
+  }
+
+  // Apply: putRecord is an upsert keyed by rkey, so this is idempotent.
+  let written = 0;
+  for (const p of toWrite) {
+    await agent.com.atproto.repo.putRecord({
+      repo,
+      collection: LEXICON_COLLECTION,
+      rkey: p.nsid,
+      record: p.value,
+    });
+
+    // Verify the write landed and matches.
+    const after = await fetchPublished(agent, repo, p.nsid);
+    if (!after || canonical(after) !== canonical(p.value)) {
+      throw new Error(`Verification failed for ${p.nsid}: published record does not match source`);
+    }
+    console.log(`  ✓ published ${p.nsid}`);
+    written += 1;
+  }
+
+  console.log(`\nPublished ${written} lexicon record(s).`);
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/reindex-all-eprints.ts
+++ b/scripts/reindex-all-eprints.ts
@@ -66,9 +66,34 @@ interface ReindexStats {
   success: number;
   failed: number;
   skipped: number;
+  /**
+   * Records that no longer exist in their PDS and were therefore removed from
+   * the index (orphans left behind when a firehose delete was missed). These
+   * are a successful outcome, not a failure.
+   */
+  pruned: number;
   startTime: number;
   endTime?: number;
   failedRecords: ReindexResult[];
+  prunedRecords: string[];
+}
+
+/**
+ * Whether an error from `getRecord` means the record is definitively gone from
+ * its PDS (deleted), as opposed to a transient failure (timeout, network, 5xx).
+ *
+ * @remarks
+ * Only a definitive "not found" justifies pruning the index row. Transient
+ * errors must keep retrying/failing so a flaky PDS never causes data loss.
+ */
+function isRecordGoneError(error: Error): boolean {
+  const message = error.message.toLowerCase();
+  const name = (error as { error?: string }).error?.toLowerCase() ?? '';
+  return (
+    name === 'recordnotfound' ||
+    message.includes('could not locate record') ||
+    message.includes('record not found')
+  );
 }
 
 // =============================================================================
@@ -269,6 +294,35 @@ async function reindexSingleRecord(
 // BATCH PROCESSING
 // =============================================================================
 
+/**
+ * Remove an orphaned eprint (deleted from its PDS but still indexed) from the
+ * Postgres and Elasticsearch indexes.
+ *
+ * @remarks
+ * Deleting from the AppView's own indexes is ATProto-compliant: the PDS remains
+ * the source of truth and the record is already gone there. This is the same
+ * cleanup the firehose delete performs; doing it here makes a full reindex
+ * self-healing for orphans a missed firehose event left behind.
+ */
+async function pruneEprintFromIndex(
+  uri: string,
+  esClient: ElasticsearchClient,
+  pgPool: Pool,
+  indexName: string
+): Promise<void> {
+  await pgPool.query(`DELETE FROM eprints_index WHERE uri = $1`, [uri]);
+
+  try {
+    await esClient.delete({ index: indexName, id: uri });
+  } catch (error) {
+    // A 404 here just means it was never indexed in ES; ignore it.
+    const status = (error as { meta?: { statusCode?: number } }).meta?.statusCode;
+    if (status !== 404) {
+      throw error;
+    }
+  }
+}
+
 async function processBatch(
   batch: Array<{ uri: string; pds_url: string; paper_did: string; submitted_by: string }>,
   esClient: ElasticsearchClient,
@@ -295,6 +349,7 @@ async function processBatch(
 
     let lastError: Error | undefined;
     let retries = 0;
+    let pruned = false;
 
     // Retry loop with exponential backoff
     for (let attempt = 0; attempt <= CONFIG.maxRetries; attempt++) {
@@ -316,6 +371,17 @@ async function processBatch(
         lastError = error instanceof Error ? error : new Error(String(error));
         retries = attempt;
 
+        // The record is gone from its PDS (deleted): retrying won't help. Prune
+        // the orphaned index row instead of failing the whole reindex.
+        if (isRecordGoneError(lastError)) {
+          await pruneEprintFromIndex(uri, esClient, pgPool, indexName);
+          stats.pruned++;
+          stats.prunedRecords.push(uri);
+          console.log(`  PRUNE: ${uri} - deleted from PDS, removed from index`);
+          pruned = true;
+          break;
+        }
+
         if (attempt < CONFIG.maxRetries) {
           const delay = getBackoffDelay(attempt);
           console.log(`  RETRY ${attempt + 1}/${CONFIG.maxRetries}: ${uri} - ${lastError.message}`);
@@ -324,8 +390,8 @@ async function processBatch(
       }
     }
 
-    // Record failure if all retries exhausted
-    if (lastError && retries >= CONFIG.maxRetries) {
+    // Record failure if all retries exhausted (pruned records are not failures)
+    if (!pruned && lastError && retries >= CONFIG.maxRetries) {
       stats.failed++;
       stats.failedRecords.push({
         uri,
@@ -480,8 +546,10 @@ async function main() {
     success: 0,
     failed: 0,
     skipped: 0,
+    pruned: 0,
     startTime: Date.now(),
     failedRecords: [],
+    prunedRecords: [],
   };
 
   console.log('Starting reindexing...');
@@ -527,7 +595,21 @@ async function main() {
   );
   console.log(`  Failed: ${stats.failed} (${((stats.failed / stats.total) * 100).toFixed(1)}%)`);
   console.log(`  Skipped: ${stats.skipped} (${((stats.skipped / stats.total) * 100).toFixed(1)}%)`);
+  console.log(
+    `  Pruned (deleted from PDS): ${stats.pruned} (${((stats.pruned / stats.total) * 100).toFixed(1)}%)`
+  );
   console.log(`Field labels cached: ${nodeLookup.cacheSize}`);
+
+  if (stats.prunedRecords.length > 0) {
+    console.log();
+    console.log('Pruned orphaned records (no longer in PDS):');
+    for (const uri of stats.prunedRecords.slice(0, 20)) {
+      console.log(`  ${uri}`);
+    }
+    if (stats.prunedRecords.length > 20) {
+      console.log(`  ... and ${stats.prunedRecords.length - 20} more`);
+    }
+  }
 
   if (stats.failedRecords.length > 0) {
     console.log();

--- a/src/api/handlers/rest/health.ts
+++ b/src/api/handlers/rest/health.ts
@@ -14,6 +14,7 @@ import type { Context } from 'hono';
 import type { Hono } from 'hono';
 
 import type { DID } from '../../../types/atproto.js';
+import { getAppVersion } from '../../../utils/app-version.js';
 import { HEALTH_PATHS } from '../../config.js';
 import type { ChiveEnv } from '../../types/context.js';
 
@@ -65,7 +66,7 @@ export function livenessHandler(c: Context<ChiveEnv>): Response {
   const response: HealthResponse = {
     status: 'healthy',
     timestamp: new Date().toISOString(),
-    version: process.env.npm_package_version ?? '0.0.0',
+    version: getAppVersion(),
     uptime: Math.floor((Date.now() - startTime) / 1000),
   };
 
@@ -215,7 +216,7 @@ export async function readinessHandler(c: Context<ChiveEnv>): Promise<Response> 
   const response: HealthResponse = {
     status: overallStatus,
     timestamp: new Date().toISOString(),
-    version: process.env.npm_package_version ?? '0.0.0',
+    version: getAppVersion(),
     uptime: Math.floor((Date.now() - startTime) / 1000),
     checks,
   };

--- a/src/api/handlers/xrpc/eprint/deleteSubmission.ts
+++ b/src/api/handlers/xrpc/eprint/deleteSubmission.ts
@@ -40,9 +40,11 @@ import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
  * For paper-centric eprints (paperDid is set), the user must be authenticated
  * as the paper account to delete.
  *
- * After successful authorization, the frontend should:
- * 1. Call com.atproto.repo.deleteRecord on the appropriate PDS
- * 2. The firehose will propagate the deletion to Chive's index
+ * After successful authorization, this handler removes the eprint from Chive's
+ * own indexes immediately (deleting from the AppView's index is compliant; we
+ * never write to the user's PDS). The frontend then:
+ * 1. Calls com.atproto.repo.deleteRecord on the appropriate PDS
+ * 2. The firehose delete reconciles the index (idempotent with the above)
  *
  * @example
  * ```http
@@ -118,10 +120,21 @@ export const deleteSubmission: XRPCMethod<void, InputSchema, OutputSchema> = {
       isPaperCentric: !!eprintData.paperDid,
     });
 
-    // Authorization successful. The frontend should now:
-    // 1. Call com.atproto.repo.deleteRecord on recordOwner's PDS
-    // 2. The deletion will propagate through the firehose
-    // 3. Chive will remove the record from its index via indexEprintDelete
+    // Remove the eprint from Chive's own indexes immediately rather than
+    // waiting for the firehose delete event. Deleting from the AppView's own
+    // index is ATProto-compliant (we never touch the user's PDS), and it makes
+    // deletion reliable even when firehose ingestion is lagging or down: the
+    // firehose delete remains the source of truth and is idempotent with this.
+    const deleteResult = await eprint.indexEprintDelete(uri as AtUri);
+    if (!deleteResult.ok) {
+      // Surface the failure so the frontend does not report success while the
+      // eprint is still indexed.
+      logger.error('Failed to remove eprint from index', deleteResult.error, { uri });
+      throw deleteResult.error;
+    }
+
+    // The frontend still deletes the record from the owner's PDS via
+    // com.atproto.repo.deleteRecord; the firehose delete reconciles the index.
 
     return {
       encoding: 'application/json',

--- a/src/auth/atproto-oauth/node-oauth-client.ts
+++ b/src/auth/atproto-oauth/node-oauth-client.ts
@@ -43,7 +43,7 @@ export interface OAuthClientMetadataConfig {
    * @remarks
    * Must include 'atproto' for PDS access.
    *
-   * @defaultValue ['atproto', 'transition:generic', 'include:pub.chive.auth.fullAccess']
+   * @defaultValue ['atproto', 'include:pub.chive.fullAccess', ...repo/blob scopes]
    */
   readonly scopes?: readonly string[];
 }
@@ -150,8 +150,7 @@ export function createATProtoOAuthClient(options: ATProtoOAuthClientOptions): No
 
   const scopes = config.clientMetadata.scopes ?? [
     'atproto',
-    'transition:generic',
-    'include:pub.chive.auth.fullAccess',
+    'include:pub.chive.fullAccess',
     'repo:app.bsky.feed.post',
     'repo:app.bsky.actor.profile',
     'repo:site.standard.document',

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -55,6 +55,10 @@ import { GovernancePDSWriter } from './services/governance/governance-pds-writer
 import { NodeService } from './services/governance/node-service.js';
 import { PersonalGraphService } from './services/graph/personal-graph-service.js';
 import { createEventProcessor } from './services/indexing/event-processor.js';
+import {
+  type FirehoseHealthServer,
+  startFirehoseHealthServer,
+} from './services/indexing/firehose-health-server.js';
 import { IndexingService } from './services/indexing/indexing-service.js';
 import { KnowledgeGraphService } from './services/knowledge-graph/graph-service.js';
 import { PDSRegistry } from './services/pds-discovery/pds-registry.js';
@@ -172,7 +176,14 @@ interface IndexerState {
   indexingService?: IndexingService;
   fieldPromotionJob?: FieldPromotionJob;
   fieldLabelResolutionJob?: FieldLabelResolutionJob;
+  healthServer?: FirehoseHealthServer;
 }
+
+/**
+ * Guards against the watchdog and a termination signal both triggering
+ * shutdown concurrently.
+ */
+let shuttingDown = false;
 
 /**
  * Initializes all database connections.
@@ -241,7 +252,17 @@ function parseRedisUrl(url: string): RedisOptions {
  * Gracefully shuts down all connections.
  */
 async function shutdown(state: IndexerState, signal: string): Promise<void> {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+
   state.logger.info(`Received ${signal}, starting graceful shutdown...`);
+
+  // Stop the health server and watchdog first so it can't fire mid-shutdown.
+  if (state.healthServer) {
+    await state.healthServer.close();
+  }
 
   // Stop jobs
   if (state.fieldPromotionJob) {
@@ -553,6 +574,20 @@ async function main(): Promise<void> {
     });
 
     state.indexingService = indexingService;
+
+    // Expose firehose liveness over HTTP for the container healthcheck, and run
+    // a watchdog that restarts the process if the consumer stays wedged past the
+    // recovery threshold (the consumer reconnects itself first; this is the last
+    // resort). Without this, a dead firehose is invisible and never recovers.
+    const healthPort = parseInt(process.env.INDEXER_HEALTH_PORT ?? '3001', 10);
+    state.healthServer = startFirehoseHealthServer({
+      indexingService,
+      logger,
+      port: healthPort,
+      onUnrecoverable: () => {
+        void shutdown(state, 'firehose-watchdog');
+      },
+    });
 
     // Start indexing
     logger.info('Starting firehose consumption...', {

--- a/src/observability/logger.ts
+++ b/src/observability/logger.ts
@@ -16,6 +16,7 @@ import pino from 'pino';
 import type { Logger as PinoBaseLogger, LoggerOptions as PinoOptions } from 'pino';
 
 import type { ILogger, LogContext, LogLevel } from '../types/interfaces/logger.interface.js';
+import { getAppVersion } from '../utils/app-version.js';
 
 /**
  * Sensitive field names to redact from logs.
@@ -84,7 +85,7 @@ export interface PinoLoggerOptions {
    * @remarks
    * Appears in every log entry as `version` field.
    *
-   * @defaultValue process.env.npm_package_version || '0.0.0'
+   * @defaultValue The release version from `getAppVersion()`
    */
   readonly version?: string;
 
@@ -233,7 +234,7 @@ export class PinoLogger implements ILogger {
       level = process.env.LOG_LEVEL ?? 'info',
       service = process.env.OTEL_SERVICE_NAME ?? 'chive-appview',
       environment = process.env.NODE_ENV ?? 'development',
-      version = process.env.npm_package_version ?? '0.0.0',
+      version = getAppVersion(),
       pretty = false,
     } = options;
 

--- a/src/observability/telemetry.ts
+++ b/src/observability/telemetry.ts
@@ -27,6 +27,8 @@ import {
   SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
 } from '@opentelemetry/semantic-conventions';
 
+import { getAppVersion } from '../utils/app-version.js';
+
 /**
  * Configuration options for OpenTelemetry initialization.
  *
@@ -49,7 +51,7 @@ export interface TelemetryOptions {
    * @remarks
    * Appears in traces and metrics as `service.version`.
    *
-   * @defaultValue process.env.OTEL_SERVICE_VERSION || process.env.npm_package_version || '0.0.0'
+   * @defaultValue process.env.OTEL_SERVICE_VERSION, else the release version from `getAppVersion()`
    */
   readonly serviceVersion?: string;
 
@@ -131,10 +133,7 @@ const telemetryState: TelemetryState = {
 function createResource(options: TelemetryOptions): Resource {
   const serviceName = options.serviceName ?? process.env.OTEL_SERVICE_NAME ?? 'chive-appview';
   const serviceVersion =
-    options.serviceVersion ??
-    process.env.OTEL_SERVICE_VERSION ??
-    process.env.npm_package_version ??
-    '0.0.0';
+    options.serviceVersion ?? process.env.OTEL_SERVICE_VERSION ?? getAppVersion();
   const environment = options.environment ?? process.env.NODE_ENV ?? 'development';
 
   return resourceFromAttributes({

--- a/src/services/governance/governance-pds-writer.ts
+++ b/src/services/governance/governance-pds-writer.ts
@@ -113,7 +113,7 @@ export interface GovernancePDSWriterOptions {
  * ```typescript
  * const writer = new GovernancePDSWriter({
  *   graphPdsDid: 'did:plc:chive-governance' as DID,
- *   pdsUrl: 'https://pds.chive.pub',
+ *   pdsUrl: 'https://governance.chive.pub',
  *   signingKey: process.env.GOVERNANCE_SIGNING_KEY!,
  *   pool,
  *   cache: redis,

--- a/src/services/indexing/firehose-consumer.ts
+++ b/src/services/indexing/firehose-consumer.ts
@@ -115,6 +115,49 @@ export interface FirehoseConsumerOptions {
    * If not provided, logging is silently skipped.
    */
   readonly logger?: ILogger;
+
+  /**
+   * Interval, in milliseconds, between WebSocket keepalive pings.
+   *
+   * @remarks
+   * Jetstream does not push periodic keepalives on a filtered stream, so a
+   * half-open TCP connection can otherwise sit "open" forever delivering no
+   * events and emitting no `close`. Each interval sends a `ping`; if no `pong`
+   * or message arrived since the previous interval the socket is terminated so
+   * the reconnection loop can recover it. Set to `0` to disable.
+   *
+   * @defaultValue 30000 (30 seconds)
+   */
+  readonly heartbeatIntervalMs?: number;
+}
+
+/**
+ * Point-in-time liveness snapshot for a firehose consumer.
+ *
+ * @public
+ */
+export interface FirehoseHealth {
+  /**
+   * Current connection state.
+   */
+  readonly state: ConnectionState;
+
+  /**
+   * Whether the WebSocket is currently open and subscribed.
+   */
+  readonly connected: boolean;
+
+  /**
+   * Epoch milliseconds of the most recent successful connection, or `null`
+   * if the consumer has never connected.
+   */
+  readonly lastConnectedAt: number | null;
+
+  /**
+   * Epoch milliseconds of the most recent inbound message, or `null` if no
+   * message has been received yet.
+   */
+  readonly lastEventAt: number | null;
 }
 
 /**
@@ -210,6 +253,47 @@ export class FirehoseConsumer implements IEventStreamConsumer {
   private shouldReconnect = true;
 
   /**
+   * Whether a reconnection loop is currently running. Guards against the
+   * overlapping `error` + `close` events of a single failed connection
+   * spawning two competing reconnect loops.
+   */
+  private reconnecting = false;
+
+  /**
+   * Whether the active-connection gauge has been incremented for the current
+   * socket. Keeps the gauge balanced when a connection attempt fails before
+   * ever opening (no matching `onOpen`).
+   */
+  private connectionCounted = false;
+
+  /**
+   * Epoch milliseconds of the most recent successful connection.
+   */
+  private lastConnectedAt: number | null = null;
+
+  /**
+   * Epoch milliseconds of the most recent inbound message.
+   */
+  private lastEventAt: number | null = null;
+
+  /**
+   * Liveness flag toggled by the heartbeat: set true on any message or pong,
+   * cleared before each ping. A cleared flag at ping time means the peer went
+   * silent and the socket is terminated to force reconnection.
+   */
+  private isAlive = true;
+
+  /**
+   * Active keepalive interval handle, or `null` when not connected.
+   */
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Keepalive ping interval in milliseconds (`0` disables the heartbeat).
+   */
+  private readonly heartbeatIntervalMs: number;
+
+  /**
    * Creates a firehose consumer.
    *
    * @param options - Configuration options
@@ -225,6 +309,7 @@ export class FirehoseConsumer implements IEventStreamConsumer {
         enableJitter: true,
       });
     this.logger = options.logger ?? null;
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? 30_000;
   }
 
   /**
@@ -284,8 +369,20 @@ export class FirehoseConsumer implements IEventStreamConsumer {
       done: false,
     };
 
-    // Connect
-    await this.connect();
+    // Establish the initial connection. On failure we do NOT throw out of the
+    // generator: that would tear down the whole consumer if the relay happens
+    // to be down at startup. Instead we hand off to the reconnection loop,
+    // which retries with backoff while the event loop below waits for the
+    // first buffered event.
+    try {
+      await this.connect();
+    } catch (error) {
+      this.logger?.error(
+        'Initial firehose connection failed; entering reconnection loop',
+        error instanceof Error ? error : new Error(String(error))
+      );
+      void this.onClose();
+    }
 
     // Yield events as they arrive
     while (!this.eventBuffer.done) {
@@ -370,6 +467,8 @@ export class FirehoseConsumer implements IEventStreamConsumer {
     this.shouldReconnect = false;
     this.state = ConnectionState.DISCONNECTING;
 
+    this.stopHeartbeat();
+
     if (this.ws) {
       this.ws.close();
       this.ws = null;
@@ -402,6 +501,33 @@ export class FirehoseConsumer implements IEventStreamConsumer {
    */
   getState(): ConnectionState {
     return this.state;
+  }
+
+  /**
+   * Returns a liveness snapshot for health checks.
+   *
+   * @returns Current connection state plus last-connected / last-event timestamps
+   *
+   * @remarks
+   * Used by the indexer's health endpoint and watchdog to decide whether the
+   * firehose is alive. `connected` reflects the live WebSocket state, which the
+   * keepalive heartbeat keeps honest even on half-open connections.
+   *
+   * @example
+   * ```typescript
+   * const { connected, lastConnectedAt } = consumer.getHealth();
+   * if (!connected) {
+   *   console.warn('Firehose not connected');
+   * }
+   * ```
+   */
+  getHealth(): FirehoseHealth {
+    return {
+      state: this.state,
+      connected: this.state === ConnectionState.CONNECTED,
+      lastConnectedAt: this.lastConnectedAt,
+      lastEventAt: this.lastEventAt,
+    };
   }
 
   /**
@@ -483,9 +609,15 @@ export class FirehoseConsumer implements IEventStreamConsumer {
   private onOpen(): void {
     this.state = ConnectionState.CONNECTED;
     this.reconnectionManager.reset();
+    this.lastConnectedAt = Date.now();
+    this.isAlive = true;
 
-    // Track active connection
-    firehoseMetrics.activeConnections.inc();
+    // Track active connection (balanced via connectionCounted so a failed
+    // attempt that never opens can't drive the gauge negative).
+    if (!this.connectionCounted) {
+      firehoseMetrics.activeConnections.inc();
+      this.connectionCounted = true;
+    }
 
     if (!this.ws) {
       return;
@@ -494,6 +626,11 @@ export class FirehoseConsumer implements IEventStreamConsumer {
     // Listen for messages
     this.ws.on('message', (data: Buffer) => {
       this.onMessage(data);
+    });
+
+    // Keepalive: a pong (or any message) proves the connection is alive.
+    this.ws.on('pong', () => {
+      this.isAlive = true;
     });
 
     // Listen for errors
@@ -505,6 +642,8 @@ export class FirehoseConsumer implements IEventStreamConsumer {
     this.ws.on('close', () => {
       void this.onClose();
     });
+
+    this.startHeartbeat();
   }
 
   /**
@@ -533,6 +672,11 @@ export class FirehoseConsumer implements IEventStreamConsumer {
    * @internal
    */
   private onMessage(data: Buffer): void {
+    // Any inbound traffic proves the connection is alive and keeps the
+    // heartbeat from terminating it.
+    this.isAlive = true;
+    this.lastEventAt = Date.now();
+
     try {
       // Parse Jetstream JSON event
       const jetstreamEvent = JSON.parse(data.toString('utf-8')) as JetstreamEvent;
@@ -603,8 +747,12 @@ export class FirehoseConsumer implements IEventStreamConsumer {
    * @internal
    */
   private async onClose(): Promise<void> {
-    // Decrement active connections
-    firehoseMetrics.activeConnections.dec();
+    // Stop the keepalive for the dead socket and balance the gauge.
+    this.stopHeartbeat();
+    if (this.connectionCounted) {
+      firehoseMetrics.activeConnections.dec();
+      this.connectionCounted = false;
+    }
 
     if (this.state === ConnectionState.DISCONNECTING) {
       // Graceful shutdown: don't reconnect
@@ -617,35 +765,103 @@ export class FirehoseConsumer implements IEventStreamConsumer {
       return;
     }
 
-    // Attempt reconnection
-    if (this.reconnectionManager.shouldRetry()) {
-      const delay = this.reconnectionManager.calculateDelay();
-      const attempt = this.reconnectionManager.getAttempts() + 1;
-      this.logger?.warn('Scheduling firehose reconnection', {
-        delayMs: delay,
-        attempt,
-      });
+    // Guard against overlapping reconnect loops: a single failed connection can
+    // emit both 'error' and 'close'.
+    if (this.reconnecting) {
+      return;
+    }
+    this.reconnecting = true;
 
-      await this.sleep(delay);
-      this.reconnectionManager.recordAttempt();
+    try {
+      // Retry indefinitely with capped exponential backoff. A firehose consumer
+      // must survive arbitrarily long relay outages: a transient relay 503 must
+      // never permanently wedge ingestion (the previous single-shot logic gave
+      // up after one failed attempt because the failed reconnect never re-armed
+      // the 'close' handler). A successful connect() runs onOpen(), which resets
+      // the backoff and re-arms the handlers, so the loop exits via the return
+      // below on the first successful connect.
+      while (this.shouldReconnect) {
+        const delay = this.reconnectionManager.calculateDelay();
+        const attempt = this.reconnectionManager.getAttempts() + 1;
+        this.logger?.warn('Scheduling firehose reconnection', {
+          delayMs: delay,
+          attempt,
+        });
 
-      try {
-        await this.connect();
-      } catch (error) {
-        this.logger?.error(
-          'Reconnection failed',
-          error instanceof Error ? error : new Error(String(error)),
-          { attempt }
-        );
+        await this.sleep(delay);
 
-        if (!this.reconnectionManager.shouldRetry()) {
-          // Max retries exceeded: terminate stream
-          this.terminateStream(new Error('Max reconnection attempts exceeded'));
+        if (!this.shouldReconnect) {
+          break;
+        }
+
+        this.reconnectionManager.recordAttempt();
+
+        try {
+          await this.connect();
+          this.logger?.info('Firehose reconnected', { attempt });
+          return;
+        } catch (error) {
+          this.logger?.error(
+            'Reconnection failed',
+            error instanceof Error ? error : new Error(String(error)),
+            { attempt }
+          );
+          // Loop continues; calculateDelay() grows the backoff up to maxDelay.
         }
       }
-    } else {
-      // Max retries exceeded: terminate stream
-      this.terminateStream(new Error('Max reconnection attempts exceeded'));
+    } finally {
+      this.reconnecting = false;
+    }
+  }
+
+  /**
+   * Starts the WebSocket keepalive heartbeat.
+   *
+   * @internal
+   */
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+
+    if (this.heartbeatIntervalMs <= 0) {
+      return;
+    }
+
+    this.heartbeatTimer = setInterval(() => {
+      const ws = this.ws;
+      if (!ws) {
+        return;
+      }
+
+      if (!this.isAlive) {
+        // No pong or message since the previous tick: the connection is
+        // half-open. Force-terminate it so the 'close' handler reconnects.
+        this.logger?.warn('Firehose heartbeat timed out; terminating stale connection');
+        ws.terminate();
+        return;
+      }
+
+      this.isAlive = false;
+      try {
+        ws.ping();
+      } catch {
+        // ping() can throw on an already-closing socket; let the close
+        // handler drive reconnection.
+      }
+    }, this.heartbeatIntervalMs);
+
+    // The heartbeat must not by itself keep the process alive.
+    this.heartbeatTimer.unref?.();
+  }
+
+  /**
+   * Stops the WebSocket keepalive heartbeat.
+   *
+   * @internal
+   */
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
     }
   }
 
@@ -706,21 +922,6 @@ export class FirehoseConsumer implements IEventStreamConsumer {
         }
       });
     });
-  }
-
-  /**
-   * Terminates event stream with error.
-   *
-   * @internal
-   */
-  private terminateStream(error: Error): void {
-    if (!this.eventBuffer) {
-      return;
-    }
-
-    this.eventBuffer.done = true;
-    this.eventBuffer.error = error;
-    this.resolveAllPending();
   }
 
   /**

--- a/src/services/indexing/firehose-health-server.ts
+++ b/src/services/indexing/firehose-health-server.ts
@@ -1,0 +1,270 @@
+/**
+ * HTTP health endpoint and liveness watchdog for the firehose indexer.
+ *
+ * @remarks
+ * The indexer process otherwise runs no HTTP server, so a wedged firehose
+ * consumer was previously invisible: the container's healthcheck was a no-op
+ * and Docker reported "healthy" while ingestion had been dead for weeks.
+ *
+ * This module closes that gap on two fronts:
+ *
+ * - **Detection** — exposes `GET /health`, returning `200` while every relay
+ *   consumer is connected (or only briefly disconnected) and `503` once a relay
+ *   has been disconnected longer than {@link FirehoseHealthServerOptions.unhealthyAfterMs}.
+ *   The container healthcheck polls this endpoint.
+ * - **Recovery** — a watchdog re-evaluates liveness on an interval. The
+ *   consumer reconnects itself with backoff, but if a relay stays unhealthy
+ *   past {@link FirehoseHealthServerOptions.restartAfterMs} the watchdog invokes
+ *   `onUnrecoverable` (a process restart via the container's restart policy) as
+ *   a last resort.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import http from 'node:http';
+
+import type { ILogger } from '../../types/interfaces/logger.interface.js';
+
+import type { IndexingHealth, IndexingService } from './indexing-service.js';
+
+/**
+ * Configuration for {@link startFirehoseHealthServer}.
+ *
+ * @public
+ */
+export interface FirehoseHealthServerOptions {
+  /**
+   * Indexing service whose liveness is reported.
+   */
+  readonly indexingService: IndexingService;
+
+  /**
+   * Logger instance.
+   */
+  readonly logger: ILogger;
+
+  /**
+   * TCP port for the health endpoint.
+   */
+  readonly port: number;
+
+  /**
+   * How long a relay may stay disconnected before it is reported unhealthy.
+   *
+   * @remarks
+   * Tolerates the brief disconnects of normal backoff reconnection without
+   * flapping the healthcheck.
+   *
+   * @defaultValue 300000 (5 minutes)
+   */
+  readonly unhealthyAfterMs?: number;
+
+  /**
+   * How long the firehose may stay continuously unhealthy before the watchdog
+   * triggers recovery via {@link FirehoseHealthServerOptions.onUnrecoverable}.
+   *
+   * @defaultValue 900000 (15 minutes)
+   */
+  readonly restartAfterMs?: number;
+
+  /**
+   * Watchdog evaluation interval.
+   *
+   * @defaultValue 30000 (30 seconds)
+   */
+  readonly checkIntervalMs?: number;
+
+  /**
+   * Invoked when the firehose has been unhealthy past
+   * {@link FirehoseHealthServerOptions.restartAfterMs}.
+   *
+   * @remarks
+   * Defaults to exiting the process with a non-zero code so the container
+   * restart policy brings up a fresh consumer. Injectable for tests and to
+   * route recovery through a graceful shutdown.
+   */
+  readonly onUnrecoverable?: () => void;
+}
+
+/**
+ * Handle for stopping the health server and watchdog.
+ *
+ * @public
+ */
+export interface FirehoseHealthServer {
+  /**
+   * Stops the watchdog and closes the HTTP server.
+   */
+  close(): Promise<void>;
+}
+
+/**
+ * Result of a liveness evaluation.
+ *
+ * @public
+ */
+export interface FirehoseHealthEvaluation {
+  /**
+   * Whether the firehose is considered healthy.
+   */
+  readonly healthy: boolean;
+
+  /**
+   * Human-readable reason when unhealthy.
+   */
+  readonly reason?: string;
+}
+
+/**
+ * Pure liveness decision used by both the HTTP endpoint and the watchdog.
+ *
+ * @param health - Snapshot from {@link IndexingService.getHealth}
+ * @param unhealthyAfterMs - Disconnect tolerance window
+ * @param now - Current epoch milliseconds
+ * @returns Whether the firehose is healthy, with a reason when not
+ *
+ * @public
+ */
+export function evaluateFirehoseHealth(
+  health: IndexingHealth,
+  unhealthyAfterMs: number,
+  now: number
+): FirehoseHealthEvaluation {
+  if (!health.running) {
+    return { healthy: false, reason: 'indexing service not running' };
+  }
+
+  if (health.relays.length === 0) {
+    return { healthy: false, reason: 'no relays configured' };
+  }
+
+  for (const relay of health.relays) {
+    if (relay.connected) {
+      continue;
+    }
+
+    // Tolerate brief disconnects while the consumer reconnects with backoff.
+    if (relay.lastConnectedAt !== null && now - relay.lastConnectedAt < unhealthyAfterMs) {
+      continue;
+    }
+
+    const detail =
+      relay.lastConnectedAt === null
+        ? 'never connected'
+        : `disconnected for ${Math.round((now - relay.lastConnectedAt) / 1000)}s`;
+    return { healthy: false, reason: `relay ${relay.relay} ${detail}` };
+  }
+
+  return { healthy: true };
+}
+
+/**
+ * Starts the firehose health endpoint and liveness watchdog.
+ *
+ * @param options - Server configuration
+ * @returns Handle for stopping the server and watchdog
+ *
+ * @example
+ * ```typescript
+ * const health = startFirehoseHealthServer({
+ *   indexingService,
+ *   logger,
+ *   port: 3001,
+ *   onUnrecoverable: () => void shutdown(state, 'firehose-watchdog'),
+ * });
+ * ```
+ *
+ * @public
+ */
+export function startFirehoseHealthServer(
+  options: FirehoseHealthServerOptions
+): FirehoseHealthServer {
+  const unhealthyAfterMs = options.unhealthyAfterMs ?? 300_000;
+  const restartAfterMs = options.restartAfterMs ?? 900_000;
+  const checkIntervalMs = options.checkIntervalMs ?? 30_000;
+  const onUnrecoverable =
+    options.onUnrecoverable ??
+    ((): void => {
+      process.exit(1);
+    });
+
+  let unhealthySince: number | null = null;
+  let recovering = false;
+
+  const server = http.createServer((req, res) => {
+    const path = (req.url ?? '/').split('?')[0];
+    if (req.method === 'GET' && (path === '/health' || path === '/healthz')) {
+      const health = options.indexingService.getHealth();
+      const evaluation = evaluateFirehoseHealth(health, unhealthyAfterMs, Date.now());
+      const body = JSON.stringify({
+        status: evaluation.healthy ? 'ok' : 'unhealthy',
+        reason: evaluation.reason,
+        running: health.running,
+        relays: health.relays,
+      });
+      res.writeHead(evaluation.healthy ? 200 : 503, { 'content-type': 'application/json' });
+      res.end(body);
+      return;
+    }
+
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end('{"error":"not found"}');
+  });
+
+  server.on('error', (error: Error) => {
+    options.logger.error('Firehose health server error', error);
+  });
+
+  server.listen(options.port, () => {
+    options.logger.info('Firehose health server listening', { port: options.port });
+  });
+
+  const watchdog = setInterval(() => {
+    const now = Date.now();
+    const health = options.indexingService.getHealth();
+    const evaluation = evaluateFirehoseHealth(health, unhealthyAfterMs, now);
+
+    if (evaluation.healthy) {
+      unhealthySince = null;
+      return;
+    }
+
+    if (unhealthySince === null) {
+      unhealthySince = now;
+      options.logger.warn('Firehose unhealthy; reconnection in progress', {
+        reason: evaluation.reason,
+      });
+      return;
+    }
+
+    const unhealthyMs = now - unhealthySince;
+    if (unhealthyMs >= restartAfterMs && !recovering) {
+      recovering = true;
+      options.logger.error(
+        'Firehose unhealthy past recovery threshold; restarting process',
+        new Error(evaluation.reason ?? 'firehose unhealthy'),
+        { unhealthyMs, restartAfterMs }
+      );
+      onUnrecoverable();
+      return;
+    }
+
+    options.logger.warn('Firehose still unhealthy', {
+      reason: evaluation.reason,
+      unhealthyMs,
+    });
+  }, checkIntervalMs);
+
+  // The watchdog must not by itself keep the process alive.
+  watchdog.unref?.();
+
+  return {
+    async close(): Promise<void> {
+      clearInterval(watchdog);
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}

--- a/src/services/indexing/indexing-service.ts
+++ b/src/services/indexing/indexing-service.ts
@@ -60,7 +60,7 @@ import { CursorManager } from './cursor-manager.js';
 import { DeadLetterQueue, type AlertService, type DLQEvent } from './dlq-handler.js';
 import { EventFilter } from './event-filter.js';
 import { EventQueue, BackpressureError } from './event-queue.js';
-import { FirehoseConsumer } from './firehose-consumer.js';
+import { type ConnectionState, FirehoseConsumer } from './firehose-consumer.js';
 import { ReconnectionManager } from './reconnection-manager.js';
 
 /**
@@ -258,6 +258,60 @@ export interface RelayStatus {
    * Last event timestamp from this relay.
    */
   readonly lastEvent: Date | null;
+}
+
+/**
+ * Liveness of a single relay's firehose consumer.
+ *
+ * @public
+ */
+export interface RelayHealth {
+  /**
+   * Relay name.
+   */
+  readonly relay: string;
+
+  /**
+   * Live WebSocket connection state.
+   */
+  readonly state: ConnectionState;
+
+  /**
+   * Whether the WebSocket is currently open and subscribed.
+   */
+  readonly connected: boolean;
+
+  /**
+   * Epoch milliseconds of the most recent successful connection, or `null`.
+   */
+  readonly lastConnectedAt: number | null;
+
+  /**
+   * Epoch milliseconds of the most recent inbound message, or `null`.
+   */
+  readonly lastEventAt: number | null;
+}
+
+/**
+ * Aggregate firehose liveness snapshot across all relays.
+ *
+ * @public
+ */
+export interface IndexingHealth {
+  /**
+   * Whether the indexing service is running.
+   */
+  readonly running: boolean;
+
+  /**
+   * When the service started, or `null` if not started.
+   */
+  readonly startedAt: Date | null;
+
+  /**
+   * Per-relay liveness.
+   */
+  readonly relays: readonly RelayHealth[];
 }
 
 export interface IndexingStatus {
@@ -764,6 +818,45 @@ export class IndexingService {
       startedAt: this.startedAt,
       relayStatuses: relayStatuses.length > 1 ? relayStatuses : undefined,
       duplicatesFiltered: this.duplicatesFiltered > 0 ? this.duplicatesFiltered : undefined,
+    };
+  }
+
+  /**
+   * Returns a liveness snapshot for health checks and the firehose watchdog.
+   *
+   * @returns Per-relay connection state derived from the live WebSocket(s)
+   *
+   * @remarks
+   * Unlike {@link getStatus}, which reports the subscribe loop's `connected`
+   * flag, this reflects each consumer's real WebSocket state. The keepalive
+   * heartbeat keeps that state honest even on half-open connections, so a
+   * disconnected (or wedged-and-reconnecting) firehose is observable here.
+   *
+   * @example
+   * ```typescript
+   * const health = service.getHealth();
+   * if (!health.relays.every((r) => r.connected)) {
+   *   logger.warn('Firehose degraded', health);
+   * }
+   * ```
+   */
+  getHealth(): IndexingHealth {
+    const relays: RelayHealth[] = [];
+    for (const state of this.relayStates.values()) {
+      const consumerHealth = state.consumer.getHealth();
+      relays.push({
+        relay: this.getRelayName(state.relay),
+        state: consumerHealth.state,
+        connected: consumerHealth.connected,
+        lastConnectedAt: consumerHealth.lastConnectedAt,
+        lastEventAt: consumerHealth.lastEventAt,
+      });
+    }
+
+    return {
+      running: this.running,
+      startedAt: this.startedAt,
+      relays,
     };
   }
 

--- a/src/utils/app-version.ts
+++ b/src/utils/app-version.ts
@@ -1,0 +1,93 @@
+/**
+ * Resolves the running service's own release version.
+ *
+ * @remarks
+ * Distinct from `./version.js`, which handles semantic versioning of eprint
+ * records. This module answers "which Chive release is this process?" and is
+ * used by the health endpoints, the logger, and telemetry resources.
+ *
+ * `process.env.npm_package_version` is only populated when a process is
+ * launched through a package script. The production image starts Node directly
+ * (`CMD ["node", "--enable-source-maps", "dist/src/index.js"]`), so that
+ * variable is unset in every deployed container and the version silently
+ * degraded to `0.0.0`. Reading `package.json` relative to the working directory
+ * covers both cases: `WORKDIR /app` in the production image, where the builder
+ * stage copies `package.json` alongside `dist/`, and the repository root in
+ * development.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Version reported when the real version cannot be determined.
+ *
+ * @public
+ */
+export const UNKNOWN_APP_VERSION = '0.0.0';
+
+let cachedVersion: string | undefined;
+
+/**
+ * Reads the `version` field from the working directory's `package.json`.
+ *
+ * @returns The version string, or undefined if the file is missing, unreadable,
+ * malformed, or carries no string `version`
+ *
+ * @internal
+ */
+function readVersionFromPackageJson(): string | undefined {
+  try {
+    const contents = readFileSync(join(process.cwd(), 'package.json'), 'utf8');
+    const parsed: unknown = JSON.parse(contents);
+
+    if (typeof parsed !== 'object' || parsed === null || !('version' in parsed)) {
+      return undefined;
+    }
+
+    const { version } = parsed as { version: unknown };
+    return typeof version === 'string' && version.length > 0 ? version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns the release version of the running service.
+ *
+ * @returns The semantic version string, or `0.0.0` if it cannot be determined
+ *
+ * @remarks
+ * Resolution order: `npm_package_version`, then `package.json` in the working
+ * directory, then {@link UNKNOWN_APP_VERSION}. The result is cached, so the
+ * file is read at most once per process.
+ *
+ * @example
+ * ```typescript
+ * getAppVersion(); // "0.7.0"
+ * ```
+ *
+ * @public
+ */
+export function getAppVersion(): string {
+  cachedVersion ??=
+    process.env.npm_package_version ?? readVersionFromPackageJson() ?? UNKNOWN_APP_VERSION;
+
+  return cachedVersion;
+}
+
+/**
+ * Clears the cached version so the next {@link getAppVersion} call re-resolves.
+ *
+ * @remarks
+ * Exists for tests that need to exercise different resolution paths within a
+ * single process. Production code should not call this.
+ *
+ * @internal
+ */
+export function resetAppVersionCache(): void {
+  cachedVersion = undefined;
+}

--- a/tests/unit/api/handlers/xrpc/eprint/deleteSubmission.test.ts
+++ b/tests/unit/api/handlers/xrpc/eprint/deleteSubmission.test.ts
@@ -98,10 +98,12 @@ const createMockEprint = (overrides?: Partial<EprintView>): EprintView => ({
 
 interface MockEprintService {
   getEprint: ReturnType<typeof vi.fn>;
+  indexEprintDelete: ReturnType<typeof vi.fn>;
 }
 
 const createMockEprintService = (): MockEprintService => ({
   getEprint: vi.fn(),
+  indexEprintDelete: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
 });
 
 describe('XRPC deleteSubmission Handler', () => {
@@ -153,6 +155,9 @@ describe('XRPC deleteSubmission Handler', () => {
       expect(result.encoding).toBe('application/json');
       expect(result.body.success).toBe(true);
       expect(mockEprintService.getEprint).toHaveBeenCalledWith(eprint.uri);
+      // Removes the eprint from Chive's own index immediately rather than
+      // relying solely on the firehose delete event.
+      expect(mockEprintService.indexEprintDelete).toHaveBeenCalledWith(eprint.uri);
       expect(mockLogger.info).toHaveBeenCalledWith(
         'Delete submission authorized',
         expect.objectContaining({
@@ -161,6 +166,22 @@ describe('XRPC deleteSubmission Handler', () => {
           isPaperCentric: false,
         })
       );
+    });
+
+    it('propagates an error when index deletion fails', async () => {
+      const eprint = createMockEprint();
+      mockEprintService.getEprint.mockResolvedValue(eprint);
+      const dbError = new Error('index delete failed');
+      mockEprintService.indexEprintDelete.mockResolvedValue({ ok: false, error: dbError });
+
+      await expect(
+        deleteSubmission.handler({
+          params: undefined as unknown as void,
+          input: { uri: eprint.uri },
+          auth: { did: SUBMITTER_DID, iss: 'https://bsky.social' } as AuthContext,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('index delete failed');
     });
 
     it('throws AuthorizationError when non-owner tries to delete', async () => {

--- a/tests/unit/services/indexing/firehose-consumer.test.ts
+++ b/tests/unit/services/indexing/firehose-consumer.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for FirehoseConsumer reconnection and liveness behavior.
+ *
+ * @remarks
+ * Focuses on the regression that previously wedged production: a single failed
+ * reconnection attempt permanently stopped the consumer. The reconnect loop
+ * must keep retrying with backoff until it reconnects.
+ *
+ * @packageDocumentation
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Self-contained WebSocket mock (no EventEmitter import: vi.hoisted runs before
+// module imports). Each constructed socket is pushed to `sockets` so the test
+// can drive open/close/error events and assert reconnection.
+const wsMock = vi.hoisted(() => {
+  class MockSocket {
+    public readonly url: string;
+    public terminateCount = 0;
+    public pingCount = 0;
+    private readonly listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+    constructor(url: string) {
+      this.url = url;
+      MockSocket.instances.push(this);
+    }
+
+    static instances: MockSocket[] = [];
+
+    on(event: string, cb: (...args: unknown[]) => void): this {
+      (this.listeners[event] ??= []).push(cb);
+      return this;
+    }
+
+    once(event: string, cb: (...args: unknown[]) => void): this {
+      const wrapper = (...args: unknown[]): void => {
+        this.off(event, wrapper);
+        cb(...args);
+      };
+      return this.on(event, wrapper);
+    }
+
+    off(event: string, cb: (...args: unknown[]) => void): this {
+      this.listeners[event] = (this.listeners[event] ?? []).filter((f) => f !== cb);
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      for (const cb of (this.listeners[event] ?? []).slice()) {
+        cb(...args);
+      }
+    }
+
+    ping(): void {
+      this.pingCount += 1;
+    }
+
+    terminate(): void {
+      this.terminateCount += 1;
+      this.emit('close');
+    }
+
+    close(): void {
+      this.emit('close');
+    }
+  }
+  return { MockSocket };
+});
+
+vi.mock('ws', () => ({ default: wsMock.MockSocket }));
+
+import type { CursorManager } from '../../../../src/services/indexing/cursor-manager.js';
+import {
+  ConnectionState,
+  FirehoseConsumer,
+} from '../../../../src/services/indexing/firehose-consumer.js';
+import { ReconnectionManager } from '../../../../src/services/indexing/reconnection-manager.js';
+
+function createCursorManager(): CursorManager {
+  return {
+    getCurrentCursor: vi.fn().mockResolvedValue(null),
+    updateCursor: vi.fn().mockResolvedValue(undefined),
+    flush: vi.fn().mockResolvedValue(undefined),
+    getPendingCursor: vi.fn().mockReturnValue(null),
+  } as unknown as CursorManager;
+}
+
+function makeConsumer(heartbeatIntervalMs = 0): FirehoseConsumer {
+  return new FirehoseConsumer({
+    cursorManager: createCursorManager(),
+    // Fixed tiny delay, no jitter, so fake timers advance deterministically.
+    reconnectionManager: new ReconnectionManager({
+      maxAttempts: 100,
+      baseDelay: 10,
+      maxDelay: 10,
+      enableJitter: false,
+    }),
+    heartbeatIntervalMs,
+  });
+}
+
+/** Flush pending microtasks. */
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/** Returns the constructed socket at the given index, asserting it exists. */
+function socketAt(index: number): InstanceType<typeof wsMock.MockSocket> {
+  const socket = wsMock.MockSocket.instances[index];
+  if (!socket) {
+    throw new Error(`expected a socket at index ${index}`);
+  }
+  return socket;
+}
+
+describe('FirehoseConsumer reconnection', () => {
+  beforeEach(() => {
+    wsMock.MockSocket.instances.length = 0;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('keeps retrying after a failed reconnection attempt', async () => {
+    const consumer = makeConsumer();
+    const sockets = wsMock.MockSocket.instances;
+
+    // Begin consuming: connect() creates the first socket.
+    const iterator = consumer.subscribe({ relay: 'wss://relay.test' })[Symbol.asyncIterator]();
+    void iterator.next();
+    await flush();
+    expect(sockets).toHaveLength(1);
+
+    // First connection opens successfully.
+    socketAt(0).emit('open');
+    await flush();
+    expect(consumer.getHealth().connected).toBe(true);
+
+    // Connection drops -> schedules a reconnect.
+    socketAt(0).emit('close');
+    await flush();
+
+    // After the backoff delay, the consumer reconnects (socket #2)...
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sockets).toHaveLength(2);
+
+    // ...but that reconnect FAILS before opening (the exact case that used to
+    // permanently wedge the consumer).
+    socketAt(1).emit('error', new Error('Unexpected server response: 503'));
+    await flush();
+
+    // The fix: it must schedule ANOTHER attempt rather than give up.
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sockets).toHaveLength(3);
+
+    // The next attempt succeeds and the consumer is healthy again.
+    socketAt(2).emit('open');
+    await flush();
+    expect(consumer.getHealth().connected).toBe(true);
+    expect(consumer.getState()).toBe(ConnectionState.CONNECTED);
+
+    await consumer.disconnect();
+  });
+
+  it('does not reconnect after a graceful disconnect', async () => {
+    const consumer = makeConsumer();
+    const sockets = wsMock.MockSocket.instances;
+
+    const iterator = consumer.subscribe({ relay: 'wss://relay.test' })[Symbol.asyncIterator]();
+    void iterator.next();
+    await flush();
+    socketAt(0).emit('open');
+    await flush();
+
+    await consumer.disconnect();
+    socketAt(0).emit('close');
+    await flush();
+    await vi.advanceTimersByTimeAsync(100);
+
+    // No new socket: a graceful disconnect must not reconnect.
+    expect(sockets).toHaveLength(1);
+    expect(consumer.getHealth().connected).toBe(false);
+  });
+
+  it('terminates a half-open connection when the heartbeat gets no pong', async () => {
+    const consumer = makeConsumer(50);
+
+    const iterator = consumer.subscribe({ relay: 'wss://relay.test' })[Symbol.asyncIterator]();
+    void iterator.next();
+    await flush();
+    socketAt(0).emit('open');
+    await flush();
+
+    // First heartbeat tick: isAlive was true (just opened) -> sends a ping.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(socketAt(0).pingCount).toBe(1);
+
+    // No pong arrives. Next tick: isAlive is false -> terminate the socket.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(socketAt(0).terminateCount).toBe(1);
+
+    await consumer.disconnect();
+  });
+});

--- a/tests/unit/services/indexing/firehose-health-server.test.ts
+++ b/tests/unit/services/indexing/firehose-health-server.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the firehose health evaluation logic.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { ConnectionState } from '../../../../src/services/indexing/firehose-consumer.js';
+import { evaluateFirehoseHealth } from '../../../../src/services/indexing/firehose-health-server.js';
+import type {
+  IndexingHealth,
+  RelayHealth,
+} from '../../../../src/services/indexing/indexing-service.js';
+
+const NOW = 1_000_000_000_000;
+const GRACE = 300_000; // 5 minutes
+
+function relay(overrides: Partial<RelayHealth>): RelayHealth {
+  return {
+    relay: 'bsky',
+    state: ConnectionState.CONNECTED,
+    connected: true,
+    lastConnectedAt: NOW,
+    lastEventAt: NOW,
+    ...overrides,
+  };
+}
+
+function health(overrides: Partial<IndexingHealth>): IndexingHealth {
+  return {
+    running: true,
+    startedAt: new Date(NOW),
+    relays: [relay({})],
+    ...overrides,
+  };
+}
+
+describe('evaluateFirehoseHealth', () => {
+  it('is healthy when the relay is connected', () => {
+    expect(evaluateFirehoseHealth(health({}), GRACE, NOW).healthy).toBe(true);
+  });
+
+  it('is unhealthy when the service is not running', () => {
+    const result = evaluateFirehoseHealth(health({ running: false }), GRACE, NOW);
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/not running/);
+  });
+
+  it('is unhealthy when no relays are configured', () => {
+    const result = evaluateFirehoseHealth(health({ relays: [] }), GRACE, NOW);
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/no relays/);
+  });
+
+  it('tolerates a brief disconnect within the grace window', () => {
+    const recent = relay({
+      connected: false,
+      state: ConnectionState.DISCONNECTED,
+      lastConnectedAt: NOW - (GRACE - 1),
+    });
+    expect(evaluateFirehoseHealth(health({ relays: [recent] }), GRACE, NOW).healthy).toBe(true);
+  });
+
+  it('is unhealthy once a disconnect exceeds the grace window', () => {
+    const stale = relay({
+      connected: false,
+      state: ConnectionState.DISCONNECTED,
+      lastConnectedAt: NOW - (GRACE + 1),
+    });
+    const result = evaluateFirehoseHealth(health({ relays: [stale] }), GRACE, NOW);
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/bsky/);
+  });
+
+  it('is unhealthy when a relay has never connected', () => {
+    const never = relay({
+      connected: false,
+      state: ConnectionState.CONNECTING,
+      lastConnectedAt: null,
+    });
+    const result = evaluateFirehoseHealth(health({ relays: [never] }), GRACE, NOW);
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/never connected/);
+  });
+
+  it('is unhealthy when any one of several relays is down', () => {
+    const result = evaluateFirehoseHealth(
+      health({
+        relays: [
+          relay({ relay: 'a' }),
+          relay({ relay: 'b', connected: false, lastConnectedAt: NOW - (GRACE + 5000) }),
+        ],
+      }),
+      GRACE,
+      NOW
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/b/);
+  });
+});

--- a/tests/unit/utils/app-version.test.ts
+++ b/tests/unit/utils/app-version.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for release version resolution.
+ *
+ * @remarks
+ * Tests validate the resolution order that keeps deployed containers from
+ * reporting `0.0.0`: the `npm_package_version` environment variable first, then
+ * the working directory's `package.json`, then the unknown-version fallback.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getAppVersion, resetAppVersionCache, UNKNOWN_APP_VERSION } from '@/utils/app-version.js';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+const mockReadFileSync = vi.mocked(readFileSync);
+
+describe('getAppVersion', () => {
+  const originalEnvVersion = process.env.npm_package_version;
+
+  beforeEach(() => {
+    resetAppVersionCache();
+    vi.clearAllMocks();
+    delete process.env.npm_package_version;
+  });
+
+  afterEach(() => {
+    if (originalEnvVersion === undefined) {
+      delete process.env.npm_package_version;
+    } else {
+      process.env.npm_package_version = originalEnvVersion;
+    }
+    resetAppVersionCache();
+  });
+
+  it('should prefer npm_package_version when the process was launched via a package script', () => {
+    process.env.npm_package_version = '1.2.3';
+
+    expect(getAppVersion()).toBe('1.2.3');
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should read package.json when npm_package_version is unset', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@chive/monorepo', version: '0.7.0' }));
+
+    expect(getAppVersion()).toBe('0.7.0');
+  });
+
+  it('should resolve package.json relative to the working directory', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.7.0' }));
+
+    getAppVersion();
+
+    const [path] = mockReadFileSync.mock.calls[0] ?? [];
+    expect(String(path)).toBe(`${process.cwd()}/package.json`);
+  });
+
+  it('should cache the result so package.json is read at most once', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.7.0' }));
+
+    expect(getAppVersion()).toBe('0.7.0');
+    expect(getAppVersion()).toBe('0.7.0');
+    expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fall back when package.json cannot be read', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT: no such file or directory');
+    });
+
+    expect(getAppVersion()).toBe(UNKNOWN_APP_VERSION);
+  });
+
+  it('should fall back when package.json is not valid JSON', () => {
+    mockReadFileSync.mockReturnValue('not json at all');
+
+    expect(getAppVersion()).toBe(UNKNOWN_APP_VERSION);
+  });
+
+  it('should fall back when package.json carries no version field', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@chive/monorepo' }));
+
+    expect(getAppVersion()).toBe(UNKNOWN_APP_VERSION);
+  });
+
+  it('should fall back when version is not a non-empty string', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '' }));
+
+    expect(getAppVersion()).toBe(UNKNOWN_APP_VERSION);
+  });
+});

--- a/web/app/eprints/[...uri]/eprint-content.tsx
+++ b/web/app/eprints/[...uri]/eprint-content.tsx
@@ -86,6 +86,7 @@ import {
   useDeleteEndorsement,
 } from '@/lib/hooks/use-endorsement';
 import { useIsAuthenticated, useCurrentUser, useAgent } from '@/lib/auth';
+import { deleteStandardDocumentsForEprint } from '@/lib/atproto/record-creator';
 import { getPaperSession } from '@/lib/auth/paper-session';
 import { useEprintPermissions, useDeleteEprint } from '@/lib/hooks';
 import type { Review, Endorsement, ContributionType } from '@/lib/api/schema';
@@ -374,6 +375,26 @@ export function EprintDetailContent({ uri }: EprintDetailContentProps) {
             repo,
             collection,
             rkey,
+          });
+        }
+
+        // Step 3: Delete the site.standard.document record(s) dual-written for
+        // this eprint. They live in the same repo and are linked only by
+        // content.uri, so deleting the eprint alone orphans them in the PDS.
+        // Best-effort: the eprint itself is already gone, so a failure here is
+        // logged but does not fail the deletion.
+        try {
+          const removed = await deleteStandardDocumentsForEprint(effectiveAgent, uri);
+          if (removed.length > 0) {
+            eprintLogger.info('Deleted associated standard documents', {
+              eprintUri: uri,
+              count: removed.length,
+            });
+          }
+        } catch (standardError) {
+          eprintLogger.warn('Failed to delete associated standard documents', {
+            eprintUri: uri,
+            error: standardError instanceof Error ? standardError.message : String(standardError),
           });
         }
       }

--- a/web/app/oauth/client-metadata.json/route.ts
+++ b/web/app/oauth/client-metadata.json/route.ts
@@ -97,31 +97,9 @@ const EXTERNAL_SCOPES = [
  */
 const RPC_WILDCARD_SCOPE = `rpc:*?aud=${CHIVE_SERVICE_DID}`;
 
-/**
- * Legacy catch-all scope that authorizes `com.atproto.server.getServiceAuth`.
- *
- * @remarks
- * The granular permission-set `rpc` grants (aud:"*") express service-auth
- * minting, but the deployed bsky PDS does not yet authorize getServiceAuth
- * against them, so every getServiceAuth call 401s and the AppView falls back
- * to anonymous (getMyProfile, discovery settings, collections all 401).
- *
- * `transition:generic` is the scope the PDS does honor for getServiceAuth, so
- * the client must be allowed to request it. The granular scopes remain and
- * supersede this automatically once the PDS honors rpc grants for service auth.
- */
-const LEGACY_SERVICE_AUTH_SCOPE = 'transition:generic';
-
 function buildScope(): string {
   const chive = USE_PERMISSION_SETS ? PERMISSION_SET_SCOPES : CHIVE_REPO_SCOPES;
-  return [
-    'atproto',
-    ...chive,
-    RPC_WILDCARD_SCOPE,
-    LEGACY_SERVICE_AUTH_SCOPE,
-    ...EXTERNAL_SCOPES,
-    'blob:*/*',
-  ].join(' ');
+  return ['atproto', ...chive, RPC_WILDCARD_SCOPE, ...EXTERNAL_SCOPES, 'blob:*/*'].join(' ');
 }
 
 /**

--- a/web/app/oauth/client-metadata.json/route.ts
+++ b/web/app/oauth/client-metadata.json/route.ts
@@ -94,17 +94,34 @@ const EXTERNAL_SCOPES = [
  * `rpc:*?aud=<chive-did>` grants "any rpc method, but only when the
  * audience is Chive's API DID" -- one scope string instead of enumerating
  * 60+ lxms. The forbidden form is `rpc:*?aud=*` (any rpc to any service).
- *
- * Required on the legacy `repo:`-scope path because that path emits no
- * rpc scopes; on the `include:` permission-set path the rpc scopes are
- * inherited from each set's `inheritAud: true` rpc permission and this
- * wildcard isn't strictly required but is harmless.
  */
 const RPC_WILDCARD_SCOPE = `rpc:*?aud=${CHIVE_SERVICE_DID}`;
 
+/**
+ * Legacy catch-all scope that authorizes `com.atproto.server.getServiceAuth`.
+ *
+ * @remarks
+ * The granular permission-set `rpc` grants (aud:"*") express service-auth
+ * minting, but the deployed bsky PDS does not yet authorize getServiceAuth
+ * against them, so every getServiceAuth call 401s and the AppView falls back
+ * to anonymous (getMyProfile, discovery settings, collections all 401).
+ *
+ * `transition:generic` is the scope the PDS does honor for getServiceAuth, so
+ * the client must be allowed to request it. The granular scopes remain and
+ * supersede this automatically once the PDS honors rpc grants for service auth.
+ */
+const LEGACY_SERVICE_AUTH_SCOPE = 'transition:generic';
+
 function buildScope(): string {
   const chive = USE_PERMISSION_SETS ? PERMISSION_SET_SCOPES : CHIVE_REPO_SCOPES;
-  return ['atproto', ...chive, RPC_WILDCARD_SCOPE, ...EXTERNAL_SCOPES, 'blob:*/*'].join(' ');
+  return [
+    'atproto',
+    ...chive,
+    RPC_WILDCARD_SCOPE,
+    LEGACY_SERVICE_AUTH_SCOPE,
+    ...EXTERNAL_SCOPES,
+    'blob:*/*',
+  ].join(' ');
 }
 
 /**

--- a/web/lib/atproto/record-creator.test.ts
+++ b/web/lib/atproto/record-creator.test.ts
@@ -25,6 +25,7 @@ import {
   parseAtUri,
   createStandardDocument,
   updateStandardDocument,
+  deleteStandardDocumentsForEprint,
 } from './record-creator';
 
 // =============================================================================
@@ -370,6 +371,98 @@ describe('deleteRecord', () => {
 
     await expect(deleteRecord(agent, uri)).rejects.toThrow(
       'Cannot delete records belonging to other users'
+    );
+  });
+});
+
+describe('deleteStandardDocumentsForEprint', () => {
+  const did = 'did:plc:test123';
+  const eprintUri = `at://${did}/pub.chive.eprint.submission/paper123`;
+
+  /**
+   * Build a mock agent whose listRecords returns the supplied pages of
+   * site.standard.document records.
+   */
+  function createListingAgent(pages: Array<{ records: unknown[]; cursor?: string }>) {
+    const agent = createMockAgent({ did });
+    const listRecords = vi.fn();
+    pages.forEach((page) => {
+      listRecords.mockResolvedValueOnce({ data: { records: page.records, cursor: page.cursor } });
+    });
+    (agent.com.atproto.repo as unknown as { listRecords: typeof listRecords }).listRecords =
+      listRecords;
+    return { agent, listRecords };
+  }
+
+  it('deletes only the documents pointing at the eprint', async () => {
+    const { agent } = createListingAgent([
+      {
+        records: [
+          {
+            uri: `at://${did}/site.standard.document/match1`,
+            value: { content: { uri: eprintUri } },
+          },
+          {
+            uri: `at://${did}/site.standard.document/other`,
+            value: { content: { uri: `at://${did}/pub.chive.eprint.submission/different` } },
+          },
+        ],
+      },
+    ]);
+
+    const deleted = await deleteStandardDocumentsForEprint(agent, eprintUri);
+
+    expect(deleted).toEqual([`at://${did}/site.standard.document/match1`]);
+    expect(agent.com.atproto.repo.deleteRecord).toHaveBeenCalledTimes(1);
+    expect(agent.com.atproto.repo.deleteRecord).toHaveBeenCalledWith({
+      repo: did,
+      collection: 'site.standard.document',
+      rkey: 'match1',
+    });
+  });
+
+  it('pages through the collection until the cursor is exhausted', async () => {
+    const { agent, listRecords } = createListingAgent([
+      {
+        records: [
+          {
+            uri: `at://${did}/site.standard.document/match1`,
+            value: { content: { uri: eprintUri } },
+          },
+        ],
+        cursor: 'page2',
+      },
+      {
+        records: [
+          {
+            uri: `at://${did}/site.standard.document/match2`,
+            value: { content: { uri: eprintUri } },
+          },
+        ],
+      },
+    ]);
+
+    const deleted = await deleteStandardDocumentsForEprint(agent, eprintUri);
+
+    expect(deleted).toHaveLength(2);
+    expect(listRecords).toHaveBeenCalledTimes(2);
+    expect(listRecords.mock.calls[1][0]).toMatchObject({ cursor: 'page2' });
+  });
+
+  it('returns an empty array when no documents match', async () => {
+    const { agent } = createListingAgent([{ records: [] }]);
+
+    const deleted = await deleteStandardDocumentsForEprint(agent, eprintUri);
+
+    expect(deleted).toEqual([]);
+    expect(agent.com.atproto.repo.deleteRecord).not.toHaveBeenCalled();
+  });
+
+  it('throws when the agent is not authenticated', async () => {
+    const agent = createMockAgent({ authenticated: false });
+
+    await expect(deleteStandardDocumentsForEprint(agent, eprintUri)).rejects.toThrow(
+      'Agent is not authenticated'
     );
   });
 });

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -2143,6 +2143,68 @@ export async function createStandardDocument(
 }
 
 /**
+ * Find and delete every `site.standard.document` record in a repo that points
+ * at a given eprint.
+ *
+ * @remarks
+ * Standard documents are dual-written alongside an eprint at submission time
+ * (see {@link createStandardDocument}) and are linked back only by their
+ * `content.uri` field. When the eprint is deleted these must be removed too,
+ * otherwise they are orphaned in the PDS and continue to surface the deleted
+ * eprint to standard.site readers.
+ *
+ * Only the agent's own repo is scanned. For a traditional eprint the document
+ * lives in the submitter's PDS; for a paper-centric eprint it lives in the
+ * paper account's PDS, so pass the matching agent.
+ *
+ * @param agent - Authenticated ATProto Agent for the repo holding the documents
+ * @param eprintUri - AT-URI of the eprint whose documents should be removed
+ * @returns AT-URIs of the standard document records that were deleted
+ *
+ * @throws Error if the agent is not authenticated
+ *
+ * @example
+ * ```typescript
+ * const removed = await deleteStandardDocumentsForEprint(agent, eprintUri);
+ * console.log(`Removed ${removed.length} standard document(s)`);
+ * ```
+ */
+export async function deleteStandardDocumentsForEprint(
+  agent: Agent,
+  eprintUri: string
+): Promise<string[]> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const deleted: string[] = [];
+  let cursor: string | undefined;
+
+  // Page through the collection: a prolific author can have many documents.
+  do {
+    const response = await agent.com.atproto.repo.listRecords({
+      repo: did,
+      collection: 'site.standard.document',
+      limit: 100,
+      cursor,
+    });
+
+    for (const record of response.data.records) {
+      const value = record.value as StandardDocumentRecord;
+      if (value.content?.uri === eprintUri) {
+        await deleteRecord(agent, record.uri);
+        deleted.push(record.uri);
+      }
+    }
+
+    cursor = response.data.cursor;
+  } while (cursor);
+
+  return deleted;
+}
+
+/**
  * Input for updating a standard.site document.
  */
 export interface UpdateStandardDocumentInput {

--- a/web/lib/auth/oauth-client.ts
+++ b/web/lib/auth/oauth-client.ts
@@ -16,7 +16,7 @@ import {
 } from '@atproto/oauth-client-browser';
 import { Agent } from '@atproto/api';
 import type { DID, Handle, ChiveUser, LoginOptions } from './types';
-import { getScopesForIntent, LEGACY_SCOPE } from './scopes';
+import { getScopesForIntent } from './scopes';
 import { AuthenticationError, NetworkError } from '@/lib/errors';
 import { logger } from '@/lib/observability';
 
@@ -316,20 +316,15 @@ export async function startLogin(options: LoginOptions): Promise<string> {
   const client = await getOAuthClient();
 
   try {
-    // Request granular scopes based on the user's intent, PLUS
-    // `transition:generic`.
-    //
-    // The granular permission-set `rpc` grants (aud:"*") are correct, but the
-    // deployed bsky PDS does not yet authorize `com.atproto.server.getServiceAuth`
-    // against them: every getServiceAuth call 401s, so the frontend cannot mint
-    // the service-auth JWTs the AppView requires and all authenticated calls
-    // (getMyProfile, getDiscoverySettings, collection.*) fall back to anonymous
-    // → 401. `transition:generic` is the scope the PDS does honor for
-    // getServiceAuth, so it restores service-auth minting. We keep the granular
-    // scopes too: they drive the consent screen and the repo writes, and they
-    // take over automatically once the PDS honors rpc grants for service auth.
+    // Request granular scopes based on the user's intent. We deliberately
+    // do NOT include `transition:generic`: that scope short-circuits the
+    // granular permission model and causes PDSes (e.g. bsky.social) to show
+    // "any public record" on the consent screen instead of our specific
+    // permission sets. The published `pub.chive.*` permission-set lexicons
+    // (with `aud:"*"` rpc grants) fully express what the app needs, including
+    // minting service-auth JWTs for `pub.chive.*` rpc methods.
     const granularScope = getScopesForIntent(intent);
-    const scope = `${granularScope} ${LEGACY_SCOPE} blob:*/*`;
+    const scope = `${granularScope} blob:*/*`;
 
     const url = await client.authorize(handle, { scope });
 
@@ -471,9 +466,12 @@ export async function getSessionScopes(session: OAuthSession): Promise<string[]>
       return String(tokenInfo.scope).split(' ').filter(Boolean);
     }
   } catch {
-    // Fall back to legacy scopes if token info is unavailable
+    // Token info unavailable: fail closed with only the base scope rather than
+    // assuming `transition:generic`. Assuming the legacy catch-all would make
+    // hasScope() report every permission as granted; an under-reported scope
+    // just surfaces an upgrade prompt, which is the safe degradation.
   }
-  return ['atproto', 'transition:generic'];
+  return ['atproto'];
 }
 
 function getPdsEndpoint(session: OAuthSession): string {

--- a/web/lib/auth/oauth-client.ts
+++ b/web/lib/auth/oauth-client.ts
@@ -16,7 +16,7 @@ import {
 } from '@atproto/oauth-client-browser';
 import { Agent } from '@atproto/api';
 import type { DID, Handle, ChiveUser, LoginOptions } from './types';
-import { getScopesForIntent } from './scopes';
+import { getScopesForIntent, LEGACY_SCOPE } from './scopes';
 import { AuthenticationError, NetworkError } from '@/lib/errors';
 import { logger } from '@/lib/observability';
 
@@ -316,14 +316,20 @@ export async function startLogin(options: LoginOptions): Promise<string> {
   const client = await getOAuthClient();
 
   try {
-    // Request granular scopes based on the user's intent. We deliberately
-    // do NOT include `transition:generic` here: that scope short-circuits
-    // granular permissions and causes PDSes (e.g. bsky.social) to show
-    // "any public record" on the consent screen instead of our specific
-    // repo scopes. The atproto-base scope + individual repo:/blob: scopes
-    // fully express what the app needs.
+    // Request granular scopes based on the user's intent, PLUS
+    // `transition:generic`.
+    //
+    // The granular permission-set `rpc` grants (aud:"*") are correct, but the
+    // deployed bsky PDS does not yet authorize `com.atproto.server.getServiceAuth`
+    // against them: every getServiceAuth call 401s, so the frontend cannot mint
+    // the service-auth JWTs the AppView requires and all authenticated calls
+    // (getMyProfile, getDiscoverySettings, collection.*) fall back to anonymous
+    // → 401. `transition:generic` is the scope the PDS does honor for
+    // getServiceAuth, so it restores service-auth minting. We keep the granular
+    // scopes too: they drive the consent screen and the repo writes, and they
+    // take over automatically once the PDS honors rpc grants for service auth.
     const granularScope = getScopesForIntent(intent);
-    const scope = `${granularScope} blob:*/*`;
+    const scope = `${granularScope} ${LEGACY_SCOPE} blob:*/*`;
 
     const url = await client.authorize(handle, { scope });
 

--- a/web/lib/auth/service-auth.ts
+++ b/web/lib/auth/service-auth.ts
@@ -115,11 +115,15 @@ export async function getServiceAuthToken(agent: Agent, lxm?: string): Promise<s
     return cached.token;
   }
 
-  // Request new service auth token from PDS
-  const response = await agent.com.atproto.server.getServiceAuth({
-    aud: CHIVE_SERVICE_DID,
-    lxm,
-  });
+  // Request new service auth token from PDS.
+  // The first call against a given PDS can fail with `use_dpop_nonce` when the
+  // OAuth client's stored nonce is empty or stale for that origin. The
+  // @atproto/oauth-client-browser fetch handler is supposed to auto-retry once,
+  // but in practice the retry can leak through as a thrown error -- the
+  // response *does* return a fresh `DPoP-Nonce`, so a second call succeeds.
+  // Wrapping in a single explicit retry guarantees the user-visible request
+  // succeeds when the only obstacle is the nonce-priming step.
+  const response = await callGetServiceAuthWithNonceRetry(agent, lxm);
 
   const { token } = response.data as ServiceAuthResponse;
 
@@ -131,6 +135,40 @@ export async function getServiceAuthToken(agent: Agent, lxm?: string): Promise<s
   tokenCache.set(cacheKey, { token, expiresAt, lxm });
 
   return token;
+}
+
+async function callGetServiceAuthWithNonceRetry(
+  agent: Agent,
+  lxm?: string
+): Promise<{ data: ServiceAuthResponse }> {
+  try {
+    return await agent.com.atproto.server.getServiceAuth({
+      aud: CHIVE_SERVICE_DID,
+      lxm,
+    });
+  } catch (error) {
+    if (isNonceMismatchError(error)) {
+      serviceAuthLogger.debug('getServiceAuth hit DPoP nonce mismatch; retrying once', { lxm });
+      return await agent.com.atproto.server.getServiceAuth({
+        aud: CHIVE_SERVICE_DID,
+        lxm,
+      });
+    }
+    throw error;
+  }
+}
+
+function isNonceMismatchError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const message = (error as { message?: string }).message ?? '';
+  const data = (error as { data?: unknown }).data;
+  const dataError =
+    data && typeof data === 'object' ? (data as { error?: string }).error : undefined;
+  return (
+    dataError === 'use_dpop_nonce' ||
+    /use_dpop_nonce/i.test(message) ||
+    /dpop.*nonce.*mismatch/i.test(message)
+  );
 }
 
 /**

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -22,7 +22,7 @@
     "@atproto/api": "^0.18.3",
     "@atproto/common-web": "^0.4.9",
     "@atproto/lexicon": "^0.5.2",
-    "@atproto/oauth-client-browser": "^0.3.37",
+    "@atproto/oauth-client-browser": "^0.3.42",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Promotes three months of merged, staging-verified work to production and cuts **release 0.7.0**. Bundles #90, #91, #93, and #94, plus the release commit itself.

**Why this matters for prod:** production has not been redeployed since 2026-05-12 (`cc1d3f4c`, "Release 0.6.3"). Its indexer healthcheck is literally `CMD-SHELL true`, so a wedged firehose consumer is invisible — which is exactly what happened when a single relay `503` on 2026-05-18 killed ingestion for three weeks unnoticed. Production also carries none of the deletion or reindex fixes, and its own orphaned index rows would have failed the next deploy outright.

### What's included

- **Firehose recovery (#90):** reconnection retries indefinitely with capped backoff, so a relay outage can no longer permanently wedge ingestion; a WebSocket keepalive heartbeat detects half-open connections; a new health endpoint on `INDEXER_HEALTH_PORT` (default 3001) plus a watchdog make a dead consumer visible to the container healthcheck and restart the process if it stays wedged. The indexer healthcheck stops being a no-op.
- **Eprint deletion (#90):** `deleteSubmission` removes the eprint from Chive's own index immediately — index-only, never touching the PDS — so deletes no longer depend solely on the firehose. The frontend also deletes the dual-written `site.standard.document` records.
- **Reindex prune (#91):** the deploy's Elasticsearch backfill prunes eprints that are gone from their PDS (`RecordNotFound`) instead of hard-failing. Without this, the production deploy would fail on prod's own orphaned index rows.
- **Scopes (#93):** `transition:generic` is not requested anywhere. Scope resolution fails closed to the ATProto base scope when session scopes are unavailable, leaving authorization entirely on the `pub.chive.*` permission sets. An idempotent `scripts/publish-lexicons.ts` publishes those permission sets so edits actually reach the resolving PDS. **This supersedes the `transition:generic` change that #90 originally shipped** — an earlier version of this PR description described that now-reverted approach.
- **Lexicon account (#94):** the publisher targets the dedicated lexicon account on the governance PDS (`lexicons.governance.chive.pub`) rather than the `chive.pub` Bluesky bot account.
- **Version reporting:** backend services read their release version from `package.json` at runtime. `npm_package_version` is unset when a container starts Node directly, so `/health`, structured logs, and OpenTelemetry resources had all reported `0.0.0` in every deployed environment — which made it impossible to confirm what was actually deployed.
- **Release 0.7.0:** version bump across the three `package.json` files, the 0.7.0 CHANGELOG entry, and a repair of the CHANGELOG's drifted history (three release dates that disagreed with their tags, the missing 0.4.1 entry, and a link-reference block that had been stuck at v0.4.0).

### Post-deploy follow-ups (operational, not code)

- **Users must re-authenticate** to pick up the post-`transition:generic` scopes; existing sessions keep their old ones.
- `_lexicon.chive.pub` still resolves to `did:plc:7natp5xae72bddaqlkef2t4e` (the old bot account). The lexicons are already published to the new governance account, so nothing breaks, but the TXT record should be repointed so the publisher and the resolving DID agree.
- Re-enable the scheduled **Health Check** workflow — GitHub set it to `disabled_inactivity` after 60 days without repo activity, so the `*/15` cursor-staleness and DLQ watchdog has not run since 2026-08-16.

## Related Issues

Bundles #90, #91, #93, #94.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## How Has This Been Tested?

- Deployed to staging and verified live before cutting the release: `/api/health` 200, `/ready` 200 with Redis, PostgreSQL, Elasticsearch, and Neo4j all passing, indexer `/health` reporting the relay connected, firehose cursor lag under a minute, DLQ empty, no unhealthy containers.
- The staging indexer has been exercising the recovery path continuously: `bsky.network` drops the socket every 10–15 minutes and the consumer reconnects each time, which is the failure mode that permanently wedged production under the old code.
- Full unit suite green locally (4018 passed, 2 skipped) and full CI green on this branch.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable) — TSDoc on new and changed APIs

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes (index-only deletion and prune; the PDS delete stays in the frontend client, and the lexicon publisher writes only to Chive's own account)
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose (immediate delete and prune mirror the firehose delete; idempotent)
- [x] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes (users re-authenticate to gain the new scopes; no data migration)
