### PR TITLE
Stop wiping the knowledge graph on a governance sync that cannot run

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -363,15 +363,16 @@ jobs:
 
             # Run the reindex script inside the chive-api container
             # The script syncs all pub.chive.graph.node and pub.chive.graph.edge records
+            # Only GRAPH_PDS_URL is overridden, to reach the PDS over the
+            # container network. GRAPH_PDS_DID is deliberately NOT passed: the
+            # repository variable is often undefined, and interpolating it
+            # yielded an empty string that overrode the correct built-in
+            # default, so every run failed with `Params must have the property
+            # "repo"` *after* it had already cleared the graph.
             docker exec \
               -e GRAPH_PDS_URL=http://governance-pds:3000 \
-              -e GRAPH_PDS_DID=${{ vars.GRAPH_PDS_DID }} \
-              -e GRAPH_PDS_HANDLE=${{ vars.GRAPH_PDS_HANDLE }} \
-              -e GRAPH_PDS_PASSWORD=${{ secrets.GRAPH_PDS_ADMIN_PASSWORD }} \
               chive-api \
-              node --enable-source-maps dist/scripts/db/reindex-governance-to-neo4j.js || {
-                echo "::warning::Graph PDS sync failed - this may be expected on first deploy before records exist"
-              }
+              node --enable-source-maps dist/scripts/db/reindex-governance-to-neo4j.js
 
             echo "=== Governance sync complete ==="
 

--- a/scripts/db/reindex-governance-to-neo4j.ts
+++ b/scripts/db/reindex-governance-to-neo4j.ts
@@ -15,8 +15,22 @@
 import { AtpAgent } from '@atproto/api';
 import neo4j from 'neo4j-driver';
 
-const PDS_URL = process.env.GRAPH_PDS_URL ?? 'https://governance.chive.pub';
-const GRAPH_PDS_DID = process.env.GRAPH_PDS_DID ?? 'did:plc:5wzpn4a4nbqtz3q45hyud6hd';
+/**
+ * Reads an environment variable, treating blank values as unset.
+ *
+ * @remarks
+ * Deploy steps interpolate repository variables that may not be defined,
+ * producing an empty string rather than an absent variable. Nullish coalescing
+ * accepts `''` as a real value, which silently replaced the graph PDS DID with
+ * nothing and made every `listRecords` call fail.
+ */
+function envOrDefault(name: string, fallback: string): string {
+  const value = process.env[name];
+  return value !== undefined && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+const PDS_URL = envOrDefault('GRAPH_PDS_URL', 'https://governance.chive.pub');
+const GRAPH_PDS_DID = envOrDefault('GRAPH_PDS_DID', 'did:plc:5wzpn4a4nbqtz3q45hyud6hd');
 
 const NEO4J_URI = process.env.NEO4J_URI ?? 'bolt://localhost:7687';
 const NEO4J_USER = process.env.NEO4J_USER ?? 'neo4j';
@@ -107,25 +121,43 @@ async function main(): Promise<void> {
   console.log('Connected.\n');
 
   try {
-    // Clear existing nodes and edges
-    console.log('Clearing existing graph data...');
-    await session.run('MATCH (n:Node) DETACH DELETE n');
-    console.log('Cleared.\n');
-
-    // Fetch and index nodes
-    console.log('=== Indexing Nodes ===');
-    let nodeCount = 0;
-    let cursor: string | undefined;
+    // Fetch every node before mutating Neo4j. The graph must never be cleared
+    // on a run that then fails to repopulate it: an empty graph silently turns
+    // every eprint field label into a raw UUID at the next reindex.
+    console.log('=== Fetching Nodes ===');
+    const nodeRecords: { uri: string; value: unknown }[] = [];
+    let fetchCursor: string | undefined;
 
     do {
       const response = await agent.com.atproto.repo.listRecords({
         repo: GRAPH_PDS_DID,
         collection: 'pub.chive.graph.node',
         limit: 100,
-        cursor,
+        cursor: fetchCursor,
       });
+      nodeRecords.push(...response.data.records);
+      fetchCursor = response.data.cursor;
+    } while (fetchCursor);
 
-      for (const record of response.data.records) {
+    console.log(`  ${nodeRecords.length} node records fetched\n`);
+
+    if (nodeRecords.length === 0) {
+      throw new Error(
+        `No pub.chive.graph.node records found in ${GRAPH_PDS_DID}. Refusing to clear the ` +
+          'knowledge graph, which would leave every eprint field label showing a raw UUID.'
+      );
+    }
+
+    // Only now is it safe to replace the graph.
+    console.log('Clearing existing graph data...');
+    await session.run('MATCH (n:Node) DETACH DELETE n');
+    console.log('Cleared.\n');
+
+    console.log('=== Indexing Nodes ===');
+    let nodeCount = 0;
+
+    {
+      for (const record of nodeRecords) {
         if (!isNodeRecord(record.value)) {
           console.warn(`Skipping invalid node record: ${record.uri}`);
           continue;
@@ -175,16 +207,14 @@ async function main(): Promise<void> {
           process.stdout.write(`  ${nodeCount} nodes indexed\r`);
         }
       }
-
-      cursor = response.data.cursor;
-    } while (cursor);
+    }
 
     console.log(`  ${nodeCount} nodes indexed\n`);
 
     // Fetch and index edges
     console.log('=== Indexing Edges ===');
     let edgeCount = 0;
-    cursor = undefined;
+    let cursor: string | undefined;
 
     do {
       const response = await agent.com.atproto.repo.listRecords({

--- a/src/config/graph.ts
+++ b/src/config/graph.ts
@@ -27,8 +27,12 @@ import type { DID } from '../types/atproto.js';
  *
  * @public
  */
-export const GRAPH_PDS_DID: DID =
-  (process.env.GRAPH_PDS_DID as DID | undefined) ?? ('did:plc:5wzpn4a4nbqtz3q45hyud6hd' as DID);
+export const GRAPH_PDS_DID: DID = ((): DID => {
+  // A deploy step that interpolates an undefined repository variable yields an
+  // empty string, which nullish coalescing would accept as a real value.
+  const configured = process.env.GRAPH_PDS_DID?.trim();
+  return configured ? (configured as DID) : ('did:plc:5wzpn4a4nbqtz3q45hyud6hd' as DID);
+})();
 
 /**
  * Returns the graph PDS DID.


### PR DESCRIPTION
## Summary

The "Sync Governance PDS to Neo4j" deploy step has been failing on **every** production deploy, and because it clears the graph before it fetches anything, each deploy left Neo4j empty. That is the root cause of the recurring bug where eprint cards show raw UUIDs instead of field names.

Observed in the 0.7.0 deploy log:

```
Clearing existing graph data...
Cleared.
=== Indexing Nodes ===
Reindex failed: XRPCError: Error: Params must have the property "repo"
```

### Why it failed

`deploy-app.yml` passed `-e GRAPH_PDS_DID=${{ vars.GRAPH_PDS_DID }}`, but that repository variable is not defined, so it interpolated to an **empty string**. `process.env.GRAPH_PDS_DID ?? '<default>'` treats `''` as a real value, so the empty string overrode the correct built-in default and every `listRecords` call returned HTTP 400.

Verified directly against the production governance PDS from inside the container: the correct DID returns records, `repo=` returns `400 Bad Request`.

### Why it mattered downstream

The graph was wiped at 20:18:14 and repopulated at 20:18:31. The eprint reindex resolved field labels at 20:18:23 — in between — so every label resolved to nothing and was written to PostgreSQL and Elasticsearch as a raw UUID. `resolveFieldLabels` swallows all errors and returns the original UUID, so the deploy reported success over visibly broken data.

### Changes

- `scripts/db/reindex-governance-to-neo4j.ts`: fetch **all** node records before clearing the graph, and refuse to clear when the fetch returns nothing. A failed sync can no longer leave an empty graph. Blank environment variables are treated as unset.
- `src/config/graph.ts`: same blank-string guard on the shared `GRAPH_PDS_DID` constant.
- `.github/workflows/deploy-app.yml`: stop passing `GRAPH_PDS_DID` entirely, so the correct built-in default applies; stop masking sync failure behind `::warning::`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- Reproduced the exact failure against production: correct DID returns records, empty DID returns 400.
- `tsc --noEmit` and prettier clean.
- The ordering fix is verifiable on the next deploy: the sync must report a non-zero node count before the eprint reindex runs.

## Checklist

### General
- [x] Self-review
- [x] Lint passes
- [x] Documentation updated (TSDoc explaining the ordering requirement)

### ATProto Compliance
- [x] No writes to user PDSes (reads the Governance PDS, writes only Chive's Neo4j index)
- [x] Indexes can be rebuilt from firehose

### Breaking Changes
- [x] N/A
