### PR TITLE
Let the PDS scanner reach relay-connected servers and recover wedged scans

### DIFF
--- a/src/services/pds-discovery/pds-registry.ts
+++ b/src/services/pds-discovery/pds-registry.ts
@@ -237,11 +237,22 @@ export class PDSRegistry implements IPDSRegistry {
         `
         SELECT *
         FROM pds_registry
-        WHERE status IN ('pending', 'active')
+        WHERE (
+                status IN ('pending', 'active')
+                -- Recover PDSes wedged in 'scanning' by a process that died
+                -- mid-scan. Nothing else clears that status, and 'scanning' is
+                -- otherwise excluded here, so such a PDS is never scanned again.
+                OR (status = 'scanning' AND updated_at < NOW() - INTERVAL '1 hour')
+              )
           AND (next_scan_at IS NULL OR next_scan_at <= NOW())
           AND consecutive_failures < 5
-          AND is_relay_connected = FALSE
-        ORDER BY scan_priority ASC, next_scan_at ASC NULLS FIRST
+        -- Relay-connected PDSes are deprioritised, not excluded. Their records
+        -- normally arrive over the firehose, but a relay outage longer than the
+        -- relay's backfill window silently skips a range of events, and this
+        -- scan is the only mechanism that can find what was missed. Excluding
+        -- them outright made the scanner unable to repair exactly the gap it
+        -- exists for; scan cadence is still governed by next_scan_at.
+        ORDER BY is_relay_connected ASC, scan_priority ASC, next_scan_at ASC NULLS FIRST
         LIMIT $1
         `,
         [limit]
@@ -268,7 +279,8 @@ export class PDSRegistry implements IPDSRegistry {
       await this.pool.query(
         `
         UPDATE pds_registry
-        SET status = 'scanning'
+        SET status = 'scanning',
+            updated_at = NOW()
         WHERE pds_url = $1
         `,
         [pdsUrl]

--- a/tests/integration/services/pds-discovery/pds-discovery.integration.test.ts
+++ b/tests/integration/services/pds-discovery/pds-discovery.integration.test.ts
@@ -272,13 +272,46 @@ describe('PDS Discovery Integration', () => {
         `);
       });
 
-      it('only returns non-relay-connected PDSes', async () => {
+      it('includes relay-connected PDSes, ranked after direct ones', async () => {
         const result = await registry.getPDSesForScan(10);
 
         const urls = result.map((r) => r.pdsUrl);
         expect(urls).toContain('https://test-scannable-1.example.com');
         expect(urls).toContain('https://test-scannable-2.example.com');
-        expect(urls).not.toContain('https://test-relay-skip.bsky.network');
+
+        // Relay-connected PDSes must be reachable by a scan. Their records
+        // normally arrive over the firehose, but a relay outage longer than the
+        // relay's backfill window skips a range of events permanently, and this
+        // scan is the only mechanism that can find what was missed. They are
+        // ranked last rather than excluded.
+        expect(urls).toContain('https://test-relay-skip.bsky.network');
+        expect(urls.indexOf('https://test-relay-skip.bsky.network')).toBeGreaterThan(
+          urls.indexOf('https://test-scannable-1.example.com')
+        );
+      });
+
+      it('reclaims a PDS wedged in scanning by a crashed scan', async () => {
+        // Nothing clears 'scanning', so before this a process that died
+        // mid-scan excluded that PDS from every subsequent cycle.
+        await pool.query(`
+          INSERT INTO pds_registry (pds_url, discovery_source, status, is_relay_connected, consecutive_failures, updated_at)
+          VALUES ('https://test-wedged.example.com', 'user_registration', 'scanning', FALSE, 0, NOW() - INTERVAL '2 hours')
+        `);
+
+        const result = await registry.getPDSesForScan(10);
+
+        expect(result.map((r) => r.pdsUrl)).toContain('https://test-wedged.example.com');
+      });
+
+      it('leaves a scan that started recently alone', async () => {
+        await pool.query(`
+          INSERT INTO pds_registry (pds_url, discovery_source, status, is_relay_connected, consecutive_failures, updated_at)
+          VALUES ('https://test-in-flight.example.com', 'user_registration', 'scanning', FALSE, 0, NOW())
+        `);
+
+        const result = await registry.getPDSesForScan(10);
+
+        expect(result.map((r) => r.pdsUrl)).not.toContain('https://test-in-flight.example.com');
       });
 
       it('excludes PDSes with too many failures', async () => {

--- a/tests/unit/services/pds-discovery/pds-registry.test.ts
+++ b/tests/unit/services/pds-discovery/pds-registry.test.ts
@@ -163,7 +163,7 @@ describe('PDSRegistry', () => {
   });
 
   describe('getPDSesForScan', () => {
-    it('only returns non-relay-connected PDSes', async () => {
+    it('returns relay-connected PDSes too, ranked after direct ones', async () => {
       const mockRows = [
         {
           pds_url: 'https://custom-pds.example.com',
@@ -194,11 +194,25 @@ describe('PDSRegistry', () => {
         expect(firstResult.isRelayConnected).toBe(false);
       }
 
-      // Verify query includes relay filter
-      expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining('is_relay_connected = FALSE'),
-        [10]
-      );
+      // Relay-connected PDSes must not be filtered out: a relay outage longer
+      // than the relay's backfill window silently skips events, and this scan
+      // is the only mechanism that can find the records that were missed.
+      // They are ranked last instead.
+      const [sql] = mockPool.query.mock.calls[0] as [string, unknown];
+      expect(sql).not.toContain('is_relay_connected = FALSE');
+      expect(sql).toContain('ORDER BY is_relay_connected ASC');
+    });
+
+    it('recovers PDSes wedged in scanning by a crashed scan', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await registry.getPDSesForScan(10);
+
+      // Nothing else clears 'scanning', so without this a process that died
+      // mid-scan excludes that PDS from every future cycle.
+      const [sql] = mockPool.query.mock.calls[0] as [string, unknown];
+      expect(sql).toContain("status = 'scanning'");
+      expect(sql).toContain('updated_at <');
     });
 
     it('excludes PDSes with too many consecutive failures', async () => {


### PR DESCRIPTION
## Summary

Chive's PDS scanner — the mechanism that finds `pub.chive.*` records the firehose missed — has never scanned anything in production. The scheduler runs on time every 15 minutes and reports `pdsesScanned: 0` on every cycle.

Production `pds_registry` state:

| status | count | ever scanned | most recent |
|---|---|---|---|
| `pending` | 29 | 0 | never |
| `no_chive_records` | 15 | 15 | 2026-05-03 |
| `scanning` | 2 | 1 | 2026-03-01 (wedged) |

### Two defects

**1. The selection query excluded every registered PDS.** `getPDSesForScan` required `is_relay_connected = FALSE`, and all 29 `pending` rows are relay-connected, so the query returned zero rows. Confirmed by running the query against production.

The intent is reasonable — records from relay-connected PDSes normally arrive over the firehose, so scanning them is redundant. But it is exactly backwards for the case this scanner exists to handle. When a relay outage runs longer than the relay's backfill window, the stored cursor is too old to replay, the relay resumes at the live edge, and the skipped range is never re-delivered. Production lost firehose ingestion from 2026-05-18 to 2026-06-11 this way. Those PDSes are precisely the ones that then need scanning, and they were the only ones excluded.

Relay-connected PDSes are now **deprioritised rather than excluded** (`ORDER BY is_relay_connected ASC`). Cadence is still governed by `next_scan_at`, so this is a periodic safety net, not a hot loop.

**2. A crashed scan wedged a PDS permanently.** `markScanStarted` sets `status = 'scanning'` and nothing ever clears it; `'scanning'` was not in the selection query's status list. If the process died mid-scan, that PDS was excluded from every future cycle — which is why two rows have been stuck since 2026-03-01. Stale `scanning` rows older than an hour are now reclaimed, and `markScanStarted` sets `updated_at` so the staleness check has a timestamp to work from.

### Note

No new component was added. Both fixes are in the existing `PDSRegistry`; the scanner, scheduler job, admin endpoints (`triggerPDSScan`, `getBackfillStatus`, `cancelBackfill`, `getBackfillHistory`) and `BackfillManager` already existed and are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- Ran the production query to confirm it returns 0 rows, and confirmed all 29 pending rows are relay-connected.
- Updated the existing `getPDSesForScan` test, which asserted the broken behaviour (`stringContaining('is_relay_connected = FALSE')`), and added coverage for wedged-scan recovery.
- 40 tests pass across `tests/unit/services/pds-discovery/`.

## Checklist

### General
- [x] Self-review
- [x] Lint passes
- [x] Tests added/updated for changes

### ATProto Compliance
- [x] No writes to user PDSes (the scanner reads via standard XRPC)
- [x] Indexes can be rebuilt from firehose (this restores a repair path for when the firehose misses events)
- [x] PDS source is tracked for staleness detection

### Breaking Changes
- [x] N/A — relay-connected PDSes will now be scanned on their `next_scan_at` cadence, which is the intended behaviour
