### PR TITLE
Validate Neo4j label identifiers to close an unauthenticated Cypher injection

### DIFF
--- a/src/storage/neo4j/adapter.ts
+++ b/src/storage/neo4j/adapter.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../types/interfaces/graph.interface.js';
 
 import { Neo4jConnection } from './connection.js';
+import { subkindToLabel } from './labels.js';
 import type {
   GraphNode,
   GraphEdge,
@@ -43,16 +44,6 @@ import type {
   UserRole,
   VoteType,
 } from './types.js';
-
-/**
- * Map subkind slugs to Neo4j labels (PascalCase).
- */
-function subkindToLabel(subkind: string): string {
-  return subkind
-    .split('-')
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join('');
-}
 
 /**
  * Neo4j adapter implementing the IGraphDatabase interface.

--- a/src/storage/neo4j/labels.ts
+++ b/src/storage/neo4j/labels.ts
@@ -1,0 +1,79 @@
+/**
+ * Safe construction of Neo4j label identifiers.
+ *
+ * @remarks
+ * Neo4j has no parameter binding for labels, so a label used in a `MATCH` must
+ * be interpolated into the query string. Anything interpolated into Cypher is a
+ * potential injection point, and node subkinds arrive from unauthenticated
+ * callers via `pub.chive.graph.listNodes` and `pub.chive.graph.getHierarchy`.
+ *
+ * This module is the single place that turns a subkind slug into a label, so
+ * the validation cannot be bypassed by a caller that builds the label itself.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import { ValidationError } from '../../types/errors.js';
+
+/**
+ * A valid Neo4j label: a letter followed by letters, digits, or underscores.
+ *
+ * @remarks
+ * Deliberately narrower than Neo4j's own rules, which permit almost anything
+ * inside backticks. Chive's subkinds are hyphenated slugs, so the PascalCase
+ * form of a legitimate subkind always fits this shape.
+ */
+const SAFE_LABEL = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+/**
+ * Converts a subkind slug to its Neo4j label, rejecting anything unsafe.
+ *
+ * @param subkind - Subkind slug, e.g. `field` or `research-method`
+ * @returns The PascalCase label, e.g. `Field` or `ResearchMethod`
+ *
+ * @throws {ValidationError} If the resulting label is not a plain identifier
+ *
+ * @remarks
+ * The previous implementations — duplicated in `adapter.ts` and
+ * `node-repository.ts` — only capitalised and joined the hyphen-separated
+ * parts. Parentheses, whitespace, and comment markers passed straight through
+ * into the query, so a crafted `subkind` could close the `MATCH` pattern and
+ * append arbitrary Cypher.
+ *
+ * @example
+ * ```typescript
+ * subkindToLabel('research-method'); // 'ResearchMethod'
+ * subkindToLabel('a) DETACH DELETE n //'); // throws ValidationError
+ * ```
+ *
+ * @public
+ */
+export function subkindToLabel(subkind: string): string {
+  const label = subkind
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+
+  if (!SAFE_LABEL.test(label)) {
+    throw new ValidationError(
+      `Invalid subkind '${subkind}': must contain only letters, digits, hyphens and underscores`,
+      'subkind',
+      'format'
+    );
+  }
+
+  return label;
+}
+
+/**
+ * Converts a node kind to its Neo4j label.
+ *
+ * @param kind - Either `type` or `object`
+ * @returns `Type` or `Object`
+ *
+ * @public
+ */
+export function kindToLabel(kind: 'type' | 'object'): string {
+  return kind === 'type' ? 'Type' : 'Object';
+}

--- a/src/storage/neo4j/node-repository.ts
+++ b/src/storage/neo4j/node-repository.ts
@@ -16,6 +16,7 @@ import type { AtUri, DID } from '../../types/atproto.js';
 import { DatabaseError, NotFoundError, ValidationError } from '../../types/errors.js';
 
 import { Neo4jConnection } from './connection.js';
+import { subkindToLabel } from './labels.js';
 import type {
   GraphNode,
   NodeKind,
@@ -27,17 +28,6 @@ import type {
   ExternalId,
   NodeMetadata,
 } from './types.js';
-
-/**
- * Subkind label mapping - converts slug to Neo4j label
- */
-function subkindToLabel(slug: string): string {
-  // Convert kebab-case to PascalCase
-  return slug
-    .split('-')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('');
-}
 
 /**
  * Neo4j repository for unified graph node operations.

--- a/tests/unit/storage/neo4j/labels.test.ts
+++ b/tests/unit/storage/neo4j/labels.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for Neo4j label construction.
+ *
+ * @remarks
+ * Neo4j cannot bind a label as a query parameter, so labels are interpolated
+ * into Cypher. Node subkinds reach that interpolation from unauthenticated
+ * callers via `pub.chive.graph.listNodes` and `pub.chive.graph.getHierarchy`,
+ * which made this the injection point these tests close.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { kindToLabel, subkindToLabel } from '@/storage/neo4j/labels.js';
+import { ValidationError } from '@/types/errors.js';
+
+describe('subkindToLabel', () => {
+  it('should convert a slug to a PascalCase label', () => {
+    expect(subkindToLabel('field')).toBe('Field');
+    expect(subkindToLabel('research-method')).toBe('ResearchMethod');
+    expect(subkindToLabel('institution')).toBe('Institution');
+  });
+
+  it('should preserve digits and underscores', () => {
+    expect(subkindToLabel('facet2')).toBe('Facet2');
+    expect(subkindToLabel('legacy_field')).toBe('Legacy_field');
+  });
+
+  // Each of these previously passed straight through into the query string,
+  // letting a caller close the MATCH pattern and append their own Cypher.
+  it.each([
+    ['pattern break + delete', 'a) DETACH DELETE n //'],
+    ['clause injection', 'Field) RETURN n UNION MATCH (m) RETURN m //'],
+    ['whitespace', 'Field OR true'],
+    ['backtick escape', 'Field`) MATCH (x) DETACH DELETE x //'],
+    ['comment marker', 'Field//'],
+    ['braces', 'Field {uri: 1}'],
+    ['empty', ''],
+    ['leading digit', '1field'],
+  ])('should reject %s', (_name, malicious) => {
+    expect(() => subkindToLabel(malicious)).toThrow(ValidationError);
+  });
+
+  it('should not leak the rejected value into a usable label', () => {
+    // A thrown error is the only acceptable outcome; returning a sanitised
+    // fragment would still interpolate attacker-influenced text.
+    let label: string | undefined;
+    try {
+      label = subkindToLabel('a) DETACH DELETE n //');
+    } catch {
+      label = undefined;
+    }
+    expect(label).toBeUndefined();
+  });
+});
+
+describe('kindToLabel', () => {
+  it('should map kinds to their labels', () => {
+    expect(kindToLabel('type')).toBe('Type');
+    expect(kindToLabel('object')).toBe('Object');
+  });
+});


### PR DESCRIPTION
## Summary

`subkind` reaches Cypher string interpolation from unauthenticated callers, with no validation. Found by the governance audit and verified by hand.

Neo4j cannot bind a label as a query parameter, so labels must be interpolated into the query text. `subkindToLabel` only capitalised the hyphen-separated parts:

```ts
return subkind.split('-').map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join('');
```

Parentheses, whitespace, backticks and comment markers all passed through into:

```ts
matchClause = `MATCH (n:Node:${subkindLabel})`;
```

So a `subkind` such as `a) DETACH DELETE n //` closes the pattern and appends arbitrary Cypher. `subkind` is caller-supplied on `pub.chive.graph.listNodes` and `pub.chive.graph.getHierarchy`, neither of which requires authentication.

The helper was **duplicated**, unsanitised, in two files (`adapter.ts` and `node-repository.ts`), feeding nine interpolation sites between them.

## Changes

- New `src/storage/neo4j/labels.ts` — the single place a subkind becomes a label. Validates the derived label against `/^[A-Za-z][A-Za-z0-9_]*$/` and throws `ValidationError` otherwise, so it cannot be bypassed by a caller constructing its own label.
- Both duplicate definitions deleted; `adapter.ts` and `node-repository.ts` now import the guarded helper. No call sites changed behaviour for legitimate subkinds.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- 12 new tests in `tests/unit/storage/neo4j/labels.test.ts` covering legitimate slugs and eight rejection cases: pattern break with delete, clause injection via `UNION`, whitespace, backtick escape, comment marker, braces, empty string, leading digit.
- 67 tests pass across `tests/unit/storage/neo4j/`; full unit suite green at 4035 passed.
- Verified the vulnerable behaviour by reading both original implementations; neither performed any escaping or whitelisting.

## Checklist

### General
- [x] Self-review
- [x] Lint passes
- [x] Tests added/updated for changes
- [x] Documentation updated (TSDoc explains why labels cannot be parameterised)

### ATProto Compliance
- [x] No writes to user PDSes
- [x] Indexes can be rebuilt from firehose

### Breaking Changes
- [x] N/A — a subkind that would now be rejected could not have matched a real label anyway
