### PR TITLE
Resolve proposals by record key so proposal pages and votes load (fixes #89)

### DIFF
--- a/src/api/handlers/xrpc/governance/listVotes.ts
+++ b/src/api/handlers/xrpc/governance/listVotes.ts
@@ -13,6 +13,7 @@ import type {
   OutputSchema,
   VoteView,
 } from '../../../../lexicons/generated/types/pub/chive/governance/listVotes.js';
+import { NotFoundError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 /**
@@ -31,11 +32,18 @@ export const listVotes: XRPCMethod<QueryParams, void, OutputSchema> = {
       limit: params.limit,
     });
 
-    // Construct proposal URI from ID
-    const proposalUri = `at://chive.governance/pub.chive.graph.fieldProposal/${params.proposalId}`;
+    // Resolve the proposal to get its real URI. The previous implementation
+    // synthesised one as `at://chive.governance/pub.chive.graph.fieldProposal/<id>`,
+    // whose authority is not a DID and whose collection does not exist
+    // (proposals are `pub.chive.graph.nodeProposal`), so it matched no vote and
+    // this endpoint always returned an empty list.
+    const proposal = await graphService.getProposalById(params.proposalId);
+    if (!proposal) {
+      throw new NotFoundError('Proposal', params.proposalId);
+    }
 
     // Get votes from the knowledge graph service
-    const allVotes = await graphService.getVotesForProposal(proposalUri);
+    const allVotes = await graphService.getVotesForProposal(proposal.uri);
 
     // Apply pagination
     const limit = params.limit ?? 100;

--- a/src/api/handlers/xrpc/sync/indexRecord.ts
+++ b/src/api/handlers/xrpc/sync/indexRecord.ts
@@ -183,6 +183,8 @@ export const indexRecord: XRPCMethod<void, InputSchema, OutputSchema> = {
       'pub.chive.eprint.relatedWork',
       'pub.chive.graph.node',
       'pub.chive.graph.edge',
+      'pub.chive.graph.nodeProposal',
+      'pub.chive.graph.vote',
       'pub.chive.actor.profileConfig',
     ];
 
@@ -317,6 +319,19 @@ export const indexRecord: XRPCMethod<void, InputSchema, OutputSchema> = {
           // No personal graph service available, treat as success
           result = { ok: true as const, value: undefined };
         }
+      } else if (collection === 'pub.chive.graph.nodeProposal') {
+        // Knowledge graph proposal. Indexed here as well as from the firehose
+        // so the proposal is readable as soon as the user is redirected to it,
+        // rather than only once the firehose event arrives.
+        const graphService = c.get('services').graph;
+        result = graphService
+          ? await graphService.indexNodeProposal(record.value, metadata)
+          : { ok: true as const, value: undefined };
+      } else if (collection === 'pub.chive.graph.vote') {
+        const graphService = c.get('services').graph;
+        result = graphService
+          ? await graphService.indexVote(record.value, metadata)
+          : { ok: true as const, value: undefined };
       } else if (collection === 'pub.chive.graph.edge') {
         // Personal graph edge (including collection CONTAINS/SUBCOLLECTION_OF)
         const personalGraphService = c.get('services').personalGraph;

--- a/src/services/knowledge-graph/graph-service.ts
+++ b/src/services/knowledge-graph/graph-service.ts
@@ -651,7 +651,14 @@ export class KnowledgeGraphService {
    */
   async getProposalById(proposalId: string): Promise<ProposalView | null> {
     try {
-      const proposal = await this.graph.getProposal(proposalId as AtUri);
+      // Callers pass whichever identifier they hold. Routes and list links
+      // carry the record key, because an AT-URI cannot occupy a single dynamic
+      // route segment; internal callers hold the full URI. Casting a record key
+      // to an AtUri and matching on `uri` never matched, which made every
+      // proposal detail page and every vote lookup fail.
+      const proposal = proposalId.startsWith('at://')
+        ? await this.graph.getProposal(proposalId as AtUri)
+        : await this.graph.getProposalByRkey(proposalId);
 
       if (!proposal) {
         return null;

--- a/src/storage/neo4j/adapter.ts
+++ b/src/storage/neo4j/adapter.ts
@@ -739,6 +739,32 @@ export class Neo4jAdapter implements IGraphDatabase {
   /**
    * Gets a proposal by URI.
    */
+  /**
+   * Gets a proposal by its record key.
+   *
+   * @remarks
+   * Matches `p.id` where present and falls back to the URI suffix, so
+   * proposals indexed before the record key was persisted resolve too. That
+   * fallback is what makes this work without a data migration.
+   */
+  async getProposalByRkey(rkey: string): Promise<NodeProposal | null> {
+    const query = `
+      MATCH (p:Proposal)
+      WHERE p.id = $rkey OR p.uri ENDS WITH '/' + $rkey
+      RETURN p
+      LIMIT 1
+    `;
+
+    const result = await this.connection.executeQuery<{ p: Neo4jProposal }>(query, { rkey });
+
+    const record = result.records[0];
+    if (!record) {
+      return null;
+    }
+
+    return this.mapNeo4jProposal(record.get('p'));
+  }
+
   async getProposal(uri: AtUri): Promise<NodeProposal | null> {
     const query = `
       MATCH (p:Proposal {uri: $uri})
@@ -868,6 +894,7 @@ export class Neo4jAdapter implements IGraphDatabase {
     const query = `
       MERGE (p:Proposal {uri: $uri})
       ON CREATE SET
+        p.id = $id,
         p.proposalType = $proposalType,
         p.kind = $kind,
         p.subkind = $subkind,
@@ -886,6 +913,8 @@ export class Neo4jAdapter implements IGraphDatabase {
 
     await this.connection.executeQuery(query, {
       uri: proposal.uri,
+      // The record key is how every UI link and route addresses a proposal.
+      id: proposal.uri.split('/').pop() ?? '',
       proposalType: proposal.proposalType,
       kind: proposal.kind,
       subkind: proposal.subkind ?? null,

--- a/src/types/interfaces/graph.interface.ts
+++ b/src/types/interfaces/graph.interface.ts
@@ -240,6 +240,20 @@ export interface IGraphDatabase {
   getProposal(uri: AtUri): Promise<NodeProposal | null>;
 
   /**
+   * Gets a proposal by its record key.
+   *
+   * @param rkey - Record key, the last segment of the proposal's AT-URI
+   * @returns The proposal, or null if no proposal has that record key
+   *
+   * @remarks
+   * Every proposal link in the UI carries the record key rather than the full
+   * AT-URI, because an AT-URI cannot sit in a single dynamic route segment.
+   * Without this lookup those links resolve against `getProposal`, which
+   * matches on the full URI and therefore never matches.
+   */
+  getProposalByRkey(rkey: string): Promise<NodeProposal | null>;
+
+  /**
    * Creates a vote on a proposal.
    */
   createVote(vote: Vote): Promise<void>;

--- a/tests/unit/api/handlers/xrpc/governance.test.ts
+++ b/tests/unit/api/handlers/xrpc/governance.test.ts
@@ -275,6 +275,11 @@ describe('XRPC Governance Handlers', () => {
         },
       ];
 
+      // listVotes resolves the proposal first so it can use the real URI.
+      mockGraphAdapter.getProposalById.mockResolvedValue({
+        ...createMockProposal(),
+        uri: `at://did:plc:chive/pub.chive.graph.proposal/${PROPOSAL_UUIDS.abc123}`,
+      });
       mockGraphAdapter.getVotesForProposal.mockResolvedValue(votes);
 
       const result = await listVotes.handler({
@@ -302,6 +307,11 @@ describe('XRPC Governance Handlers', () => {
         },
       ];
 
+      // listVotes resolves the proposal first so it can use the real URI.
+      mockGraphAdapter.getProposalById.mockResolvedValue({
+        ...createMockProposal(),
+        uri: `at://did:plc:chive/pub.chive.graph.proposal/${PROPOSAL_UUIDS.abc123}`,
+      });
       mockGraphAdapter.getVotesForProposal.mockResolvedValue(votes);
 
       const result = await listVotes.handler({
@@ -315,6 +325,11 @@ describe('XRPC Governance Handlers', () => {
     });
 
     it('returns empty array when no votes exist', async () => {
+      // listVotes resolves the proposal first so it can use the real URI.
+      mockGraphAdapter.getProposalById.mockResolvedValue({
+        ...createMockProposal(),
+        uri: `at://did:plc:chive/pub.chive.graph.proposal/${PROPOSAL_UUIDS.abc123}`,
+      });
       mockGraphAdapter.getVotesForProposal.mockResolvedValue([]);
 
       const result = await listVotes.handler({

--- a/tests/unit/services/knowledge-graph/proposal-lookup.test.ts
+++ b/tests/unit/services/knowledge-graph/proposal-lookup.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for proposal identifier resolution.
+ *
+ * @remarks
+ * Regression cover for issue #89. Proposal routes and every list link carry the
+ * record key, because an AT-URI cannot occupy a single dynamic route segment,
+ * while `getProposalById` cast whatever it was given to an `AtUri` and matched
+ * on `uri`. A record key never equals a full AT-URI, so no proposal detail page
+ * could load and `getUserVote` — which resolves the proposal first — failed the
+ * same way. The reporter's proposal record was created successfully; only the
+ * read path was broken.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { KnowledgeGraphService } from '@/services/knowledge-graph/graph-service.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+const RKEY = '3mlbhk6h2ne2k';
+const URI = `at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.graph.nodeProposal/${RKEY}`;
+
+const proposal = {
+  id: RKEY,
+  uri: URI,
+  proposalType: 'create' as const,
+  kind: 'type' as const,
+  subkind: 'field',
+  rationale: 'because',
+  status: 'pending' as const,
+  proposerDid: 'did:plc:izttpdp3l6vss5crelt5kcux',
+  createdAt: new Date('2026-05-07T14:48:40.171Z'),
+};
+
+const createLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+describe('KnowledgeGraphService.getProposalById', () => {
+  let graph: { getProposal: ReturnType<typeof vi.fn>; getProposalByRkey: ReturnType<typeof vi.fn> };
+  let service: KnowledgeGraphService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    graph = {
+      getProposal: vi.fn().mockResolvedValue(null),
+      getProposalByRkey: vi.fn().mockResolvedValue(null),
+    };
+    service = new KnowledgeGraphService({
+      graph: graph as never,
+      logger: createLogger(),
+    } as never);
+  });
+
+  it('should resolve a record key through the record-key lookup', async () => {
+    graph.getProposalByRkey.mockResolvedValue(proposal);
+
+    const result = await service.getProposalById(RKEY);
+
+    expect(result).not.toBeNull();
+    expect(graph.getProposalByRkey).toHaveBeenCalledWith(RKEY);
+    // Casting a record key to an AtUri and matching on `uri` is what broke.
+    expect(graph.getProposal).not.toHaveBeenCalled();
+  });
+
+  it('should still resolve a full AT-URI through the URI lookup', async () => {
+    graph.getProposal.mockResolvedValue(proposal);
+
+    const result = await service.getProposalById(URI);
+
+    expect(result).not.toBeNull();
+    expect(graph.getProposal).toHaveBeenCalledWith(URI);
+    expect(graph.getProposalByRkey).not.toHaveBeenCalled();
+  });
+
+  it('should return null when neither lookup finds the proposal', async () => {
+    expect(await service.getProposalById(RKEY)).toBeNull();
+  });
+
+  it('should not treat a user-typed slug as an AT-URI', async () => {
+    // The form used to route by the slug the user typed into the ID field.
+    await service.getProposalById('quantum-machine-learning');
+
+    expect(graph.getProposalByRkey).toHaveBeenCalledWith('quantum-machine-learning');
+    expect(graph.getProposal).not.toHaveBeenCalled();
+  });
+});

--- a/web/components/governance/proposal-form.tsx
+++ b/web/components/governance/proposal-form.tsx
@@ -23,7 +23,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Send, Loader2, Info, Plus, Edit, Trash2, Network, Tags, X } from 'lucide-react';
 
 import { logger } from '@/lib/observability';
-import { api } from '@/lib/api/client';
+import { api, authApi } from '@/lib/api/client';
 import { Button } from '@/components/ui/button';
 
 const proposalLogger = logger.child({ component: 'proposal-form' });
@@ -449,6 +449,33 @@ function NodeUriInput({
 // =============================================================================
 
 /**
+ * Extracts the record key from an AT-URI.
+ *
+ * @remarks
+ * Proposal routes are a single dynamic segment, so they cannot carry a full
+ * AT-URI. The record key is the identifier every proposal link uses.
+ */
+function rkeyOf(uri: string): string {
+  return uri.split('/').pop() ?? '';
+}
+
+/**
+ * Asks the AppView to index a freshly created proposal.
+ *
+ * @remarks
+ * Mirrors what endorsements, tags and annotations already do after a write.
+ * Indexing failure is not fatal: the firehose still delivers the record, so
+ * this only removes the delay before the proposal becomes readable.
+ */
+async function indexProposalRecord(uri: string): Promise<void> {
+  try {
+    await authApi.pub.chive.sync.indexRecord({ uri });
+  } catch {
+    // Non-fatal; the firehose remains the source of truth.
+  }
+}
+
+/**
  * Unified governance proposal form.
  */
 export function ProposalForm({
@@ -629,10 +656,19 @@ export function ProposalForm({
             },
           });
 
+          // Index the new record immediately. Every other user write does this;
+          // proposals did not, so the record only appeared after the firehose
+          // delivered it and the page redirected to a proposal that was not yet
+          // indexed.
+          await indexProposalRecord(result.data.uri);
+
           // Create a mock Proposal object for onSuccess
           const proposal = {
             uri: result.data.uri,
-            id: values.id,
+            // The record key, which is how proposal routes and list links
+            // address a proposal. Using the user-typed slug here sent the
+            // redirect to a URL the detail endpoint could never resolve.
+            id: rkeyOf(result.data.uri),
             type: values.proposalType,
             status: 'pending' as const,
             label: values.label,
@@ -674,10 +710,12 @@ export function ProposalForm({
             },
           });
 
+          await indexProposalRecord(result.data.uri);
+
           // Create a mock Proposal object for onSuccess
           const proposal = {
             uri: result.data.uri,
-            id: `${values.sourceUri}-${values.relationSlug}-${values.targetUri}`,
+            id: rkeyOf(result.data.uri),
             type: 'create' as const,
             status: 'pending' as const,
             label: `${values.sourceLabel ?? 'Source'} → ${values.relationSlug} → ${values.targetLabel ?? 'Target'}`,


### PR DESCRIPTION
## Summary

Fixes #89. **The premise of the issue is wrong in an important way: the proposal was created.** Robin's record is still in his PDS and I verified it directly:

```
at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.graph.nodeProposal/3mlbhk6h2ne2k
created 2026-05-07T14:48:40.171Z  (113 seconds before the issue was filed)
```

The write path, OAuth and the granular `repo:pub.chive.graph.nodeProposal` scope all worked. The bug is entirely on the read side — and it is broader than the report: **no proposal detail page could ever load, for any proposal**, and voting was broken by the same defect.

### Root cause

`KnowledgeGraphService.getProposalById` cast whatever identifier it received to an `AtUri` and handed it to `Neo4jAdapter.getProposal`, which runs `MATCH (p:Proposal {uri: $uri})`.

But nothing addresses a proposal by its full AT-URI. `createProposal` never set `p.id`, so `mapNeo4jProposal` derives the id as the URI's record key, and every link uses that — the proposals list, the governance home page, the dashboard, the moderation queue. A record key never equals a full AT-URI, so the match was always empty, the handler threw `NotFoundError`, and the page rendered "Proposal not found".

`getUserVote` resolves the proposal before reading votes, so it failed identically.

### Changes

- **`getProposalById` dispatches on the identifier's shape** — full AT-URI to the URI lookup, anything else to a new `getProposalByRkey`. This alone repairs every already-indexed proposal.
- **`Neo4jAdapter.getProposalByRkey`** matches `p.id` and falls back to the URI suffix, so proposals indexed before the record key was persisted resolve without a data migration.
- **`createProposal` now persists `p.id`**, so new proposals match directly.
- **`listVotes` resolves the real proposal URI.** It previously synthesised `at://chive.governance/pub.chive.graph.fieldProposal/<id>` — an authority that is not a DID and a collection that does not exist (proposals are `pub.chive.graph.nodeProposal`) — so it matched no vote and always returned an empty list.
- **The proposal form routes by record key** on both the node and edge branches. The node branch used the free-text slug the user typed into the ID field; the edge branch concatenated AT-URIs, which contain slashes and would break Next's dynamic segment outright.
- **New proposals are indexed immediately** via `sync.indexRecord`, matching what endorsements, tags and annotations already do. `pub.chive.graph.nodeProposal` and `pub.chive.graph.vote` were not in that endpoint's supported collections, so they are added and routed to `indexNodeProposal` / `indexVote` — the same service methods the firehose uses. Without this the redirect could beat the firehose and 404 on a proposal that was genuinely created.

## Related Issues

Closes #89.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- 4 new tests in `tests/unit/services/knowledge-graph/proposal-lookup.test.ts` covering record-key resolution, AT-URI resolution, the not-found case, and the user-typed slug that caused the original report.
- Updated three `listVotes` tests that encoded the synthetic-URI behaviour.
- Full unit suite green: 4027 passed, 2 skipped. Backend and frontend typecheck clean, lint clean.
- Verified the reporter's record still exists in his PDS, confirming the write succeeded and the defect is read-side.

## Checklist

### General
- [x] Self-review
- [x] Lint passes
- [x] Tests added/updated for changes
- [x] Documentation updated (TSDoc explains why routes carry the record key)

### ATProto Compliance
- [x] No writes to user PDSes (the record is written by the user's own client; this only indexes it)
- [x] Indexes can be rebuilt from firehose (force-indexing uses the same service methods as the firehose path and is idempotent)
- [x] PDS source is tracked for staleness detection

### Breaking Changes
- [x] N/A — the URI lookup still works for internal callers that hold one
