### PR TITLE
Release 0.7.1: governance fixes, Cypher injection, proposal lookup, and PDS scanning

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -363,15 +363,16 @@ jobs:
 
             # Run the reindex script inside the chive-api container
             # The script syncs all pub.chive.graph.node and pub.chive.graph.edge records
+            # Only GRAPH_PDS_URL is overridden, to reach the PDS over the
+            # container network. GRAPH_PDS_DID is deliberately NOT passed: the
+            # repository variable is often undefined, and interpolating it
+            # yielded an empty string that overrode the correct built-in
+            # default, so every run failed with `Params must have the property
+            # "repo"` *after* it had already cleared the graph.
             docker exec \
               -e GRAPH_PDS_URL=http://governance-pds:3000 \
-              -e GRAPH_PDS_DID=${{ vars.GRAPH_PDS_DID }} \
-              -e GRAPH_PDS_HANDLE=${{ vars.GRAPH_PDS_HANDLE }} \
-              -e GRAPH_PDS_PASSWORD=${{ secrets.GRAPH_PDS_ADMIN_PASSWORD }} \
               chive-api \
-              node --enable-source-maps dist/scripts/db/reindex-governance-to-neo4j.js || {
-                echo "::warning::Graph PDS sync failed - this may be expected on first deploy before records exist"
-              }
+              node --enable-source-maps dist/scripts/db/reindex-governance-to-neo4j.js
 
             echo "=== Governance sync complete ==="
 

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -368,9 +368,6 @@ jobs:
               -e GRAPH_PDS_DID=${{ vars.GRAPH_PDS_DID }} \
               -e GRAPH_PDS_HANDLE=${{ vars.GRAPH_PDS_HANDLE }} \
               -e GRAPH_PDS_PASSWORD=${{ secrets.GRAPH_PDS_ADMIN_PASSWORD }} \
-              -e NEO4J_URI=bolt://neo4j:7687 \
-              -e NEO4J_USER=neo4j \
-              -e NEO4J_PASSWORD=${{ secrets.NEO4J_PASSWORD }} \
               chive-api \
               node --enable-source-maps dist/scripts/db/reindex-governance-to-neo4j.js || {
                 echo "::warning::Graph PDS sync failed - this may be expected on first deploy before records exist"
@@ -424,18 +421,21 @@ jobs:
 
             cd /opt/chive
 
-            # Run the reindex script inside the chive-api container
-            # This fetches fresh records from PDSes and reindexes with current schema
+            # Run the reindex script inside the chive-api container.
+            # chive-api already has DATABASE_URL, ELASTICSEARCH_URL, NEO4J_URI,
+            # NEO4J_USER and NEO4J_PASSWORD from .env.production, so we pass no
+            # overrides: the script must use exactly the credentials the running
+            # service uses, and re-injecting them here risks drift and shell
+            # quoting damage.
+            #
+            # The script waits for the Neo4j knowledge graph to be populated
+            # before resolving field labels, and exits non-zero if any eprint
+            # still carries a raw UUID as a field label. A failure here means
+            # the search index is live with broken field names, so let it fail
+            # the deploy rather than warn.
             docker exec \
-              -e DATABASE_URL=postgresql://chive:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/chive \
-              -e ELASTICSEARCH_URL=http://elasticsearch:9200 \
-              -e NEO4J_URI=bolt://neo4j:7687 \
-              -e NEO4J_USER=neo4j \
-              -e NEO4J_PASSWORD=${{ secrets.NEO4J_PASSWORD }} \
               chive-api \
-              node --enable-source-maps dist/scripts/reindex-all-eprints.js || {
-                echo "::warning::Elasticsearch reindex failed - manual intervention may be required"
-              }
+              node --enable-source-maps dist/scripts/reindex-all-eprints.js
 
             echo "=== Elasticsearch reindex complete ==="
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-24
+
+### Fixed
+
+- Node subkinds are validated before being interpolated into Cypher. `subkindToLabel` only capitalised the hyphen-separated parts, so parentheses, whitespace and comment markers passed into `MATCH (n:Node:<label>)` unaltered, and `subkind` is caller-supplied on the unauthenticated `pub.chive.graph.listNodes` and `pub.chive.graph.getHierarchy`. The helper was also duplicated, unguarded, across two files feeding nine interpolation sites; both now route through `src/storage/neo4j/labels.ts`, which rejects anything that is not a plain identifier.
+- Proposals resolve by record key, so proposal detail pages and votes load. `getProposalById` cast whatever identifier it received to an `AtUri` and matched on `uri`, while every route and list link carries the record key — a value that never equals a full AT-URI. No proposal page could load and `getUserVote` failed identically. `IGraphDatabase` gains `getProposalByRkey`, which falls back to the URI suffix so proposals indexed before the record key was persisted resolve without a migration. Closes #89.
+- `pub.chive.governance.listVotes` returns the votes on a proposal. It synthesised `at://chive.governance/pub.chive.graph.fieldProposal/<id>` — an authority that is not a DID, and a collection that does not exist — so it matched no vote and always returned an empty list.
+- New proposals are indexed immediately through `pub.chive.sync.indexRecord`, as every other user write already was. `pub.chive.graph.nodeProposal` and `pub.chive.graph.vote` were not accepted by that endpoint, so a proposal was only readable once the firehose delivered it.
+- The governance sync no longer clears the knowledge graph before it has the records to replace it with. An undefined `GRAPH_PDS_DID` repository variable interpolated to an empty string, which overrode the correct built-in default and failed every request with `Params must have the property "repo"` — after the graph had already been wiped. Deploys therefore left Neo4j empty, and the eprint reindex that followed resolved every field label to a raw UUID.
+- Field labels survive a reindex that cannot reach the knowledge graph. `resolveFieldLabels` returns the original UUID when Neo4j has no matching node and swallows the error that caused it, so a racing or failed lookup overwrote correct labels. The reindex now waits briefly for the graph to populate and preserves the label already stored in PostgreSQL rather than downgrading it.
+- The field label resolution job mirrors repairs into Elasticsearch. It only ever wrote to PostgreSQL, while browse and search read from the search index, so repaired labels never reached the UI.
+- The PDS scanner can reach relay-connected servers. `getPDSesForScan` required `is_relay_connected = FALSE` and every registered PDS is relay-connected, so the scheduler ran every 15 minutes and scanned nothing. Records from those servers normally arrive over the firehose, but a relay outage longer than the relay's backfill window skips events permanently, and this scan is the only mechanism that can find them. They are now ranked last rather than excluded.
+- A PDS wedged in `scanning` by a crashed scan is reclaimed after an hour. Nothing cleared that status and it was absent from the selection query, so such a server was excluded from every future cycle.
+- Backend services report their real release version. `npm_package_version` is unset when a container starts Node directly, so `/health`, structured logs and OpenTelemetry resources reported `0.0.0` in every deployed environment.
+
+### Changed
+
+- The production deploy no longer re-injects database credentials into the reindex and governance sync steps, using the container's own environment instead. Re-interpolating them risked drift from the values the running service uses, and an undefined variable silently overrode a correct default.
+- A failed Elasticsearch reindex or governance sync now fails the deploy instead of emitting a warning and reporting success.
+
 ## [0.7.0] - 2026-08-24
 
 ### Added
@@ -669,7 +689,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/chive-pub/chive/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/chive-pub/chive/compare/v0.6.3...v0.7.0
 [0.6.3]: https://github.com/chive-pub/chive/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/chive-pub/chive/compare/v0.6.1...v0.6.2

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/scripts/db/reindex-governance-to-neo4j.ts
+++ b/scripts/db/reindex-governance-to-neo4j.ts
@@ -15,8 +15,22 @@
 import { AtpAgent } from '@atproto/api';
 import neo4j from 'neo4j-driver';
 
-const PDS_URL = process.env.GRAPH_PDS_URL ?? 'https://governance.chive.pub';
-const GRAPH_PDS_DID = process.env.GRAPH_PDS_DID ?? 'did:plc:5wzpn4a4nbqtz3q45hyud6hd';
+/**
+ * Reads an environment variable, treating blank values as unset.
+ *
+ * @remarks
+ * Deploy steps interpolate repository variables that may not be defined,
+ * producing an empty string rather than an absent variable. Nullish coalescing
+ * accepts `''` as a real value, which silently replaced the graph PDS DID with
+ * nothing and made every `listRecords` call fail.
+ */
+function envOrDefault(name: string, fallback: string): string {
+  const value = process.env[name];
+  return value !== undefined && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+const PDS_URL = envOrDefault('GRAPH_PDS_URL', 'https://governance.chive.pub');
+const GRAPH_PDS_DID = envOrDefault('GRAPH_PDS_DID', 'did:plc:5wzpn4a4nbqtz3q45hyud6hd');
 
 const NEO4J_URI = process.env.NEO4J_URI ?? 'bolt://localhost:7687';
 const NEO4J_USER = process.env.NEO4J_USER ?? 'neo4j';
@@ -107,25 +121,43 @@ async function main(): Promise<void> {
   console.log('Connected.\n');
 
   try {
-    // Clear existing nodes and edges
-    console.log('Clearing existing graph data...');
-    await session.run('MATCH (n:Node) DETACH DELETE n');
-    console.log('Cleared.\n');
-
-    // Fetch and index nodes
-    console.log('=== Indexing Nodes ===');
-    let nodeCount = 0;
-    let cursor: string | undefined;
+    // Fetch every node before mutating Neo4j. The graph must never be cleared
+    // on a run that then fails to repopulate it: an empty graph silently turns
+    // every eprint field label into a raw UUID at the next reindex.
+    console.log('=== Fetching Nodes ===');
+    const nodeRecords: { uri: string; value: unknown }[] = [];
+    let fetchCursor: string | undefined;
 
     do {
       const response = await agent.com.atproto.repo.listRecords({
         repo: GRAPH_PDS_DID,
         collection: 'pub.chive.graph.node',
         limit: 100,
-        cursor,
+        cursor: fetchCursor,
       });
+      nodeRecords.push(...response.data.records);
+      fetchCursor = response.data.cursor;
+    } while (fetchCursor);
 
-      for (const record of response.data.records) {
+    console.log(`  ${nodeRecords.length} node records fetched\n`);
+
+    if (nodeRecords.length === 0) {
+      throw new Error(
+        `No pub.chive.graph.node records found in ${GRAPH_PDS_DID}. Refusing to clear the ` +
+          'knowledge graph, which would leave every eprint field label showing a raw UUID.'
+      );
+    }
+
+    // Only now is it safe to replace the graph.
+    console.log('Clearing existing graph data...');
+    await session.run('MATCH (n:Node) DETACH DELETE n');
+    console.log('Cleared.\n');
+
+    console.log('=== Indexing Nodes ===');
+    let nodeCount = 0;
+
+    {
+      for (const record of nodeRecords) {
         if (!isNodeRecord(record.value)) {
           console.warn(`Skipping invalid node record: ${record.uri}`);
           continue;
@@ -175,16 +207,14 @@ async function main(): Promise<void> {
           process.stdout.write(`  ${nodeCount} nodes indexed\r`);
         }
       }
-
-      cursor = response.data.cursor;
-    } while (cursor);
+    }
 
     console.log(`  ${nodeCount} nodes indexed\n`);
 
     // Fetch and index edges
     console.log('=== Indexing Edges ===');
     let edgeCount = 0;
-    cursor = undefined;
+    let cursor: string | undefined;
 
     do {
       const response = await agent.com.atproto.repo.listRecords({

--- a/scripts/reindex-all-eprints.ts
+++ b/scripts/reindex-all-eprints.ts
@@ -46,6 +46,12 @@ const CONFIG = {
   delayBetweenBatchesMs: parseInt(process.env.REINDEX_DELAY_MS ?? '1000', 10),
   maxRetries: parseInt(process.env.REINDEX_MAX_RETRIES ?? '3', 10),
   pdsTimeoutMs: 30000,
+  /**
+   * How long to wait for the Neo4j knowledge graph to become populated before
+   * aborting. Deploys recreate Neo4j and repopulate it asynchronously, so the
+   * graph is routinely empty for the first few seconds after a restart.
+   */
+  graphWaitMs: parseInt(process.env.REINDEX_GRAPH_WAIT_MS ?? '180000', 10),
   indexAlias: 'eprints',
   indexName: 'eprints-v1', // Fallback if alias doesn't exist
 };
@@ -198,6 +204,46 @@ async function checkElasticsearchHealth(client: ElasticsearchClient): Promise<bo
   } catch (error) {
     console.error('Elasticsearch health check failed:', error);
     return false;
+  }
+}
+
+/**
+ * Waits until the Neo4j knowledge graph actually contains nodes.
+ *
+ * @param driver - Neo4j driver
+ * @param timeoutMs - How long to wait before giving up
+ * @returns The node count once non-zero, or 0 if the timeout elapsed
+ *
+ * @remarks
+ * A passing health check only proves Neo4j is reachable, not that the graph is
+ * populated. Deploys recreate Neo4j and repopulate it asynchronously, so this
+ * script can otherwise win the race and resolve every field label against an
+ * empty graph — silently persisting UUIDs into PostgreSQL and Elasticsearch,
+ * where they stay visible in the UI until someone reindexes by hand.
+ */
+async function waitForPopulatedGraph(driver: Driver, timeoutMs: number): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  let reported = false;
+
+  for (;;) {
+    const session = driver.session();
+    try {
+      const result = await session.run('MATCH (n:Node) RETURN count(n) AS count');
+      const count = result.records[0]?.get('count')?.toNumber?.() ?? 0;
+      if (count > 0) return count;
+    } catch (error) {
+      console.error('  Neo4j node count query failed:', error);
+    } finally {
+      await session.close();
+    }
+
+    if (Date.now() >= deadline) return 0;
+
+    if (!reported) {
+      console.log('  Knowledge graph is empty, waiting for it to populate...');
+      reported = true;
+    }
+    await sleep(5000);
   }
 }
 
@@ -484,6 +530,16 @@ async function main() {
   }
   console.log('  ✓ Neo4j is healthy');
 
+  const graphNodeCount = await waitForPopulatedGraph(neo4jDriver, CONFIG.graphWaitMs);
+  if (graphNodeCount === 0) {
+    throw new Error(
+      `Neo4j knowledge graph is still empty after ${Math.round(CONFIG.graphWaitMs / 1000)}s - ` +
+        'aborting rather than reindexing every field label as a raw UUID. ' +
+        'Check that the governance sync ran and populated pub.chive.graph.node records.'
+    );
+  }
+  console.log(`  ✓ Knowledge graph is populated (${graphNodeCount} nodes)`);
+
   // ==========================================================================
   // RECREATE ELASTICSEARCH INDEX
   // ==========================================================================
@@ -600,6 +656,32 @@ async function main() {
   );
   console.log(`Field labels cached: ${nodeLookup.cacheSize}`);
 
+  // A run that resolved nothing while unresolved labels remain means the
+  // knowledge graph lookups silently failed: resolveFieldLabels swallows all
+  // errors and returns the original UUID. Surface it instead of reporting a
+  // clean reindex over visibly broken data.
+  const unresolved = await pgPool.query<{ count: string }>(
+    `SELECT count(*) AS count
+     FROM eprints_index
+     WHERE fields::text ~ '"label": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
+       AND deleted_at IS NULL`
+  );
+  const unresolvedCount = parseInt(unresolved.rows[0]?.count ?? '0', 10);
+  let unresolvedLabels = false;
+  if (unresolvedCount > 0) {
+    console.error();
+    console.error(
+      `ERROR: ${unresolvedCount} eprint(s) still carry raw UUIDs as field labels after reindexing.`
+    );
+    console.error(
+      'The knowledge graph lookup returned nothing for those field ids. Check that the'
+    );
+    console.error('governance sync populated Neo4j before this script ran.');
+    unresolvedLabels = true;
+  } else {
+    console.log('Field labels: all resolved');
+  }
+
   if (stats.prunedRecords.length > 0) {
     console.log();
     console.log('Pruned orphaned records (no longer in PDS):');
@@ -632,6 +714,12 @@ async function main() {
   if (stats.failed > 0) {
     console.log();
     console.log('WARNING: Some records failed to reindex. Check logs above.');
+    process.exit(1);
+  }
+
+  // Unresolved labels mean the index is live with raw UUIDs where field names
+  // belong. Fail so the deploy surfaces it rather than reporting success.
+  if (unresolvedLabels) {
     process.exit(1);
   }
 }

--- a/scripts/reindex-all-eprints.ts
+++ b/scripts/reindex-all-eprints.ts
@@ -34,7 +34,11 @@ import neo4j, { Driver } from 'neo4j-driver';
 import { transformPDSRecord } from '../src/services/eprint/pds-record-transformer.js';
 import { mapEprintToDocument } from '../src/storage/elasticsearch/document-mapper.js';
 import { setupElasticsearch } from '../src/storage/elasticsearch/setup.js';
-import { resolveFieldLabels, type NodeLookup } from '../src/utils/field-label.js';
+import {
+  needsLabelResolution,
+  resolveFieldLabels,
+  type NodeLookup,
+} from '../src/utils/field-label.js';
 import type { AtUri, CID } from '../src/types/atproto.js';
 
 // =============================================================================
@@ -51,7 +55,7 @@ const CONFIG = {
    * aborting. Deploys recreate Neo4j and repopulate it asynchronously, so the
    * graph is routinely empty for the first few seconds after a restart.
    */
-  graphWaitMs: parseInt(process.env.REINDEX_GRAPH_WAIT_MS ?? '180000', 10),
+  graphWaitMs: parseInt(process.env.REINDEX_GRAPH_WAIT_MS ?? '60000', 10),
   indexAlias: 'eprints',
   indexName: 'eprints-v1', // Fallback if alias doesn't exist
 };
@@ -310,8 +314,11 @@ async function reindexSingleRecord(
     response.data.cid as CID
   );
 
-  // Resolve field labels from Neo4j knowledge graph
-  const fieldsWithLabels = await resolveFieldLabels(eprint.fields, nodeLookup);
+  // Resolve field labels from Neo4j knowledge graph. If the graph cannot resolve
+  // a label, fall back to whatever PostgreSQL already holds for that field id:
+  // an unresolvable lookup must never downgrade a good label to a raw UUID.
+  const resolved = await resolveFieldLabels(eprint.fields, nodeLookup);
+  const fieldsWithLabels = await preserveResolvedLabels(pgPool, uri, resolved);
 
   // Update PostgreSQL with fields (including resolved labels)
   await pgPool.query(
@@ -334,6 +341,56 @@ async function reindexSingleRecord(
     id: uri,
     document: esDocument,
   });
+}
+
+/**
+ * Keeps labels that PostgreSQL already resolved when the graph cannot resolve them.
+ *
+ * @param pool - PostgreSQL pool
+ * @param uri - AT-URI of the eprint being reindexed
+ * @param fields - Fields as returned by the knowledge graph lookup
+ * @returns Fields with any unresolved label replaced by the stored one, when present
+ *
+ * @remarks
+ * `resolveFieldLabels` returns the original value — typically a raw UUID — when
+ * Neo4j has no matching node, and swallows the error that caused it. Writing
+ * that straight back replaces a correct label with a UUID, which is what put
+ * UUIDs on production eprint cards after a deploy wiped the graph. Preserving
+ * the stored label makes a failed or racing lookup a no-op instead of damage.
+ */
+async function preserveResolvedLabels(
+  pool: Pool,
+  uri: string,
+  fields: { uri: string; label: string; id: string }[]
+): Promise<{ uri: string; label: string; id: string }[]> {
+  if (fields.length === 0) return fields;
+  if (!fields.some((f) => needsLabelResolution(f.label))) return fields;
+
+  try {
+    const existing = await pool.query<{ fields: string | null }>(
+      'SELECT fields::text AS fields FROM eprints_index WHERE uri = $1',
+      [uri]
+    );
+
+    const raw = existing.rows[0]?.fields;
+    if (!raw) return fields;
+
+    const stored = JSON.parse(raw) as { id?: string; label?: string }[];
+    const byId = new Map(
+      stored
+        .filter((f) => f.id && f.label && !needsLabelResolution(f.label))
+        .map((f) => [f.id as string, f.label as string])
+    );
+    if (byId.size === 0) return fields;
+
+    return fields.map((f) =>
+      needsLabelResolution(f.label) && byId.has(f.id)
+        ? { ...f, label: byId.get(f.id) as string }
+        : f
+    );
+  } catch {
+    return fields;
+  }
 }
 
 // =============================================================================
@@ -530,15 +587,17 @@ async function main() {
   }
   console.log('  ✓ Neo4j is healthy');
 
+  // Deploys recreate Neo4j and repopulate it asynchronously, so give the graph a
+  // moment before resolving anything against it.
   const graphNodeCount = await waitForPopulatedGraph(neo4jDriver, CONFIG.graphWaitMs);
   if (graphNodeCount === 0) {
-    throw new Error(
-      `Neo4j knowledge graph is still empty after ${Math.round(CONFIG.graphWaitMs / 1000)}s - ` +
-        'aborting rather than reindexing every field label as a raw UUID. ' +
-        'Check that the governance sync ran and populated pub.chive.graph.node records.'
+    console.warn(
+      `  ! Knowledge graph is empty after ${Math.round(CONFIG.graphWaitMs / 1000)}s. Field labels ` +
+        'cannot be resolved; already-resolved labels will be preserved rather than overwritten.'
     );
+  } else {
+    console.log(`  ✓ Knowledge graph is populated (${graphNodeCount} nodes)`);
   }
-  console.log(`  ✓ Knowledge graph is populated (${graphNodeCount} nodes)`);
 
   // ==========================================================================
   // RECREATE ELASTICSEARCH INDEX
@@ -668,16 +727,21 @@ async function main() {
   );
   const unresolvedCount = parseInt(unresolved.rows[0]?.count ?? '0', 10);
   let unresolvedLabels = false;
-  if (unresolvedCount > 0) {
+  if (unresolvedCount > 0 && graphNodeCount > 0) {
     console.error();
     console.error(
-      `ERROR: ${unresolvedCount} eprint(s) still carry raw UUIDs as field labels after reindexing.`
+      `ERROR: ${unresolvedCount} eprint(s) still carry raw UUIDs as field labels after reindexing,`
     );
     console.error(
-      'The knowledge graph lookup returned nothing for those field ids. Check that the'
+      `even though the knowledge graph holds ${graphNodeCount} nodes. Those field ids are missing`
     );
-    console.error('governance sync populated Neo4j before this script ran.');
+    console.error('from the graph, or the lookup failed silently.');
     unresolvedLabels = true;
+  } else if (unresolvedCount > 0) {
+    console.warn(
+      `  ! ${unresolvedCount} eprint(s) carry unresolved field labels because the knowledge graph ` +
+        'is empty. Populate it via the governance sync, then reindex.'
+    );
   } else {
     console.log('Field labels: all resolved');
   }

--- a/src/api/handlers/xrpc/governance/listVotes.ts
+++ b/src/api/handlers/xrpc/governance/listVotes.ts
@@ -13,6 +13,7 @@ import type {
   OutputSchema,
   VoteView,
 } from '../../../../lexicons/generated/types/pub/chive/governance/listVotes.js';
+import { NotFoundError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 /**
@@ -31,11 +32,18 @@ export const listVotes: XRPCMethod<QueryParams, void, OutputSchema> = {
       limit: params.limit,
     });
 
-    // Construct proposal URI from ID
-    const proposalUri = `at://chive.governance/pub.chive.graph.fieldProposal/${params.proposalId}`;
+    // Resolve the proposal to get its real URI. The previous implementation
+    // synthesised one as `at://chive.governance/pub.chive.graph.fieldProposal/<id>`,
+    // whose authority is not a DID and whose collection does not exist
+    // (proposals are `pub.chive.graph.nodeProposal`), so it matched no vote and
+    // this endpoint always returned an empty list.
+    const proposal = await graphService.getProposalById(params.proposalId);
+    if (!proposal) {
+      throw new NotFoundError('Proposal', params.proposalId);
+    }
 
     // Get votes from the knowledge graph service
-    const allVotes = await graphService.getVotesForProposal(proposalUri);
+    const allVotes = await graphService.getVotesForProposal(proposal.uri);
 
     // Apply pagination
     const limit = params.limit ?? 100;

--- a/src/api/handlers/xrpc/sync/indexRecord.ts
+++ b/src/api/handlers/xrpc/sync/indexRecord.ts
@@ -183,6 +183,8 @@ export const indexRecord: XRPCMethod<void, InputSchema, OutputSchema> = {
       'pub.chive.eprint.relatedWork',
       'pub.chive.graph.node',
       'pub.chive.graph.edge',
+      'pub.chive.graph.nodeProposal',
+      'pub.chive.graph.vote',
       'pub.chive.actor.profileConfig',
     ];
 
@@ -317,6 +319,19 @@ export const indexRecord: XRPCMethod<void, InputSchema, OutputSchema> = {
           // No personal graph service available, treat as success
           result = { ok: true as const, value: undefined };
         }
+      } else if (collection === 'pub.chive.graph.nodeProposal') {
+        // Knowledge graph proposal. Indexed here as well as from the firehose
+        // so the proposal is readable as soon as the user is redirected to it,
+        // rather than only once the firehose event arrives.
+        const graphService = c.get('services').graph;
+        result = graphService
+          ? await graphService.indexNodeProposal(record.value, metadata)
+          : { ok: true as const, value: undefined };
+      } else if (collection === 'pub.chive.graph.vote') {
+        const graphService = c.get('services').graph;
+        result = graphService
+          ? await graphService.indexVote(record.value, metadata)
+          : { ok: true as const, value: undefined };
       } else if (collection === 'pub.chive.graph.edge') {
         // Personal graph edge (including collection CONTAINS/SUBCOLLECTION_OF)
         const personalGraphService = c.get('services').personalGraph;

--- a/src/config/graph.ts
+++ b/src/config/graph.ts
@@ -27,8 +27,12 @@ import type { DID } from '../types/atproto.js';
  *
  * @public
  */
-export const GRAPH_PDS_DID: DID =
-  (process.env.GRAPH_PDS_DID as DID | undefined) ?? ('did:plc:5wzpn4a4nbqtz3q45hyud6hd' as DID);
+export const GRAPH_PDS_DID: DID = ((): DID => {
+  // A deploy step that interpolates an undefined repository variable yields an
+  // empty string, which nullish coalescing would accept as a real value.
+  const configured = process.env.GRAPH_PDS_DID?.trim();
+  return configured ? (configured as DID) : ('did:plc:5wzpn4a4nbqtz3q45hyud6hd' as DID);
+})();
 
 /**
  * Returns the graph PDS DID.

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -481,10 +481,12 @@ async function main(): Promise<void> {
       logger.info('Automatic proposal service disabled (graph PDS not configured)');
     }
 
-    // Start field label resolution job (hourly scan for UUID labels in PostgreSQL)
+    // Start field label resolution job (hourly scan for UUID labels, repairing
+    // both PostgreSQL and the search index that browse and search read from)
     state.fieldLabelResolutionJob = new FieldLabelResolutionJob({
       pool: pgPool,
       nodeLookup: graphAdapter,
+      indexWriter: searchAdapter,
       logger,
       intervalMs: 3_600_000, // 1 hour
       runOnStartup: true,

--- a/src/jobs/field-label-resolution-job.ts
+++ b/src/jobs/field-label-resolution-job.ts
@@ -6,7 +6,11 @@
  * (stored as UUIDs) and resolves them from the Neo4j knowledge graph.
  *
  * This handles the case where eprints were indexed before their field
- * nodes existed in Neo4j, leaving UUID placeholders in PostgreSQL.
+ * nodes existed in Neo4j, leaving UUID placeholders behind. Deploys recreate
+ * Neo4j and repopulate it asynchronously, so a reindex can resolve labels
+ * against an empty graph and persist UUIDs to both stores. Repairing
+ * PostgreSQL alone is not enough: browse and search read from Elasticsearch,
+ * so the UI would keep showing UUIDs indefinitely.
  *
  * @packageDocumentation
  * @public
@@ -20,12 +24,33 @@ import type { ILogger } from '../types/interfaces/logger.interface.js';
 import { type NodeLookup, needsLabelResolution, resolveFieldLabels } from '../utils/field-label.js';
 
 /**
+ * Minimal interface for writing resolved labels back to the search index.
+ *
+ * @remarks
+ * Satisfied by `ElasticsearchAdapter`.
+ *
+ * @public
+ */
+export interface FieldLabelIndexWriter {
+  updateFieldLabels(uri: string, fields: readonly { id: string; label: string }[]): Promise<void>;
+}
+
+/**
  * @public
  */
 export interface FieldLabelResolutionJobConfig {
   readonly pool: Pool;
   readonly nodeLookup: NodeLookup;
   readonly logger: ILogger;
+
+  /**
+   * Search index to mirror repaired labels into.
+   *
+   * @remarks
+   * Optional only so existing callers and tests keep working. Omitting it
+   * leaves the search index showing UUIDs even after PostgreSQL is repaired.
+   */
+  readonly indexWriter?: FieldLabelIndexWriter;
 
   /**
    * Interval between scans in milliseconds.
@@ -56,6 +81,7 @@ export interface ResolutionRunResult {
   readonly success: boolean;
   readonly scanned: number;
   readonly resolved: number;
+  readonly indexUpdated: number;
   readonly durationMs: number;
   readonly error?: string;
 }
@@ -68,6 +94,7 @@ export interface ResolutionRunResult {
 export class FieldLabelResolutionJob {
   private readonly pool: Pool;
   private readonly nodeLookup: NodeLookup;
+  private readonly indexWriter: FieldLabelIndexWriter | undefined;
   private readonly logger: ILogger;
   private readonly intervalMs: number;
   private readonly batchSize: number;
@@ -79,6 +106,7 @@ export class FieldLabelResolutionJob {
   constructor(config: FieldLabelResolutionJobConfig) {
     this.pool = config.pool;
     this.nodeLookup = config.nodeLookup;
+    this.indexWriter = config.indexWriter;
     this.logger = config.logger.child({ service: 'field-label-resolution-job' });
     this.intervalMs = config.intervalMs ?? 3_600_000; // 1 hour
     this.batchSize = config.batchSize ?? 100;
@@ -115,7 +143,14 @@ export class FieldLabelResolutionJob {
 
   async run(): Promise<ResolutionRunResult> {
     if (this.isRunning) {
-      return { success: false, scanned: 0, resolved: 0, durationMs: 0, error: 'Already running' };
+      return {
+        success: false,
+        scanned: 0,
+        resolved: 0,
+        indexUpdated: 0,
+        durationMs: 0,
+        error: 'Already running',
+      };
     }
 
     this.isRunning = true;
@@ -137,7 +172,13 @@ export class FieldLabelResolutionJob {
 
         if (rows.rows.length === 0) {
           this.logger.debug('No eprints with unresolved field labels found');
-          return { success: true as const, scanned: 0, resolved: 0, durationMs: 0 };
+          return {
+            success: true as const,
+            scanned: 0,
+            resolved: 0,
+            indexUpdated: 0,
+            durationMs: 0,
+          };
         }
 
         this.logger.info('Found eprints with unresolved field labels', {
@@ -145,6 +186,7 @@ export class FieldLabelResolutionJob {
         });
 
         let resolved = 0;
+        let indexUpdated = 0;
 
         for (const row of rows.rows) {
           const fields = JSON.parse(row.fields) as { uri: string; label: string; id?: string }[];
@@ -165,12 +207,29 @@ export class FieldLabelResolutionJob {
           ]);
 
           resolved++;
+
+          // Browse and search read from the search index, not PostgreSQL, so
+          // the repair is only visible to users once it lands there too. A
+          // failure here must not abort the run: PostgreSQL is already
+          // correct, and the next pass retries.
+          if (this.indexWriter) {
+            try {
+              await this.indexWriter.updateFieldLabels(row.uri, resolvedFields);
+              indexUpdated++;
+            } catch (err) {
+              this.logger.warn('Failed to mirror resolved field labels to the search index', {
+                uri: row.uri,
+                error: err instanceof Error ? err.message : 'Unknown error',
+              });
+            }
+          }
         }
 
         return {
           success: true as const,
           scanned: rows.rows.length,
           resolved,
+          indexUpdated,
           durationMs: Date.now() - startTime,
         };
       });
@@ -187,8 +246,15 @@ export class FieldLabelResolutionJob {
         this.logger.info('Field label resolution completed', {
           scanned: result.scanned,
           resolved: result.resolved,
+          indexUpdated: result.indexUpdated,
           durationMs: result.durationMs,
         });
+
+        if (!this.indexWriter) {
+          this.logger.warn(
+            'Repaired field labels in PostgreSQL only; no search index writer is configured, so browse and search will keep showing UUIDs'
+          );
+        }
       }
 
       return result;
@@ -204,6 +270,7 @@ export class FieldLabelResolutionJob {
         success: false,
         scanned: 0,
         resolved: 0,
+        indexUpdated: 0,
         durationMs: Date.now() - startTime,
         error: errorMessage,
       };

--- a/src/services/knowledge-graph/graph-service.ts
+++ b/src/services/knowledge-graph/graph-service.ts
@@ -651,7 +651,14 @@ export class KnowledgeGraphService {
    */
   async getProposalById(proposalId: string): Promise<ProposalView | null> {
     try {
-      const proposal = await this.graph.getProposal(proposalId as AtUri);
+      // Callers pass whichever identifier they hold. Routes and list links
+      // carry the record key, because an AT-URI cannot occupy a single dynamic
+      // route segment; internal callers hold the full URI. Casting a record key
+      // to an AtUri and matching on `uri` never matched, which made every
+      // proposal detail page and every vote lookup fail.
+      const proposal = proposalId.startsWith('at://')
+        ? await this.graph.getProposal(proposalId as AtUri)
+        : await this.graph.getProposalByRkey(proposalId);
 
       if (!proposal) {
         return null;

--- a/src/services/pds-discovery/pds-registry.ts
+++ b/src/services/pds-discovery/pds-registry.ts
@@ -237,11 +237,22 @@ export class PDSRegistry implements IPDSRegistry {
         `
         SELECT *
         FROM pds_registry
-        WHERE status IN ('pending', 'active')
+        WHERE (
+                status IN ('pending', 'active')
+                -- Recover PDSes wedged in 'scanning' by a process that died
+                -- mid-scan. Nothing else clears that status, and 'scanning' is
+                -- otherwise excluded here, so such a PDS is never scanned again.
+                OR (status = 'scanning' AND updated_at < NOW() - INTERVAL '1 hour')
+              )
           AND (next_scan_at IS NULL OR next_scan_at <= NOW())
           AND consecutive_failures < 5
-          AND is_relay_connected = FALSE
-        ORDER BY scan_priority ASC, next_scan_at ASC NULLS FIRST
+        -- Relay-connected PDSes are deprioritised, not excluded. Their records
+        -- normally arrive over the firehose, but a relay outage longer than the
+        -- relay's backfill window silently skips a range of events, and this
+        -- scan is the only mechanism that can find what was missed. Excluding
+        -- them outright made the scanner unable to repair exactly the gap it
+        -- exists for; scan cadence is still governed by next_scan_at.
+        ORDER BY is_relay_connected ASC, scan_priority ASC, next_scan_at ASC NULLS FIRST
         LIMIT $1
         `,
         [limit]
@@ -268,7 +279,8 @@ export class PDSRegistry implements IPDSRegistry {
       await this.pool.query(
         `
         UPDATE pds_registry
-        SET status = 'scanning'
+        SET status = 'scanning',
+            updated_at = NOW()
         WHERE pds_url = $1
         `,
         [pdsUrl]

--- a/src/storage/elasticsearch/adapter.ts
+++ b/src/storage/elasticsearch/adapter.ts
@@ -183,6 +183,52 @@ export class ElasticsearchAdapter implements ISearchEngine {
   }
 
   /**
+   * Updates only the field labels on an already-indexed eprint.
+   *
+   * @param uri - AT-URI of the eprint, used as the document ID
+   * @param fields - Field nodes carrying resolved human-readable labels
+   *
+   * @remarks
+   * A partial update, so it cannot clobber other document content. Used by the
+   * field label resolution job to repair documents that were indexed while the
+   * Neo4j knowledge graph was empty or still populating — without it, labels
+   * repaired in PostgreSQL would never reach the search index that the browse
+   * and search UI actually reads from.
+   *
+   * A missing document is not an error: the eprint may have been pruned
+   * between the PostgreSQL scan and this update.
+   *
+   * @throws {IndexError} On any failure other than a missing document
+   *
+   * @public
+   */
+  async updateFieldLabels(
+    uri: string,
+    fields: readonly { id: string; label: string }[]
+  ): Promise<void> {
+    try {
+      await this.client.update({
+        index: this.config.indexName,
+        id: uri,
+        doc: { field_nodes: fields.map((f) => ({ id: f.id, label: f.label })) },
+        retry_on_conflict: 3,
+        refresh: false,
+      });
+    } catch (error) {
+      if (error instanceof errors.ResponseError) {
+        if (error.statusCode === 404) return;
+
+        throw new IndexError(`Failed to update field labels for ${uri}: ${error.message}`, error);
+      }
+
+      throw new IndexError(
+        `Unexpected error updating field labels for ${uri}`,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
    * Searches eprints.
    *
    * @param query - Search query

--- a/src/storage/neo4j/adapter.ts
+++ b/src/storage/neo4j/adapter.ts
@@ -730,6 +730,32 @@ export class Neo4jAdapter implements IGraphDatabase {
   /**
    * Gets a proposal by URI.
    */
+  /**
+   * Gets a proposal by its record key.
+   *
+   * @remarks
+   * Matches `p.id` where present and falls back to the URI suffix, so
+   * proposals indexed before the record key was persisted resolve too. That
+   * fallback is what makes this work without a data migration.
+   */
+  async getProposalByRkey(rkey: string): Promise<NodeProposal | null> {
+    const query = `
+      MATCH (p:Proposal)
+      WHERE p.id = $rkey OR p.uri ENDS WITH '/' + $rkey
+      RETURN p
+      LIMIT 1
+    `;
+
+    const result = await this.connection.executeQuery<{ p: Neo4jProposal }>(query, { rkey });
+
+    const record = result.records[0];
+    if (!record) {
+      return null;
+    }
+
+    return this.mapNeo4jProposal(record.get('p'));
+  }
+
   async getProposal(uri: AtUri): Promise<NodeProposal | null> {
     const query = `
       MATCH (p:Proposal {uri: $uri})
@@ -859,6 +885,7 @@ export class Neo4jAdapter implements IGraphDatabase {
     const query = `
       MERGE (p:Proposal {uri: $uri})
       ON CREATE SET
+        p.id = $id,
         p.proposalType = $proposalType,
         p.kind = $kind,
         p.subkind = $subkind,
@@ -877,6 +904,8 @@ export class Neo4jAdapter implements IGraphDatabase {
 
     await this.connection.executeQuery(query, {
       uri: proposal.uri,
+      // The record key is how every UI link and route addresses a proposal.
+      id: proposal.uri.split('/').pop() ?? '',
       proposalType: proposal.proposalType,
       kind: proposal.kind,
       subkind: proposal.subkind ?? null,

--- a/src/storage/neo4j/adapter.ts
+++ b/src/storage/neo4j/adapter.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../types/interfaces/graph.interface.js';
 
 import { Neo4jConnection } from './connection.js';
+import { subkindToLabel } from './labels.js';
 import type {
   GraphNode,
   GraphEdge,
@@ -43,16 +44,6 @@ import type {
   UserRole,
   VoteType,
 } from './types.js';
-
-/**
- * Map subkind slugs to Neo4j labels (PascalCase).
- */
-function subkindToLabel(subkind: string): string {
-  return subkind
-    .split('-')
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join('');
-}
 
 /**
  * Neo4j adapter implementing the IGraphDatabase interface.

--- a/src/storage/neo4j/labels.ts
+++ b/src/storage/neo4j/labels.ts
@@ -1,0 +1,79 @@
+/**
+ * Safe construction of Neo4j label identifiers.
+ *
+ * @remarks
+ * Neo4j has no parameter binding for labels, so a label used in a `MATCH` must
+ * be interpolated into the query string. Anything interpolated into Cypher is a
+ * potential injection point, and node subkinds arrive from unauthenticated
+ * callers via `pub.chive.graph.listNodes` and `pub.chive.graph.getHierarchy`.
+ *
+ * This module is the single place that turns a subkind slug into a label, so
+ * the validation cannot be bypassed by a caller that builds the label itself.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import { ValidationError } from '../../types/errors.js';
+
+/**
+ * A valid Neo4j label: a letter followed by letters, digits, or underscores.
+ *
+ * @remarks
+ * Deliberately narrower than Neo4j's own rules, which permit almost anything
+ * inside backticks. Chive's subkinds are hyphenated slugs, so the PascalCase
+ * form of a legitimate subkind always fits this shape.
+ */
+const SAFE_LABEL = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+/**
+ * Converts a subkind slug to its Neo4j label, rejecting anything unsafe.
+ *
+ * @param subkind - Subkind slug, e.g. `field` or `research-method`
+ * @returns The PascalCase label, e.g. `Field` or `ResearchMethod`
+ *
+ * @throws {ValidationError} If the resulting label is not a plain identifier
+ *
+ * @remarks
+ * The previous implementations — duplicated in `adapter.ts` and
+ * `node-repository.ts` — only capitalised and joined the hyphen-separated
+ * parts. Parentheses, whitespace, and comment markers passed straight through
+ * into the query, so a crafted `subkind` could close the `MATCH` pattern and
+ * append arbitrary Cypher.
+ *
+ * @example
+ * ```typescript
+ * subkindToLabel('research-method'); // 'ResearchMethod'
+ * subkindToLabel('a) DETACH DELETE n //'); // throws ValidationError
+ * ```
+ *
+ * @public
+ */
+export function subkindToLabel(subkind: string): string {
+  const label = subkind
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+
+  if (!SAFE_LABEL.test(label)) {
+    throw new ValidationError(
+      `Invalid subkind '${subkind}': must contain only letters, digits, hyphens and underscores`,
+      'subkind',
+      'format'
+    );
+  }
+
+  return label;
+}
+
+/**
+ * Converts a node kind to its Neo4j label.
+ *
+ * @param kind - Either `type` or `object`
+ * @returns `Type` or `Object`
+ *
+ * @public
+ */
+export function kindToLabel(kind: 'type' | 'object'): string {
+  return kind === 'type' ? 'Type' : 'Object';
+}

--- a/src/storage/neo4j/node-repository.ts
+++ b/src/storage/neo4j/node-repository.ts
@@ -16,6 +16,7 @@ import type { AtUri, DID } from '../../types/atproto.js';
 import { DatabaseError, NotFoundError, ValidationError } from '../../types/errors.js';
 
 import { Neo4jConnection } from './connection.js';
+import { subkindToLabel } from './labels.js';
 import type {
   GraphNode,
   NodeKind,
@@ -27,17 +28,6 @@ import type {
   ExternalId,
   NodeMetadata,
 } from './types.js';
-
-/**
- * Subkind label mapping - converts slug to Neo4j label
- */
-function subkindToLabel(slug: string): string {
-  // Convert kebab-case to PascalCase
-  return slug
-    .split('-')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('');
-}
 
 /**
  * Neo4j repository for unified graph node operations.

--- a/src/types/interfaces/graph.interface.ts
+++ b/src/types/interfaces/graph.interface.ts
@@ -240,6 +240,20 @@ export interface IGraphDatabase {
   getProposal(uri: AtUri): Promise<NodeProposal | null>;
 
   /**
+   * Gets a proposal by its record key.
+   *
+   * @param rkey - Record key, the last segment of the proposal's AT-URI
+   * @returns The proposal, or null if no proposal has that record key
+   *
+   * @remarks
+   * Every proposal link in the UI carries the record key rather than the full
+   * AT-URI, because an AT-URI cannot sit in a single dynamic route segment.
+   * Without this lookup those links resolve against `getProposal`, which
+   * matches on the full URI and therefore never matches.
+   */
+  getProposalByRkey(rkey: string): Promise<NodeProposal | null>;
+
+  /**
    * Creates a vote on a proposal.
    */
   createVote(vote: Vote): Promise<void>;

--- a/tests/integration/services/pds-discovery/pds-discovery.integration.test.ts
+++ b/tests/integration/services/pds-discovery/pds-discovery.integration.test.ts
@@ -272,13 +272,46 @@ describe('PDS Discovery Integration', () => {
         `);
       });
 
-      it('only returns non-relay-connected PDSes', async () => {
+      it('includes relay-connected PDSes, ranked after direct ones', async () => {
         const result = await registry.getPDSesForScan(10);
 
         const urls = result.map((r) => r.pdsUrl);
         expect(urls).toContain('https://test-scannable-1.example.com');
         expect(urls).toContain('https://test-scannable-2.example.com');
-        expect(urls).not.toContain('https://test-relay-skip.bsky.network');
+
+        // Relay-connected PDSes must be reachable by a scan. Their records
+        // normally arrive over the firehose, but a relay outage longer than the
+        // relay's backfill window skips a range of events permanently, and this
+        // scan is the only mechanism that can find what was missed. They are
+        // ranked last rather than excluded.
+        expect(urls).toContain('https://test-relay-skip.bsky.network');
+        expect(urls.indexOf('https://test-relay-skip.bsky.network')).toBeGreaterThan(
+          urls.indexOf('https://test-scannable-1.example.com')
+        );
+      });
+
+      it('reclaims a PDS wedged in scanning by a crashed scan', async () => {
+        // Nothing clears 'scanning', so before this a process that died
+        // mid-scan excluded that PDS from every subsequent cycle.
+        await pool.query(`
+          INSERT INTO pds_registry (pds_url, discovery_source, status, is_relay_connected, consecutive_failures, updated_at)
+          VALUES ('https://test-wedged.example.com', 'user_registration', 'scanning', FALSE, 0, NOW() - INTERVAL '2 hours')
+        `);
+
+        const result = await registry.getPDSesForScan(10);
+
+        expect(result.map((r) => r.pdsUrl)).toContain('https://test-wedged.example.com');
+      });
+
+      it('leaves a scan that started recently alone', async () => {
+        await pool.query(`
+          INSERT INTO pds_registry (pds_url, discovery_source, status, is_relay_connected, consecutive_failures, updated_at)
+          VALUES ('https://test-in-flight.example.com', 'user_registration', 'scanning', FALSE, 0, NOW())
+        `);
+
+        const result = await registry.getPDSesForScan(10);
+
+        expect(result.map((r) => r.pdsUrl)).not.toContain('https://test-in-flight.example.com');
       });
 
       it('excludes PDSes with too many failures', async () => {

--- a/tests/unit/api/handlers/xrpc/governance.test.ts
+++ b/tests/unit/api/handlers/xrpc/governance.test.ts
@@ -275,6 +275,11 @@ describe('XRPC Governance Handlers', () => {
         },
       ];
 
+      // listVotes resolves the proposal first so it can use the real URI.
+      mockGraphAdapter.getProposalById.mockResolvedValue({
+        ...createMockProposal(),
+        uri: `at://did:plc:chive/pub.chive.graph.proposal/${PROPOSAL_UUIDS.abc123}`,
+      });
       mockGraphAdapter.getVotesForProposal.mockResolvedValue(votes);
 
       const result = await listVotes.handler({
@@ -302,6 +307,11 @@ describe('XRPC Governance Handlers', () => {
         },
       ];
 
+      // listVotes resolves the proposal first so it can use the real URI.
+      mockGraphAdapter.getProposalById.mockResolvedValue({
+        ...createMockProposal(),
+        uri: `at://did:plc:chive/pub.chive.graph.proposal/${PROPOSAL_UUIDS.abc123}`,
+      });
       mockGraphAdapter.getVotesForProposal.mockResolvedValue(votes);
 
       const result = await listVotes.handler({
@@ -315,6 +325,11 @@ describe('XRPC Governance Handlers', () => {
     });
 
     it('returns empty array when no votes exist', async () => {
+      // listVotes resolves the proposal first so it can use the real URI.
+      mockGraphAdapter.getProposalById.mockResolvedValue({
+        ...createMockProposal(),
+        uri: `at://did:plc:chive/pub.chive.graph.proposal/${PROPOSAL_UUIDS.abc123}`,
+      });
       mockGraphAdapter.getVotesForProposal.mockResolvedValue([]);
 
       const result = await listVotes.handler({

--- a/tests/unit/jobs/field-label-resolution-job.test.ts
+++ b/tests/unit/jobs/field-label-resolution-job.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for FieldLabelResolutionJob.
+ *
+ * @remarks
+ * The regression these guard against: a deploy recreates Neo4j and repopulates
+ * it asynchronously, so a reindex can resolve every field label against an
+ * empty graph and persist raw UUIDs. Repairing PostgreSQL alone leaves browse
+ * and search — which read from Elasticsearch — showing UUIDs indefinitely, so
+ * the job must mirror each repair into the search index.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { FieldLabelResolutionJob } from '@/jobs/field-label-resolution-job.js';
+import type { FieldLabelIndexWriter } from '@/jobs/field-label-resolution-job.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+vi.mock('@/observability/tracer.js', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+  addSpanAttributes: vi.fn(),
+}));
+
+vi.mock('@/observability/prometheus-registry.js', () => ({
+  jobMetrics: {
+    duration: { startTimer: () => () => undefined },
+    executionsTotal: { inc: vi.fn() },
+    lastRunTimestamp: { set: vi.fn() },
+    itemsProcessed: { inc: vi.fn() },
+  },
+}));
+
+const createMockLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+const UUID = '9cfe6371-0a2c-5aee-8302-f7b170b0d2d8';
+const URI = 'at://did:plc:abc/pub.chive.eprint.submission/xyz';
+
+/** One eprint whose single field label is still a raw UUID. */
+function createMockPool(
+  fields: unknown = [{ id: UUID, uri: `at://did:plc:g/n/${UUID}`, label: UUID }]
+): { query: ReturnType<typeof vi.fn> } {
+  return {
+    query: vi.fn().mockImplementation((sql: string) => {
+      if (sql.trim().startsWith('SELECT')) {
+        return Promise.resolve({ rows: [{ uri: URI, fields: JSON.stringify(fields) }] });
+      }
+      return Promise.resolve({ rows: [] });
+    }),
+  };
+}
+
+const resolvingLookup = {
+  getNodesByIds: vi.fn().mockResolvedValue(new Map([[UUID, { label: 'Formal Semantics' }]])),
+};
+
+describe('FieldLabelResolutionJob', () => {
+  let logger: ILogger;
+  let indexWriter: FieldLabelIndexWriter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = createMockLogger();
+    indexWriter = { updateFieldLabels: vi.fn().mockResolvedValue(undefined) };
+    resolvingLookup.getNodesByIds.mockResolvedValue(
+      new Map([[UUID, { label: 'Formal Semantics' }]])
+    );
+  });
+
+  it('should mirror a repaired label into the search index', async () => {
+    const pool = createMockPool();
+    const job = new FieldLabelResolutionJob({
+      pool: pool as never,
+      nodeLookup: resolvingLookup,
+      indexWriter,
+      logger,
+      runOnStartup: false,
+    });
+
+    const result = await job.run();
+
+    expect(result.resolved).toBe(1);
+    expect(result.indexUpdated).toBe(1);
+    expect(indexWriter.updateFieldLabels).toHaveBeenCalledWith(
+      URI,
+      expect.arrayContaining([expect.objectContaining({ id: UUID, label: 'Formal Semantics' })])
+    );
+  });
+
+  it('should still repair PostgreSQL when the search index write fails', async () => {
+    const pool = createMockPool();
+    indexWriter.updateFieldLabels = vi.fn().mockRejectedValue(new Error('ES unavailable'));
+
+    const job = new FieldLabelResolutionJob({
+      pool: pool as never,
+      nodeLookup: resolvingLookup,
+      indexWriter,
+      logger,
+      runOnStartup: false,
+    });
+
+    const result = await job.run();
+
+    expect(result.success).toBe(true);
+    expect(result.resolved).toBe(1);
+    expect(result.indexUpdated).toBe(0);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('should warn when no search index writer is configured', async () => {
+    const pool = createMockPool();
+    const job = new FieldLabelResolutionJob({
+      pool: pool as never,
+      nodeLookup: resolvingLookup,
+      logger,
+      runOnStartup: false,
+    });
+
+    const result = await job.run();
+
+    expect(result.resolved).toBe(1);
+    expect(result.indexUpdated).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('search index'));
+  });
+
+  it('should not touch either store when the graph cannot resolve the label', async () => {
+    const pool = createMockPool();
+    resolvingLookup.getNodesByIds.mockResolvedValue(new Map());
+
+    const job = new FieldLabelResolutionJob({
+      pool: pool as never,
+      nodeLookup: resolvingLookup,
+      indexWriter,
+      logger,
+      runOnStartup: false,
+    });
+
+    const result = await job.run();
+
+    expect(result.resolved).toBe(0);
+    expect(indexWriter.updateFieldLabels).not.toHaveBeenCalled();
+    const updates = pool.query.mock.calls.filter((c) => String(c[0]).includes('UPDATE'));
+    expect(updates).toHaveLength(0);
+  });
+
+  it('should skip eprints whose labels are already resolved', async () => {
+    const pool = createMockPool([
+      { id: UUID, uri: `at://did:plc:g/n/${UUID}`, label: 'Formal Semantics' },
+    ]);
+
+    const job = new FieldLabelResolutionJob({
+      pool: pool as never,
+      nodeLookup: resolvingLookup,
+      indexWriter,
+      logger,
+      runOnStartup: false,
+    });
+
+    const result = await job.run();
+
+    expect(result.resolved).toBe(0);
+    expect(indexWriter.updateFieldLabels).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/knowledge-graph/proposal-lookup.test.ts
+++ b/tests/unit/services/knowledge-graph/proposal-lookup.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for proposal identifier resolution.
+ *
+ * @remarks
+ * Regression cover for issue #89. Proposal routes and every list link carry the
+ * record key, because an AT-URI cannot occupy a single dynamic route segment,
+ * while `getProposalById` cast whatever it was given to an `AtUri` and matched
+ * on `uri`. A record key never equals a full AT-URI, so no proposal detail page
+ * could load and `getUserVote` — which resolves the proposal first — failed the
+ * same way. The reporter's proposal record was created successfully; only the
+ * read path was broken.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { KnowledgeGraphService } from '@/services/knowledge-graph/graph-service.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+const RKEY = '3mlbhk6h2ne2k';
+const URI = `at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.graph.nodeProposal/${RKEY}`;
+
+const proposal = {
+  id: RKEY,
+  uri: URI,
+  proposalType: 'create' as const,
+  kind: 'type' as const,
+  subkind: 'field',
+  rationale: 'because',
+  status: 'pending' as const,
+  proposerDid: 'did:plc:izttpdp3l6vss5crelt5kcux',
+  createdAt: new Date('2026-05-07T14:48:40.171Z'),
+};
+
+const createLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+describe('KnowledgeGraphService.getProposalById', () => {
+  let graph: { getProposal: ReturnType<typeof vi.fn>; getProposalByRkey: ReturnType<typeof vi.fn> };
+  let service: KnowledgeGraphService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    graph = {
+      getProposal: vi.fn().mockResolvedValue(null),
+      getProposalByRkey: vi.fn().mockResolvedValue(null),
+    };
+    service = new KnowledgeGraphService({
+      graph: graph as never,
+      logger: createLogger(),
+    } as never);
+  });
+
+  it('should resolve a record key through the record-key lookup', async () => {
+    graph.getProposalByRkey.mockResolvedValue(proposal);
+
+    const result = await service.getProposalById(RKEY);
+
+    expect(result).not.toBeNull();
+    expect(graph.getProposalByRkey).toHaveBeenCalledWith(RKEY);
+    // Casting a record key to an AtUri and matching on `uri` is what broke.
+    expect(graph.getProposal).not.toHaveBeenCalled();
+  });
+
+  it('should still resolve a full AT-URI through the URI lookup', async () => {
+    graph.getProposal.mockResolvedValue(proposal);
+
+    const result = await service.getProposalById(URI);
+
+    expect(result).not.toBeNull();
+    expect(graph.getProposal).toHaveBeenCalledWith(URI);
+    expect(graph.getProposalByRkey).not.toHaveBeenCalled();
+  });
+
+  it('should return null when neither lookup finds the proposal', async () => {
+    expect(await service.getProposalById(RKEY)).toBeNull();
+  });
+
+  it('should not treat a user-typed slug as an AT-URI', async () => {
+    // The form used to route by the slug the user typed into the ID field.
+    await service.getProposalById('quantum-machine-learning');
+
+    expect(graph.getProposalByRkey).toHaveBeenCalledWith('quantum-machine-learning');
+    expect(graph.getProposal).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/pds-discovery/pds-registry.test.ts
+++ b/tests/unit/services/pds-discovery/pds-registry.test.ts
@@ -163,7 +163,7 @@ describe('PDSRegistry', () => {
   });
 
   describe('getPDSesForScan', () => {
-    it('only returns non-relay-connected PDSes', async () => {
+    it('returns relay-connected PDSes too, ranked after direct ones', async () => {
       const mockRows = [
         {
           pds_url: 'https://custom-pds.example.com',
@@ -194,11 +194,25 @@ describe('PDSRegistry', () => {
         expect(firstResult.isRelayConnected).toBe(false);
       }
 
-      // Verify query includes relay filter
-      expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining('is_relay_connected = FALSE'),
-        [10]
-      );
+      // Relay-connected PDSes must not be filtered out: a relay outage longer
+      // than the relay's backfill window silently skips events, and this scan
+      // is the only mechanism that can find the records that were missed.
+      // They are ranked last instead.
+      const [sql] = mockPool.query.mock.calls[0] as [string, unknown];
+      expect(sql).not.toContain('is_relay_connected = FALSE');
+      expect(sql).toContain('ORDER BY is_relay_connected ASC');
+    });
+
+    it('recovers PDSes wedged in scanning by a crashed scan', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await registry.getPDSesForScan(10);
+
+      // Nothing else clears 'scanning', so without this a process that died
+      // mid-scan excludes that PDS from every future cycle.
+      const [sql] = mockPool.query.mock.calls[0] as [string, unknown];
+      expect(sql).toContain("status = 'scanning'");
+      expect(sql).toContain('updated_at <');
     });
 
     it('excludes PDSes with too many consecutive failures', async () => {

--- a/tests/unit/storage/neo4j/labels.test.ts
+++ b/tests/unit/storage/neo4j/labels.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for Neo4j label construction.
+ *
+ * @remarks
+ * Neo4j cannot bind a label as a query parameter, so labels are interpolated
+ * into Cypher. Node subkinds reach that interpolation from unauthenticated
+ * callers via `pub.chive.graph.listNodes` and `pub.chive.graph.getHierarchy`,
+ * which made this the injection point these tests close.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { kindToLabel, subkindToLabel } from '@/storage/neo4j/labels.js';
+import { ValidationError } from '@/types/errors.js';
+
+describe('subkindToLabel', () => {
+  it('should convert a slug to a PascalCase label', () => {
+    expect(subkindToLabel('field')).toBe('Field');
+    expect(subkindToLabel('research-method')).toBe('ResearchMethod');
+    expect(subkindToLabel('institution')).toBe('Institution');
+  });
+
+  it('should preserve digits and underscores', () => {
+    expect(subkindToLabel('facet2')).toBe('Facet2');
+    expect(subkindToLabel('legacy_field')).toBe('Legacy_field');
+  });
+
+  // Each of these previously passed straight through into the query string,
+  // letting a caller close the MATCH pattern and append their own Cypher.
+  it.each([
+    ['pattern break + delete', 'a) DETACH DELETE n //'],
+    ['clause injection', 'Field) RETURN n UNION MATCH (m) RETURN m //'],
+    ['whitespace', 'Field OR true'],
+    ['backtick escape', 'Field`) MATCH (x) DETACH DELETE x //'],
+    ['comment marker', 'Field//'],
+    ['braces', 'Field {uri: 1}'],
+    ['empty', ''],
+    ['leading digit', '1field'],
+  ])('should reject %s', (_name, malicious) => {
+    expect(() => subkindToLabel(malicious)).toThrow(ValidationError);
+  });
+
+  it('should not leak the rejected value into a usable label', () => {
+    // A thrown error is the only acceptable outcome; returning a sanitised
+    // fragment would still interpolate attacker-influenced text.
+    let label: string | undefined;
+    try {
+      label = subkindToLabel('a) DETACH DELETE n //');
+    } catch {
+      label = undefined;
+    }
+    expect(label).toBeUndefined();
+  });
+});
+
+describe('kindToLabel', () => {
+  it('should map kinds to their labels', () => {
+    expect(kindToLabel('type')).toBe('Type');
+    expect(kindToLabel('object')).toBe('Object');
+  });
+});

--- a/web/components/governance/proposal-form.tsx
+++ b/web/components/governance/proposal-form.tsx
@@ -23,7 +23,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Send, Loader2, Info, Plus, Edit, Trash2, Network, Tags, X } from 'lucide-react';
 
 import { logger } from '@/lib/observability';
-import { api } from '@/lib/api/client';
+import { api, authApi } from '@/lib/api/client';
 import { Button } from '@/components/ui/button';
 
 const proposalLogger = logger.child({ component: 'proposal-form' });
@@ -449,6 +449,33 @@ function NodeUriInput({
 // =============================================================================
 
 /**
+ * Extracts the record key from an AT-URI.
+ *
+ * @remarks
+ * Proposal routes are a single dynamic segment, so they cannot carry a full
+ * AT-URI. The record key is the identifier every proposal link uses.
+ */
+function rkeyOf(uri: string): string {
+  return uri.split('/').pop() ?? '';
+}
+
+/**
+ * Asks the AppView to index a freshly created proposal.
+ *
+ * @remarks
+ * Mirrors what endorsements, tags and annotations already do after a write.
+ * Indexing failure is not fatal: the firehose still delivers the record, so
+ * this only removes the delay before the proposal becomes readable.
+ */
+async function indexProposalRecord(uri: string): Promise<void> {
+  try {
+    await authApi.pub.chive.sync.indexRecord({ uri });
+  } catch {
+    // Non-fatal; the firehose remains the source of truth.
+  }
+}
+
+/**
  * Unified governance proposal form.
  */
 export function ProposalForm({
@@ -629,10 +656,19 @@ export function ProposalForm({
             },
           });
 
+          // Index the new record immediately. Every other user write does this;
+          // proposals did not, so the record only appeared after the firehose
+          // delivered it and the page redirected to a proposal that was not yet
+          // indexed.
+          await indexProposalRecord(result.data.uri);
+
           // Create a mock Proposal object for onSuccess
           const proposal = {
             uri: result.data.uri,
-            id: values.id,
+            // The record key, which is how proposal routes and list links
+            // address a proposal. Using the user-typed slug here sent the
+            // redirect to a URL the detail endpoint could never resolve.
+            id: rkeyOf(result.data.uri),
             type: values.proposalType,
             status: 'pending' as const,
             label: values.label,
@@ -674,10 +710,12 @@ export function ProposalForm({
             },
           });
 
+          await indexProposalRecord(result.data.uri);
+
           // Create a mock Proposal object for onSuccess
           const proposal = {
             uri: result.data.uri,
-            id: `${values.sourceUri}-${values.relationSlug}-${values.targetUri}`,
+            id: rkeyOf(result.data.uri),
             type: 'create' as const,
             status: 'pending' as const,
             label: `${values.sourceLabel ?? 'Source'} → ${values.relationSlug} → ${values.targetLabel ?? 'Target'}`,

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Promotes release **0.7.1** to production: four merged fix PRs plus the release commit. Every item was found by a multi-agent audit of the governance system, verified by hand against the code, and — where it was a live production defect — reproduced before being fixed.

### What's included

- **#97 — unauthenticated Cypher injection.** `subkindToLabel` capitalised and joined the hyphen-separated parts with no validation, so parentheses, whitespace and comment markers passed into `MATCH (n:Node:<label>)`. `subkind` is caller-supplied on `pub.chive.graph.listNodes` and `pub.chive.graph.getHierarchy`, neither of which requires auth. The helper was duplicated unguarded across two files feeding nine interpolation sites; both now route through a single validated `src/storage/neo4j/labels.ts`.
- **#98 — no proposal page could load (closes #89).** `getProposalById` cast its argument to an `AtUri` and matched on `uri`, while every route and list link carries the record key. Also fixes `listVotes`, which synthesised a URI with a non-DID authority and a nonexistent collection and therefore always returned zero votes, and force-indexes new proposals so the redirect cannot beat the firehose.
- **#95 — the governance sync wiped the knowledge graph and then failed.** An undefined `GRAPH_PDS_DID` repository variable interpolated to an empty string and overrode the correct built-in default, failing every request with `Params must have the property "repo"` — *after* the graph had been cleared. It now fetches before clearing and refuses to clear on an empty fetch.
- **#96 — the PDS scanner had never scanned anything.** `getPDSesForScan` required `is_relay_connected = FALSE`; all 29 registered PDSes are relay-connected, so the scheduler ran every 15 minutes and selected zero rows. Also reclaims servers wedged in `scanning` by a crashed scan (two had been stuck since 2026-03-01).
- **Field labels** (already on staging): the reindex preserves labels it cannot resolve instead of overwriting them with UUIDs, and the resolution job mirrors repairs into Elasticsearch, which is what browse and search actually read.
- **Version reporting** (already on staging): services read their real version, so `/health` no longer reports `0.0.0` in every deployed environment.

### Why this matters for prod

The UUID-instead-of-field-name bug users have seen after every redeploy is the compound effect of three of these: the governance sync wiped Neo4j, the eprint reindex then resolved every label against an empty graph and silently wrote UUIDs, and the repair job only ever fixed PostgreSQL while the UI reads Elasticsearch.

## Related Issues

Closes #89. Bundles #95, #96, #97, #98.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- Staging deployed and verified on 0.7.1: 22 checks green, including six direct datastore checks that bypass `/ready` (whose per-check error swallowing can report `pass` during an outage), plus two new regression guards — knowledge graph populated, and zero UUID field labels in the search index.
- The field-label fix is proven end-to-end: a full staging deploy ran the reindex and produced real labels ("Computational Linguistics", "Formal Semantics") with zero UUIDs, on the exact path that used to corrupt them.
- Full unit suite green (4035 passed, 2 skipped); full CI green on the release commit and on each PR individually.
- Note: the governance sync step exists only in `deploy-app.yml`, so #95 gets its first live exercise on this deploy. Its failure mode is safe by construction — it refuses to clear rather than wiping — and the default DID was verified to return records from inside the production container.

## Checklist

### General
- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (TSDoc on new and changed APIs)

### ATProto Compliance (required for data flow changes)
- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose (force-indexing reuses the firehose service methods and is idempotent)
- [x] PDS source is tracked for staleness detection

### Breaking Changes
- [x] N/A — no breaking changes, no data migration
