### PR TITLE
Stop dropping governance records and rendering datastore failures as empty results (wave 1)

### DIFF
--- a/scripts/seed-admin.ts
+++ b/scripts/seed-admin.ts
@@ -12,24 +12,16 @@
  */
 
 import { createClient, type RedisClientType } from 'redis';
+import { getAdminDids } from '../src/config/admin.js';
 
-const DEFAULT_ADMIN_DIDS = 'did:plc:34mbm5v3umztwvvgnttvcz6e';
 const ROLE_PREFIX = 'chive:authz:roles:';
 const ASSIGNMENT_PREFIX = 'chive:authz:assignments:';
 
 async function main(): Promise<void> {
   const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  const adminDidsRaw = process.env.ADMIN_DIDS ?? DEFAULT_ADMIN_DIDS;
-
-  const adminDids = adminDidsRaw
-    .split(',')
-    .map((d) => d.trim())
-    .filter(Boolean);
-
-  if (adminDids.length === 0) {
-    console.log('No admin DIDs to seed.');
-    return;
-  }
+  // Resolved through the shared helper so the seeded platform admins and the
+  // governance role service can never disagree about who the admins are.
+  const adminDids = getAdminDids();
 
   console.log(`Connecting to Redis at ${redisUrl}...`);
   const redis: RedisClientType = createClient({ url: redisUrl });

--- a/src/api/handlers/xrpc/admin/assignRole.ts
+++ b/src/api/handlers/xrpc/admin/assignRole.ts
@@ -2,8 +2,9 @@
  * XRPC handler for pub.chive.admin.assignRole.
  *
  * @remarks
- * Assigns a role to a user via the authorization service.
- * Requires admin authentication.
+ * Assigns a platform role to a user via the authorization service.
+ * Requires admin authentication. Governance roles are rejected here; they are
+ * granted through the pub.chive.governance.* endpoints.
  *
  * @packageDocumentation
  * @public
@@ -24,14 +25,40 @@ interface AssignRoleOutput {
   readonly role: string;
 }
 
+/**
+ * Roles this endpoint can grant.
+ *
+ * @remarks
+ * These are the platform roles held in Redis and read back by the
+ * authentication middleware. Governance roles are deliberately absent: they
+ * live in the `governance_roles` table and are granted through the governance
+ * endpoints, so writing one here would report success while changing nothing
+ * the governance code reads.
+ */
 const VALID_ROLES: readonly string[] = [
   'admin',
   'moderator',
-  'graph-editor',
   'author',
   'reader',
   'alpha-tester',
   'premium',
+];
+
+/**
+ * Roles that only the governance endpoints can grant.
+ *
+ * @remarks
+ * Listed separately from the generic invalid-role case so the caller is told
+ * which endpoint actually grants the role rather than that it does not exist.
+ * `graph-editor` overlaps the platform role vocabulary, which is what made the
+ * silent no-op easy to hit.
+ */
+const GOVERNANCE_ROLES: readonly string[] = [
+  'community-member',
+  'trusted-editor',
+  'graph-editor',
+  'domain-expert',
+  'administrator',
 ];
 
 export const assignRole: XRPCMethod<void, AssignRoleInput, AssignRoleOutput> = {
@@ -45,6 +72,14 @@ export const assignRole: XRPCMethod<void, AssignRoleInput, AssignRoleOutput> = {
 
     if (!input?.did || !input.role) {
       throw new ValidationError('DID and role are required', 'input', 'required');
+    }
+
+    if (GOVERNANCE_ROLES.includes(input.role)) {
+      throw new ValidationError(
+        `Role ${input.role} is a governance role and cannot be assigned here; grant it with pub.chive.governance.approveElevation`,
+        'role',
+        'governance-role'
+      );
     }
 
     if (!VALID_ROLES.includes(input.role)) {

--- a/src/config/admin.ts
+++ b/src/config/admin.ts
@@ -1,0 +1,61 @@
+/**
+ * Platform administrator identity configuration.
+ *
+ * @remarks
+ * Single source of truth for who the platform administrators are. The list was
+ * previously parsed in three places with two different behaviours: the seeding
+ * paths in `src/index.ts` and `scripts/seed-admin.ts` each fell back to a
+ * hardcoded DID when `ADMIN_DIDS` was unset, while the governance role service
+ * parsed the same variable with no fallback.
+ *
+ * On a deployment that never sets `ADMIN_DIDS` — which is the documented normal
+ * case, and is how the production compose file is configured — those paths
+ * diverged: a platform admin was seeded, but the governance layer saw an empty
+ * list and recognised no administrator. Every privileged governance endpoint
+ * was therefore unreachable, with nothing able to create the first
+ * administrator.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type { DID } from '../types/atproto.js';
+
+/**
+ * Administrator used when `ADMIN_DIDS` is unset.
+ *
+ * @remarks
+ * Preserves the behaviour the seeding scripts already relied on. Kept here so
+ * the governance layer and the seeding paths cannot disagree about it again.
+ *
+ * @public
+ */
+export const DEFAULT_ADMIN_DID = 'did:plc:34mbm5v3umztwvvgnttvcz6e' as DID;
+
+/**
+ * Resolves the configured platform administrator DIDs.
+ *
+ * @param raw - Raw `ADMIN_DIDS` value; defaults to the environment variable
+ * @returns The administrator DIDs, falling back to {@link DEFAULT_ADMIN_DID}
+ *
+ * @remarks
+ * A blank or whitespace-only value counts as unset: an environment variable
+ * interpolated from an undefined deploy variable yields an empty string, and
+ * treating that as "no administrators" is what silently disabled governance.
+ *
+ * @example
+ * ```typescript
+ * getAdminDids('did:plc:abc, did:plc:def'); // ['did:plc:abc', 'did:plc:def']
+ * getAdminDids(undefined);                  // [DEFAULT_ADMIN_DID]
+ * ```
+ *
+ * @public
+ */
+export function getAdminDids(raw: string | undefined = process.env.ADMIN_DIDS): DID[] {
+  const configured = (raw ?? '')
+    .split(',')
+    .map((did) => did.trim())
+    .filter(Boolean) as DID[];
+
+  return configured.length > 0 ? configured : [DEFAULT_ADMIN_DID];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { createServer, type ServerConfig } from './api/server.js';
 import { ATRepository } from './atproto/repository/at-repository.js';
 import { AuthorizationService } from './auth/authorization/authorization-service.js';
 import { DIDResolver } from './auth/did/did-resolver.js';
+import { getAdminDids } from './config/admin.js';
 import { getGrobidConfig } from './config/grobid.js';
 import { CitationExtractionJob } from './jobs/citation-extraction-job.js';
 import { CollaborativeFilteringSyncJob } from './jobs/collaborative-filtering-sync.js';
@@ -1022,13 +1023,7 @@ async function seedAdminRoles(
   authzService: InstanceType<typeof AuthorizationService>,
   logger: PinoLogger
 ): Promise<void> {
-  const defaultAdminDids = 'did:plc:34mbm5v3umztwvvgnttvcz6e';
-  const adminDidsRaw = process.env.ADMIN_DIDS ?? defaultAdminDids;
-
-  const adminDids = adminDidsRaw
-    .split(',')
-    .map((d) => d.trim())
-    .filter(Boolean);
+  const adminDids = getAdminDids();
 
   if (adminDids.length === 0) {
     logger.info('No admin DIDs to seed');
@@ -1038,7 +1033,7 @@ async function seedAdminRoles(
   logger.info('Seeding admin roles...', { count: adminDids.length });
 
   for (const did of adminDids) {
-    await authzService.assignRole(did as DID, 'admin', 'system-startup' as DID);
+    await authzService.assignRole(did, 'admin', 'system-startup' as DID);
     logger.info('Admin role assigned', { did });
   }
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -54,6 +54,7 @@ import { AutomaticProposalService } from './services/governance/automatic-propos
 import { GovernancePDSWriter } from './services/governance/governance-pds-writer.js';
 import { NodeService } from './services/governance/node-service.js';
 import { PersonalGraphService } from './services/graph/personal-graph-service.js';
+import { DeadLetterQueue } from './services/indexing/dlq-handler.js';
 import { createEventProcessor } from './services/indexing/event-processor.js';
 import {
   type FirehoseHealthServer,
@@ -542,9 +543,18 @@ async function main(): Promise<void> {
       logger.error('Failed to load Margin plugins', err instanceof Error ? err : undefined);
     }
 
+    // The cursor advances as soon as an event is queued, well before the
+    // processor runs, so a handler failure without a DLQ loses the record
+    // permanently — there is no sequence number left to rewind to. The DLQ is
+    // backed entirely by the `firehose_dlq` table, so this instance and the one
+    // IndexingService builds for queue-level failures are the same queue; only
+    // the alert thresholds are per-instance, and neither configures alerts.
+    const dlq = new DeadLetterQueue({ db: pgPool });
+
     // Create event processor with PDS auto-discovery
     const processor = createEventProcessor({
       pool: pgPool,
+      dlq, // Capture handler failures for replay; the cursor has already moved on
       activity: activityService,
       eprintService,
       reviewService,

--- a/src/jobs/governance-sync-job.ts
+++ b/src/jobs/governance-sync-job.ts
@@ -55,6 +55,37 @@ export interface GovernanceSyncJobConfig {
 }
 
 /**
+ * Outcome of a single sync cycle.
+ *
+ * @remarks
+ * A cycle that indexed every record it read is `success`; a cycle in which at
+ * least one record failed to index is `partial`. Callers that track the sync as
+ * an operation — e.g. the admin trigger endpoint — should treat `partial` as a
+ * failure, since a partial cycle silently leaves the Neo4j index behind the
+ * Governance PDS.
+ *
+ * @public
+ */
+export interface GovernanceSyncResult {
+  /** Nodes successfully indexed into Neo4j. */
+  nodesIndexed: number;
+  /** Edges successfully indexed into Neo4j. */
+  edgesIndexed: number;
+  /** Records that were read but could not be indexed. */
+  failedCount: number;
+  /** Whether every record read was indexed. */
+  status: 'success' | 'partial';
+}
+
+/**
+ * Per-collection sync tallies.
+ */
+interface SyncCounts {
+  indexed: number;
+  failed: number;
+}
+
+/**
  * Node record value from ATProto listRecords.
  */
 interface NodeRecordValue {
@@ -176,11 +207,19 @@ export class GovernanceSyncJob {
 
   /**
    * Runs a single sync cycle.
+   *
+   * @returns The cycle outcome, `partial` when some records failed to index.
+   *
+   * @remarks
+   * Per-record indexing failures do not abort the cycle — one poisoned record
+   * should not block the rest of the graph — but they are counted and surfaced
+   * so a caller cannot mistake a lossy cycle for a complete one.
    */
-  async run(): Promise<void> {
+  async run(): Promise<GovernanceSyncResult> {
     if (this.isRunning) {
       this.config.logger.debug('Sync already in progress, skipping');
-      return;
+      // Nothing was read, so nothing was dropped: not a partial cycle.
+      return { nodesIndexed: 0, edgesIndexed: 0, failedCount: 0, status: 'success' };
     }
 
     this.isRunning = true;
@@ -188,26 +227,46 @@ export class GovernanceSyncJob {
     const endTimer = jobMetrics.duration.startTimer({ job: 'governance_sync' });
 
     try {
-      await withSpan('job.governance_sync', async () => {
+      return await withSpan('job.governance_sync', async () => {
         this.config.logger.debug('Starting governance sync');
 
-        const nodeCount = await this.syncNodes();
-        const edgeCount = await this.syncEdges();
+        const nodes = await this.syncNodes();
+        const edges = await this.syncEdges();
+
+        const nodeCount = nodes.indexed;
+        const edgeCount = edges.indexed;
+        const failedCount = nodes.failed + edges.failed;
+        const status = failedCount > 0 ? 'partial' : 'success';
 
         const duration = Date.now() - startTime;
-        this.config.logger.info('Governance sync completed', {
-          nodesIndexed: nodeCount,
-          edgesIndexed: edgeCount,
-          durationMs: duration,
-        });
+        if (failedCount > 0) {
+          this.config.logger.warn('Governance sync completed with failures', {
+            nodesIndexed: nodeCount,
+            edgesIndexed: edgeCount,
+            nodesFailed: nodes.failed,
+            edgesFailed: edges.failed,
+            durationMs: duration,
+          });
+        } else {
+          this.config.logger.info('Governance sync completed', {
+            nodesIndexed: nodeCount,
+            edgesIndexed: edgeCount,
+            durationMs: duration,
+          });
+        }
 
-        jobMetrics.executionsTotal.inc({ job: 'governance_sync', status: 'success' });
+        jobMetrics.executionsTotal.inc({ job: 'governance_sync', status });
         jobMetrics.lastRunTimestamp.set({ job: 'governance_sync' }, Date.now() / 1000);
         jobMetrics.itemsProcessed.inc(
           { job: 'governance_sync', status: 'success' },
           nodeCount + edgeCount
         );
-        endTimer({ status: 'success' });
+        if (failedCount > 0) {
+          jobMetrics.itemsProcessed.inc({ job: 'governance_sync', status: 'error' }, failedCount);
+        }
+        endTimer({ status });
+
+        return { nodesIndexed: nodeCount, edgesIndexed: edgeCount, failedCount, status };
       });
     } catch (error) {
       this.config.logger.error(
@@ -226,9 +285,12 @@ export class GovernanceSyncJob {
 
   /**
    * Syncs all node records from the Governance PDS.
+   *
+   * @returns Indexed and failed record counts for this collection.
    */
-  private async syncNodes(): Promise<number> {
+  private async syncNodes(): Promise<SyncCounts> {
     let indexedCount = 0;
+    let failedCount = 0;
     let cursor: string | undefined;
 
     do {
@@ -270,20 +332,24 @@ export class GovernanceSyncJob {
             error instanceof Error ? error : undefined,
             { uri: record.uri }
           );
+          failedCount++;
         }
       }
 
       cursor = response.data.cursor;
     } while (cursor);
 
-    return indexedCount;
+    return { indexed: indexedCount, failed: failedCount };
   }
 
   /**
    * Syncs all edge records from the Governance PDS.
+   *
+   * @returns Indexed and failed record counts for this collection.
    */
-  private async syncEdges(): Promise<number> {
+  private async syncEdges(): Promise<SyncCounts> {
     let indexedCount = 0;
+    let failedCount = 0;
     let cursor: string | undefined;
 
     do {
@@ -322,12 +388,13 @@ export class GovernanceSyncJob {
             error instanceof Error ? error : undefined,
             { uri: record.uri }
           );
+          failedCount++;
         }
       }
 
       cursor = response.data.cursor;
     } while (cursor);
 
-    return indexedCount;
+    return { indexed: indexedCount, failed: failedCount };
   }
 }

--- a/src/services/governance/trusted-editor-service.ts
+++ b/src/services/governance/trusted-editor-service.ts
@@ -25,6 +25,7 @@
 
 import type { Pool } from 'pg';
 
+import { getAdminDids } from '../../config/admin.js';
 import type { DID, NSID, Timestamp } from '../../types/atproto.js';
 import { DatabaseError, ValidationError } from '../../types/errors.js';
 import type { ILogger } from '../../types/interfaces/logger.interface.js';
@@ -138,7 +139,24 @@ export interface TrustedEditorServiceOptions {
   pool: Pool;
   /** Logger instance */
   logger: ILogger;
+  /**
+   * DIDs that hold the administrator role without a `governance_roles` grant.
+   *
+   * @remarks
+   * Every administrator-only governance endpoint resolves the caller's role
+   * through this service, and the only way to obtain the administrator role is
+   * for an administrator to approve an elevation request — so a fresh
+   * deployment has no way to create its first administrator. Platform admins
+   * (the DIDs seeded into the `admin` authorization role at startup) are
+   * therefore accepted as administrators here. Defaults to the same
+   * `ADMIN_DIDS` environment variable that seeds those platform admins.
+   */
+  platformAdminDids?: readonly DID[];
 }
+
+/**
+ * Parse a comma-separated DID list, as carried by `ADMIN_DIDS`.
+ */
 
 /**
  * Criteria thresholds for automatic elevation.
@@ -175,10 +193,26 @@ const TRUSTED_EDITOR_CRITERIA = {
 export class TrustedEditorService {
   private readonly pool: Pool;
   private readonly logger: ILogger;
+  private readonly platformAdminDids: ReadonlySet<DID>;
 
   constructor(options: TrustedEditorServiceOptions) {
     this.pool = options.pool;
     this.logger = options.logger;
+    this.platformAdminDids = new Set(options.platformAdminDids ?? getAdminDids());
+  }
+
+  /**
+   * Resolve the effective governance role for a DID.
+   *
+   * @remarks
+   * Platform admins outrank whatever `governance_roles` holds, so that the
+   * first administrator of a deployment exists before any elevation request
+   * can be approved.
+   *
+   * @internal
+   */
+  private resolveRole(did: DID, storedRole: GovernanceRole): GovernanceRole {
+    return this.platformAdminDids.has(did) ? 'administrator' : storedRole;
   }
 
   /**
@@ -191,25 +225,27 @@ export class TrustedEditorService {
    */
   async getEditorStatus(did: DID): Promise<Result<EditorStatus, DatabaseError>> {
     try {
-      // Get user info and role
+      // Get user info and role. The query drives from the requested DID rather
+      // than from authors_index so that a granted role still resolves when the
+      // actor's profile has not been indexed; the display name is best-effort.
       const userResult = await this.pool.query<{
-        did: string;
         display_name: string | null;
         role: string;
         role_granted_at: Date | null;
         role_granted_by: string | null;
-        created_at: Date;
+        created_at: Date | null;
       }>(
         `SELECT
-          a.did,
           a.display_name,
           COALESCE(gr.role, 'community-member') as role,
           gr.granted_at as role_granted_at,
           gr.granted_by as role_granted_by,
           a.indexed_at as created_at
-        FROM authors_index a
-        LEFT JOIN governance_roles gr ON gr.did = a.did AND gr.active = true
-        WHERE a.did = $1`,
+        FROM (SELECT $1::text AS did) t
+        LEFT JOIN governance_roles gr ON gr.did = t.did AND gr.active = true
+        LEFT JOIN authors_index a ON a.did = t.did
+        ORDER BY gr.granted_at DESC
+        LIMIT 1`,
         [did]
       );
 
@@ -243,7 +279,7 @@ export class TrustedEditorService {
         value: {
           did,
           displayName: user?.display_name ?? undefined,
-          role: (user?.role ?? 'community-member') as GovernanceRole,
+          role: this.resolveRole(did, (user?.role ?? 'community-member') as GovernanceRole),
           roleGrantedAt: user?.role_granted_at?.getTime() as Timestamp | undefined,
           roleGrantedBy: user?.role_granted_by as DID | undefined,
           hasDelegation: !!delegation,
@@ -275,22 +311,28 @@ export class TrustedEditorService {
    */
   async calculateReputationMetrics(did: DID): Promise<Result<ReputationMetrics, DatabaseError>> {
     try {
-      // Get account info
+      // Get account info. As in getEditorStatus, the role comes from
+      // governance_roles rather than from an indexed profile.
       const accountResult = await this.pool.query<{
-        created_at: Date;
+        created_at: Date | null;
         role: string;
       }>(
         `SELECT
           a.indexed_at as created_at,
           COALESCE(gr.role, 'community-member') as role
-        FROM authors_index a
-        LEFT JOIN governance_roles gr ON gr.did = a.did AND gr.active = true
-        WHERE a.did = $1`,
+        FROM (SELECT $1::text AS did) t
+        LEFT JOIN governance_roles gr ON gr.did = t.did AND gr.active = true
+        LEFT JOIN authors_index a ON a.did = t.did
+        ORDER BY gr.granted_at DESC
+        LIMIT 1`,
         [did]
       );
 
       const accountCreatedAt = accountResult.rows[0]?.created_at ?? new Date();
-      const role = (accountResult.rows[0]?.role ?? 'community-member') as GovernanceRole;
+      const role = this.resolveRole(
+        did,
+        (accountResult.rows[0]?.role ?? 'community-member') as GovernanceRole
+      );
       const accountAgeDays = Math.floor(
         (Date.now() - accountCreatedAt.getTime()) / (1000 * 60 * 60 * 24)
       );
@@ -644,6 +686,8 @@ export class TrustedEditorService {
     cursor?: string
   ): Promise<Result<{ editors: EditorStatus[]; cursor?: string }, DatabaseError>> {
     try {
+      // The join to authors_index is a LEFT JOIN because an editor whose
+      // profile has not been indexed still holds the role.
       const result = await this.pool.query<{
         did: string;
         display_name: string | null;
@@ -653,7 +697,7 @@ export class TrustedEditorService {
       }>(
         `SELECT gr.did, a.display_name, gr.role, gr.granted_at, gr.granted_by
          FROM governance_roles gr
-         JOIN authors_index a ON a.did = gr.did
+         LEFT JOIN authors_index a ON a.did = gr.did
          WHERE gr.active = true AND gr.role IN ('trusted-editor', 'graph-editor')
          ${cursor ? 'AND gr.granted_at < $2' : ''}
          ORDER BY gr.granted_at DESC
@@ -710,7 +754,10 @@ export class TrustedEditorService {
         [did]
       );
 
-      const role = (result.rows[0]?.role ?? 'community-member') as GovernanceRole;
+      const role = this.resolveRole(
+        did,
+        (result.rows[0]?.role ?? 'community-member') as GovernanceRole
+      );
 
       // Authority editors get higher weight on authority proposals
       if (role === 'graph-editor' && (proposalType === 'authority' || proposalType === 'facet')) {

--- a/src/services/indexing/event-processor.ts
+++ b/src/services/indexing/event-processor.ts
@@ -504,6 +504,15 @@ export function createEventProcessor(
             }
           );
         }
+      } else {
+        // Non-critical failures are not rethrown, and the cursor has already
+        // advanced past this event, so without a DLQ the record is dropped for
+        // good. Say so loudly rather than letting a missing option look benign.
+        logger.warn('Event failed with no DLQ configured; record will not be indexed', {
+          uri,
+          collection,
+          error: result.error.message,
+        });
       }
 
       // Throw for critical failures to halt processing
@@ -1871,6 +1880,12 @@ export function createBatchEventProcessor(
               }
             );
           }
+        } else {
+          logger.warn('Event failed with no DLQ configured; record will not be indexed', {
+            uri,
+            collection: event.collection,
+            error: result.error.message,
+          });
         }
 
         // Track critical failures

--- a/src/services/knowledge-graph/graph-service.ts
+++ b/src/services/knowledge-graph/graph-service.ts
@@ -577,6 +577,13 @@ export class KnowledgeGraphService {
    *
    * @param options - Filter and pagination options
    * @returns Paginated proposals
+   * @throws {DatabaseError} If the graph query fails
+   *
+   * @remarks
+   * A read failure propagates rather than degrading to an empty page. An empty
+   * page is a meaningful answer — the UI renders it as "no proposals found"
+   * with HTTP 200, and the moderation badge reads `total` — so swallowing an
+   * outage here made a broken graph indistinguishable from an empty backlog.
    *
    * @public
    */
@@ -632,12 +639,11 @@ export class KnowledgeGraphService {
         total: result.total,
       };
     } catch (error) {
-      this.logger.error('Failed to list proposals', error instanceof Error ? error : undefined);
-      return {
-        proposals: [],
-        hasMore: false,
-        total: 0,
-      };
+      this.logger.error('Failed to list proposals', error instanceof Error ? error : undefined, {
+        status: options.status,
+        type: options.type,
+      });
+      throw this.asReadError('Failed to list proposals', error);
     }
   }
 
@@ -645,7 +651,12 @@ export class KnowledgeGraphService {
    * Gets a proposal by ID.
    *
    * @param proposalId - Proposal identifier
-   * @returns Proposal view or null if not found
+   * @returns Proposal view, or null when no proposal carries that identifier
+   * @throws {DatabaseError} If the graph query fails
+   *
+   * @remarks
+   * Null means absent and nothing else. Callers turn it into a 404, so a read
+   * failure returned as null reported a proposal that exists as missing.
    *
    * @public
    */
@@ -684,8 +695,29 @@ export class KnowledgeGraphService {
       this.logger.error('Failed to get proposal', error instanceof Error ? error : undefined, {
         proposalId,
       });
-      return null;
+      throw this.asReadError(`Failed to get proposal ${proposalId}`, error);
     }
+  }
+
+  /**
+   * Wraps a caught value as a read-side {@link DatabaseError}.
+   *
+   * @remarks
+   * Errors raised by the graph adapter are already typed; re-wrapping them
+   * would bury the failing operation the adapter recorded, so they pass
+   * through unchanged.
+   *
+   * @internal
+   */
+  private asReadError(context: string, error: unknown): DatabaseError {
+    if (error instanceof DatabaseError) {
+      return error;
+    }
+    return new DatabaseError(
+      'READ',
+      `${context}: ${error instanceof Error ? error.message : String(error)}`,
+      error instanceof Error ? error : undefined
+    );
   }
 
   /**

--- a/src/storage/neo4j/adapter.ts
+++ b/src/storage/neo4j/adapter.ts
@@ -12,6 +12,7 @@
 import neo4j, { Integer } from 'neo4j-driver';
 import { singleton } from 'tsyringe';
 
+import { createLogger } from '../../observability/logger.js';
 import { toAtUri, toDID } from '../../types/atproto-validators.js';
 import type { AtUri, DID } from '../../types/atproto.js';
 import { DatabaseError, NotFoundError } from '../../types/errors.js';
@@ -24,6 +25,7 @@ import type {
   ProposalFilters,
   FacetAggregation,
 } from '../../types/interfaces/graph.interface.js';
+import type { ILogger } from '../../types/interfaces/logger.interface.js';
 
 import { Neo4jConnection } from './connection.js';
 import { subkindToLabel } from './labels.js';
@@ -44,6 +46,16 @@ import type {
   UserRole,
   VoteType,
 } from './types.js';
+
+/**
+ * Module-level logger for row-level mapping faults.
+ *
+ * @remarks
+ * The adapter takes only a connection, so a per-row diagnostic has no injected
+ * logger to reach; the same module-level pattern is used by the Neo4j setup
+ * manager and the PostgreSQL connection.
+ */
+const logger: ILogger = createLogger({ service: 'neo4j-adapter' });
 
 /**
  * Neo4j adapter implementing the IGraphDatabase interface.
@@ -638,7 +650,9 @@ export class Neo4jAdapter implements IGraphDatabase {
       limit: neo4j.int(50),
     });
 
-    return result.records.map((record) => this.mapNeo4jProposal(record.get('p')));
+    return result.records
+      .map((record) => this.mapNeo4jProposal(record.get('p')))
+      .filter((proposal): proposal is NodeProposal => proposal !== null);
   }
 
   /**
@@ -704,11 +718,16 @@ export class Neo4jAdapter implements IGraphDatabase {
 
     const result = await this.connection.executeQuery<{ p: Neo4jProposal }>(query, params);
 
-    const proposals = result.records.map((record) => this.mapNeo4jProposal(record.get('p')));
-    const hasMore = proposals.length > (filters.limit ?? 50);
-    if (hasMore) {
-      proposals.pop();
-    }
+    // The query fetches one row beyond the page to detect a next page, so
+    // paging is decided on raw rows: an unmappable row that mapping drops must
+    // not end pagination early.
+    const limit = filters.limit ?? 50;
+    const hasMore = result.records.length > limit;
+    const pageRecords = hasMore ? result.records.slice(0, limit) : result.records;
+
+    const proposals = pageRecords
+      .map((record) => this.mapNeo4jProposal(record.get('p')))
+      .filter((proposal): proposal is NodeProposal => proposal !== null);
 
     // Get total count
     const countQuery = `
@@ -753,7 +772,7 @@ export class Neo4jAdapter implements IGraphDatabase {
       return null;
     }
 
-    return this.mapNeo4jProposal(record.get('p'));
+    return this.requireMappedProposal(record.get('p'), rkey);
   }
 
   async getProposal(uri: AtUri): Promise<NodeProposal | null> {
@@ -769,7 +788,25 @@ export class Neo4jAdapter implements IGraphDatabase {
       return null;
     }
 
-    return this.mapNeo4jProposal(record.get('p'));
+    return this.requireMappedProposal(record.get('p'), uri);
+  }
+
+  /**
+   * Maps a single proposal row, treating an unmappable row as a read failure.
+   *
+   * @throws {DatabaseError} If the row cannot be mapped
+   *
+   * @remarks
+   * Single-record lookups return null for "no such proposal", which callers
+   * render as a 404. A corrupt row is a datastore fault, not a missing
+   * proposal, so it surfaces as an error instead.
+   */
+  private requireMappedProposal(row: Neo4jProposal, identifier: string): NodeProposal {
+    const proposal = this.mapNeo4jProposal(row);
+    if (!proposal) {
+      throw new DatabaseError('READ', `Proposal ${identifier} is stored in an unmappable state`);
+    }
+    return proposal;
   }
 
   /**
@@ -1083,8 +1120,16 @@ export class Neo4jAdapter implements IGraphDatabase {
 
   /**
    * Map Neo4j proposal to NodeProposal.
+   *
+   * @returns The mapped proposal, or null when the row cannot be mapped
+   *
+   * @remarks
+   * Throwing on a malformed row aborted the enclosing query, so one proposal
+   * with an unparseable proposer DID emptied every proposal list. Skipping the
+   * row keeps the rest of the page readable; callers that fetch a single row
+   * turn the null back into a {@link DatabaseError}.
    */
-  private mapNeo4jProposal(proposal: Neo4jProposal): NodeProposal {
+  private mapNeo4jProposal(proposal: Neo4jProposal): NodeProposal | null {
     const props = proposal.properties ?? proposal;
 
     const uriVal = props.uri as string | undefined;
@@ -1110,7 +1155,11 @@ export class Neo4jAdapter implements IGraphDatabase {
 
     const proposerDid = toDID(proposerDidStr);
     if (!proposerDid) {
-      throw new DatabaseError('READ', `Invalid DID in proposal: ${proposerDidStr}`);
+      logger.warn('Skipping proposal with unparseable proposer DID', {
+        uri: uriVal,
+        proposerDid: proposerDidStr,
+      });
+      return null;
     }
 
     const createdAt = createdAtRaw instanceof Date ? createdAtRaw : new Date(String(createdAtRaw));

--- a/src/storage/postgresql/migrations/1741600000000_firehose-dlq-event-columns.ts
+++ b/src/storage/postgresql/migrations/1741600000000_firehose-dlq-event-columns.ts
@@ -1,0 +1,64 @@
+/**
+ * Adds the event-identity and error-classification columns the dead letter
+ * queue has always written to.
+ *
+ * @remarks
+ * `DeadLetterQueue.add` inserts `seq`, `repo_did`, `event_type` and
+ * `error_type`, and `list`/`getStats` select them, but the initial schema never
+ * created them and no later migration added them. Production acquired the
+ * columns out of band, so the drift stayed invisible there while any database
+ * built from migrations — CI, a fresh deploy, a restored backup — had a queue
+ * that raised `column "seq" of relation "firehose_dlq" does not exist` on every
+ * write. The failure is swallowed by the event processor's own error handling,
+ * so the record was dropped exactly as if no queue existed.
+ *
+ * `IF NOT EXISTS` keeps this a no-op against the drifted production table.
+ */
+
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumns(
+    'firehose_dlq',
+    {
+      seq: { type: 'bigint' },
+      repo_did: { type: 'text' },
+      event_type: { type: 'text' },
+      error_type: { type: 'text' },
+    },
+    { ifNotExists: true }
+  );
+
+  // The queue is read by repo, by event type and by error class when triaging
+  // a backlog; the retry worker also scans unprocessed entries by age.
+  pgm.createIndex('firehose_dlq', 'repo_did', {
+    name: 'idx_firehose_dlq_repo_did',
+    ifNotExists: true,
+  });
+  pgm.createIndex('firehose_dlq', 'event_type', {
+    name: 'idx_firehose_dlq_event_type',
+    ifNotExists: true,
+  });
+  pgm.createIndex('firehose_dlq', 'error_type', {
+    name: 'idx_firehose_dlq_error_type',
+    ifNotExists: true,
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropIndex('firehose_dlq', 'error_type', {
+    name: 'idx_firehose_dlq_error_type',
+    ifExists: true,
+  });
+  pgm.dropIndex('firehose_dlq', 'event_type', {
+    name: 'idx_firehose_dlq_event_type',
+    ifExists: true,
+  });
+  pgm.dropIndex('firehose_dlq', 'repo_did', {
+    name: 'idx_firehose_dlq_repo_did',
+    ifExists: true,
+  });
+  pgm.dropColumns('firehose_dlq', ['seq', 'repo_did', 'event_type', 'error_type'], {
+    ifExists: true,
+  });
+}

--- a/tests/unit/api/handlers/xrpc/admin.test.ts
+++ b/tests/unit/api/handlers/xrpc/admin.test.ts
@@ -755,16 +755,22 @@ describe('XRPC Admin Handlers', () => {
       expect(result.body).toMatchObject({ success: true, did: 'did:plc:user1', role: 'moderator' });
     });
 
+    it('rejects governance roles with a pointer to the governance endpoint', async () => {
+      for (const role of ['graph-editor', 'trusted-editor', 'administrator']) {
+        await expect(
+          assignRole.handler({
+            params: undefined,
+            input: { did: 'did:plc:user1', role },
+            auth: null,
+            c: mockContext as never,
+          })
+        ).rejects.toThrow('pub.chive.governance.approveElevation');
+      }
+      expect(mockRedis.sadd).not.toHaveBeenCalled();
+    });
+
     it('accepts all valid roles', async () => {
-      const validRoles = [
-        'admin',
-        'moderator',
-        'graph-editor',
-        'author',
-        'reader',
-        'alpha-tester',
-        'premium',
-      ];
+      const validRoles = ['admin', 'moderator', 'author', 'reader', 'alpha-tester', 'premium'];
       for (const role of validRoles) {
         vi.clearAllMocks();
         mockContext = buildContext(adminUser);

--- a/tests/unit/config/admin.test.ts
+++ b/tests/unit/config/admin.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for platform administrator resolution.
+ *
+ * @remarks
+ * The list was previously parsed in three places with two behaviours: the two
+ * seeding paths fell back to a hardcoded DID when `ADMIN_DIDS` was unset, while
+ * the governance role service did not. On a deployment that never sets the
+ * variable — the documented normal case — a platform admin existed while the
+ * governance layer recognised no administrator, leaving every privileged
+ * governance endpoint unreachable with no way to bootstrap one.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_ADMIN_DID, getAdminDids } from '@/config/admin.js';
+
+describe('getAdminDids', () => {
+  const original = process.env.ADMIN_DIDS;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.ADMIN_DIDS;
+    else process.env.ADMIN_DIDS = original;
+  });
+
+  it('should parse a comma-separated list', () => {
+    expect(getAdminDids('did:plc:abc,did:plc:def')).toEqual(['did:plc:abc', 'did:plc:def']);
+  });
+
+  it('should trim surrounding whitespace', () => {
+    expect(getAdminDids(' did:plc:abc , did:plc:def ')).toEqual(['did:plc:abc', 'did:plc:def']);
+  });
+
+  it('should fall back when unset', () => {
+    expect(getAdminDids(undefined)).toEqual([DEFAULT_ADMIN_DID]);
+  });
+
+  // An undefined deploy variable interpolates to an empty string rather than
+  // being absent, and treating that as "no administrators" is what silently
+  // disabled governance.
+  it.each([
+    ['empty string', ''],
+    ['whitespace only', '   '],
+    ['commas only', ',,,'],
+  ])('should fall back on %s', (_name, raw) => {
+    expect(getAdminDids(raw)).toEqual([DEFAULT_ADMIN_DID]);
+  });
+
+  it('should read the environment variable when no argument is given', () => {
+    process.env.ADMIN_DIDS = 'did:plc:fromenv';
+    expect(getAdminDids()).toEqual(['did:plc:fromenv']);
+  });
+
+  it('should fall back when the environment variable is blank', () => {
+    process.env.ADMIN_DIDS = '';
+    expect(getAdminDids()).toEqual([DEFAULT_ADMIN_DID]);
+  });
+});

--- a/tests/unit/config/admin.test.ts
+++ b/tests/unit/config/admin.test.ts
@@ -30,8 +30,13 @@ describe('getAdminDids', () => {
     expect(getAdminDids(' did:plc:abc , did:plc:def ')).toEqual(['did:plc:abc', 'did:plc:def']);
   });
 
-  it('should fall back when unset', () => {
-    expect(getAdminDids(undefined)).toEqual([DEFAULT_ADMIN_DID]);
+  // `getAdminDids(undefined)` triggers the default parameter and therefore
+  // reads ADMIN_DIDS, so "unset" has to be established on the environment
+  // rather than by passing undefined — CI sets ADMIN_DIDS, and conflating the
+  // two made this pass locally and fail there.
+  it('should fall back when the environment has no ADMIN_DIDS', () => {
+    delete process.env.ADMIN_DIDS;
+    expect(getAdminDids()).toEqual([DEFAULT_ADMIN_DID]);
   });
 
   // An undefined deploy variable interpolates to an empty string rather than

--- a/tests/unit/jobs/governance-sync-job.test.ts
+++ b/tests/unit/jobs/governance-sync-job.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for GovernanceSyncJob.
+ *
+ * @remarks
+ * Focuses on failure accounting: a cycle in which some records fail to index
+ * must report `partial` rather than `success`, so callers cannot mistake a
+ * lossy sync for a complete one. Also pins the clean-run reporting so the
+ * success path stays unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GovernanceSyncJob } from '@/jobs/governance-sync-job.js';
+import { jobMetrics } from '@/observability/prometheus-registry.js';
+import type { EdgeService } from '@/services/governance/edge-service.js';
+import type { NodeService } from '@/services/governance/node-service.js';
+import type { AtUri, DID } from '@/types/atproto.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+// Hoisted so the mock factories below can reach these spies without a TDZ error.
+const { endTimer, listRecords } = vi.hoisted(() => ({
+  endTimer: vi.fn(),
+  listRecords: vi.fn(),
+}));
+
+vi.mock('@/observability/tracer.js', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+  addSpanAttributes: vi.fn(),
+}));
+
+vi.mock('@/observability/prometheus-registry.js', () => ({
+  jobMetrics: {
+    executionsTotal: { inc: vi.fn() },
+    itemsProcessed: { inc: vi.fn() },
+    lastRunTimestamp: { set: vi.fn() },
+    duration: { startTimer: vi.fn(() => endTimer) },
+  },
+}));
+
+// A plain class, not vi.fn(), so vi.clearAllMocks() cannot strip the constructor.
+vi.mock('@atproto/api', () => ({
+  AtpAgent: class {
+    com = { atproto: { repo: { listRecords } } };
+  },
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const GOVERNANCE_DID = 'did:plc:governance' as DID;
+const INDEXED_URI = 'at://did:plc:governance/pub.chive.graph.node/indexed' as AtUri;
+
+const createMockLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+function nodeRecord(id: string): { uri: string; value: Record<string, unknown> } {
+  return {
+    uri: `at://${GOVERNANCE_DID}/pub.chive.graph.node/${id}`,
+    value: { id, kind: 'field', label: id, status: 'active' },
+  };
+}
+
+function edgeRecord(id: string): { uri: string; value: Record<string, unknown> } {
+  return {
+    uri: `at://${GOVERNANCE_DID}/pub.chive.graph.edge/${id}`,
+    value: {
+      id,
+      sourceUri: `at://${GOVERNANCE_DID}/pub.chive.graph.node/a`,
+      targetUri: `at://${GOVERNANCE_DID}/pub.chive.graph.node/b`,
+      relationSlug: 'broader',
+      status: 'active',
+    },
+  };
+}
+
+/**
+ * Stubs listRecords so the node collection returns `nodes` and the edge
+ * collection returns `edges`, each in a single page.
+ */
+function stubCollections(
+  nodes: ReturnType<typeof nodeRecord>[],
+  edges: ReturnType<typeof edgeRecord>[]
+): void {
+  listRecords.mockImplementation(({ collection }: { collection: string }) =>
+    Promise.resolve({
+      data: {
+        records: collection === 'pub.chive.graph.node' ? nodes : edges,
+        cursor: undefined,
+      },
+    })
+  );
+}
+
+function createJob(
+  nodeService: NodeService,
+  edgeService: EdgeService,
+  logger: ILogger
+): GovernanceSyncJob {
+  return new GovernanceSyncJob({
+    pdsUrl: 'https://governance.example',
+    graphPdsDid: GOVERNANCE_DID,
+    nodeService,
+    edgeService,
+    logger,
+  });
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('GovernanceSyncJob.run', () => {
+  let logger: ILogger;
+  let nodeService: NodeService;
+  let edgeService: EdgeService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = createMockLogger();
+    nodeService = { indexNode: vi.fn().mockResolvedValue(INDEXED_URI) } as unknown as NodeService;
+    edgeService = { indexEdge: vi.fn().mockResolvedValue(INDEXED_URI) } as unknown as EdgeService;
+  });
+
+  it('reports success and counts every record when nothing fails', async () => {
+    stubCollections([nodeRecord('n1'), nodeRecord('n2')], [edgeRecord('e1')]);
+
+    const result = await createJob(nodeService, edgeService, logger).run();
+
+    expect(result).toEqual({
+      nodesIndexed: 2,
+      edgesIndexed: 1,
+      failedCount: 0,
+      status: 'success',
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      'Governance sync completed',
+      expect.objectContaining({ nodesIndexed: 2, edgesIndexed: 1 })
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(jobMetrics.executionsTotal.inc).toHaveBeenCalledWith({
+      job: 'governance_sync',
+      status: 'success',
+    });
+    expect(jobMetrics.itemsProcessed.inc).toHaveBeenCalledTimes(1);
+    expect(jobMetrics.itemsProcessed.inc).toHaveBeenCalledWith(
+      { job: 'governance_sync', status: 'success' },
+      3
+    );
+    expect(endTimer).toHaveBeenCalledWith({ status: 'success' });
+  });
+
+  it('reports partial and counts failures when some records fail to index', async () => {
+    stubCollections([nodeRecord('n1'), nodeRecord('n2')], [edgeRecord('e1')]);
+    vi.mocked(nodeService.indexNode)
+      .mockResolvedValueOnce(INDEXED_URI)
+      .mockRejectedValueOnce(new Error('neo4j write failed'));
+    vi.mocked(edgeService.indexEdge).mockRejectedValueOnce(new Error('neo4j write failed'));
+
+    const result = await createJob(nodeService, edgeService, logger).run();
+
+    expect(result).toEqual({
+      nodesIndexed: 1,
+      edgesIndexed: 0,
+      failedCount: 2,
+      status: 'partial',
+    });
+    expect(logger.info).not.toHaveBeenCalledWith('Governance sync completed', expect.anything());
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Governance sync completed with failures',
+      expect.objectContaining({ nodesFailed: 1, edgesFailed: 1 })
+    );
+    expect(jobMetrics.executionsTotal.inc).toHaveBeenCalledWith({
+      job: 'governance_sync',
+      status: 'partial',
+    });
+    expect(jobMetrics.itemsProcessed.inc).toHaveBeenCalledWith(
+      { job: 'governance_sync', status: 'error' },
+      2
+    );
+    expect(endTimer).toHaveBeenCalledWith({ status: 'partial' });
+  });
+
+  it('does not fail the cycle when one record poisons the batch', async () => {
+    stubCollections([nodeRecord('n1'), nodeRecord('n2'), nodeRecord('n3')], []);
+    vi.mocked(nodeService.indexNode).mockRejectedValueOnce(new Error('boom'));
+
+    const result = await createJob(nodeService, edgeService, logger).run();
+
+    expect(nodeService.indexNode).toHaveBeenCalledTimes(3);
+    expect(result.nodesIndexed).toBe(2);
+    expect(result.failedCount).toBe(1);
+  });
+
+  it('reports success for a skipped cycle since no records were read', async () => {
+    stubCollections([nodeRecord('n1')], []);
+    const job = createJob(nodeService, edgeService, logger);
+
+    const [first, second] = await Promise.all([job.run(), job.run()]);
+
+    expect(first.nodesIndexed + second.nodesIndexed).toBe(1);
+    expect([first.status, second.status]).toEqual(['success', 'success']);
+  });
+});

--- a/tests/unit/services/governance/trusted-editor-service.test.ts
+++ b/tests/unit/services/governance/trusted-editor-service.test.ts
@@ -7,7 +7,10 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { TrustedEditorService } from '@/services/governance/trusted-editor-service.js';
+import {
+  ROLE_VOTE_WEIGHTS,
+  TrustedEditorService,
+} from '@/services/governance/trusted-editor-service.js';
 import type { DID } from '@/types/atproto.js';
 import type { ILogger } from '@/types/interfaces/logger.interface.js';
 
@@ -496,6 +499,135 @@ describe('TrustedEditorService', () => {
       if (!result.ok) {
         expect(result.error.code).toBe('DATABASE_ERROR');
       }
+    });
+  });
+
+  describe('getEditorStatus', () => {
+    const userDid = makeDID('did:plc:editor');
+
+    /**
+     * Queue the five queries getEditorStatus issues after the role lookup:
+     * delegations, then the four reputation queries.
+     */
+    const mockRemainingQueries = (role: string): void => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [] }) // delegations
+        .mockResolvedValueOnce({ rows: [{ created_at: null, role }] }) // account
+        .mockResolvedValueOnce({ rows: [] }) // eprints
+        .mockResolvedValueOnce({ rows: [] }) // proposals and votes
+        .mockResolvedValueOnce({ rows: [] }); // warnings and violations
+    };
+
+    it('resolves the role from governance_roles when the profile is not indexed', async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            display_name: null,
+            role: 'trusted-editor',
+            role_granted_at: new Date(),
+            role_granted_by: 'did:plc:admin',
+            created_at: null,
+          },
+        ],
+      });
+      mockRemainingQueries('trusted-editor');
+
+      const result = await service.getEditorStatus(userDid);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.role).toBe('trusted-editor');
+        expect(result.value.displayName).toBeUndefined();
+      }
+
+      // The role must not depend on authors_index having a row
+      const roleQuery = mockPool.query.mock.calls[0]?.[0] as string;
+      expect(roleQuery).toContain('LEFT JOIN governance_roles');
+      expect(roleQuery).toContain('LEFT JOIN authors_index');
+    });
+
+    it('treats a configured platform admin as an administrator', async () => {
+      service = new TrustedEditorService({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: mockPool as any,
+        logger: mockLogger,
+        platformAdminDids: [userDid],
+      });
+
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            display_name: 'Editor',
+            role: 'community-member',
+            role_granted_at: null,
+            role_granted_by: null,
+            created_at: new Date(),
+          },
+        ],
+      });
+      mockRemainingQueries('community-member');
+
+      const result = await service.getEditorStatus(userDid);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.role).toBe('administrator');
+        expect(result.value.metrics.role).toBe('administrator');
+      }
+    });
+
+    it('reads platform admins from ADMIN_DIDS when none are injected', async () => {
+      vi.stubEnv('ADMIN_DIDS', ` did:plc:other , ${userDid} `);
+      service = new TrustedEditorService({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: mockPool as any,
+        logger: mockLogger,
+      });
+      vi.unstubAllEnvs();
+
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+      mockRemainingQueries('community-member');
+
+      const result = await service.getEditorStatus(userDid);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.role).toBe('administrator');
+      }
+    });
+
+    it('leaves non-admins on their stored role', async () => {
+      service = new TrustedEditorService({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: mockPool as any,
+        logger: mockLogger,
+        platformAdminDids: [makeDID('did:plc:someone-else')],
+      });
+
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+      mockRemainingQueries('community-member');
+
+      const result = await service.getEditorStatus(userDid);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.role).toBe('community-member');
+      }
+    });
+  });
+
+  describe('getVoteWeight', () => {
+    it('gives a platform admin the administrator weight', async () => {
+      const adminDid = makeDID('did:plc:platform-admin');
+      service = new TrustedEditorService({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: mockPool as any,
+        logger: mockLogger,
+        platformAdminDids: [adminDid],
+      });
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      await expect(service.getVoteWeight(adminDid)).resolves.toBe(ROLE_VOTE_WEIGHTS.administrator);
     });
   });
 });

--- a/tests/unit/services/indexing/event-processor-collections.test.ts
+++ b/tests/unit/services/indexing/event-processor-collections.test.ts
@@ -1,0 +1,820 @@
+/**
+ * Unit tests for the per-collection dispatch in the firehose event processor.
+ *
+ * @remarks
+ * The processor fans every firehose commit out to a collection-specific branch,
+ * and each branch has to do two things correctly: apply the create/update path,
+ * and remove the record from the index on a delete. A branch that silently
+ * swallows a datastore failure leaves the cursor advanced past an event that was
+ * never indexed, so the failure paths are pinned here alongside the happy ones.
+ * Non-critical failures are expected to reach the DLQ; eprint failures are
+ * critical and must also throw so the indexer halts rather than losing the
+ * record.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { DeadLetterQueue } from '@/services/indexing/dlq-handler.js';
+import {
+  createEventProcessor,
+  type EventProcessorOptions,
+} from '@/services/indexing/event-processor.js';
+import type { ProcessedEvent } from '@/services/indexing/indexing-service.js';
+
+const REPO = 'did:plc:testrepo';
+
+/**
+ * Builds a firehose commit event for an arbitrary collection.
+ */
+const event = (
+  collection: string,
+  action: 'create' | 'update' | 'delete',
+  record?: unknown
+): ProcessedEvent =>
+  ({
+    $type: 'commit',
+    seq: 11,
+    repo: REPO,
+    time: '2026-08-25T00:00:00.000Z',
+    action,
+    collection,
+    rkey: '3kxyz',
+    cid: 'bafyreiabc',
+    record,
+  }) as ProcessedEvent;
+
+/**
+ * A minimal eprint submission record that survives PDS-record transformation.
+ */
+const submissionRecord = (): Record<string, unknown> => ({
+  $type: 'pub.chive.eprint.submission',
+  title: 'A Study in Indexing',
+  document: {
+    $type: 'blob',
+    ref: { $link: 'bafkreiabc123def456' },
+    mimeType: 'application/pdf',
+    size: 1234,
+  },
+  authors: [{ name: 'Alice Researcher', order: 1, did: 'did:plc:author123' }],
+  createdAt: '2026-01-18T12:00:00.000Z',
+  submittedBy: 'did:plc:submitter456',
+  abstract: 'An abstract.',
+  documentFormat: 'pdf',
+});
+
+describe('event processor collection dispatch', () => {
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const query = vi.fn();
+  const dlqAdd = vi.fn();
+
+  const ok = { ok: true, value: undefined };
+  const err = (message: string): { ok: false; error: Error } => ({
+    ok: false,
+    error: new Error(message),
+  });
+
+  const eprintService = {
+    indexEprint: vi.fn(),
+    indexEprintUpdate: vi.fn(),
+    indexEprintDelete: vi.fn(),
+  };
+  const reviewService = { indexReview: vi.fn(), indexEndorsement: vi.fn() };
+  const annotationService = { indexAnnotation: vi.fn(), indexEntityLink: vi.fn() };
+
+  /**
+   * Builds a processor over the shared mocks.
+   */
+  const processor = (extra: Record<string, unknown> = {}): ((e: ProcessedEvent) => Promise<void>) =>
+    createEventProcessor({
+      pool: { query },
+      activity: { correlateWithFirehose: vi.fn().mockResolvedValue({ ok: true, value: null }) },
+      eprintService,
+      reviewService,
+      annotationService,
+      graphService: {},
+      identity: { getPDSEndpoint: vi.fn().mockResolvedValue('https://pds.example.com') },
+      logger,
+      dlq: { add: dlqAdd } as unknown as DeadLetterQueue,
+      ...extra,
+    } as unknown as EventProcessorOptions);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    query.mockResolvedValue({ rows: [], rowCount: 0 });
+    dlqAdd.mockResolvedValue(1);
+    eprintService.indexEprint.mockResolvedValue(ok);
+    eprintService.indexEprintUpdate.mockResolvedValue(ok);
+    eprintService.indexEprintDelete.mockResolvedValue(ok);
+    reviewService.indexReview.mockResolvedValue(ok);
+    reviewService.indexEndorsement.mockResolvedValue(ok);
+    annotationService.indexAnnotation.mockResolvedValue(ok);
+    annotationService.indexEntityLink.mockResolvedValue(ok);
+  });
+
+  describe('eprint submissions', () => {
+    it('indexes a newly created submission', async () => {
+      await processor()(event('pub.chive.eprint.submission', 'create', submissionRecord()));
+      expect(eprintService.indexEprint).toHaveBeenCalledTimes(1);
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('routes an update through the update path rather than a fresh insert', async () => {
+      await processor()(event('pub.chive.eprint.submission', 'update', submissionRecord()));
+      expect(eprintService.indexEprintUpdate).toHaveBeenCalledTimes(1);
+      expect(eprintService.indexEprint).not.toHaveBeenCalled();
+    });
+
+    it('removes a submission deleted from its source PDS', async () => {
+      await processor()(event('pub.chive.eprint.submission', 'delete'));
+      expect(eprintService.indexEprintDelete).toHaveBeenCalledTimes(1);
+    });
+
+    // Eprint failures are critical: the processor both DLQs and rethrows, so a
+    // lost submission halts the indexer instead of advancing the cursor past it.
+    it('throws and DLQs when the delete fails', async () => {
+      eprintService.indexEprintDelete.mockResolvedValue(err('delete exploded'));
+      await expect(processor()(event('pub.chive.eprint.submission', 'delete'))).rejects.toThrow(
+        /Failed to delete eprint/
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws and DLQs when indexing fails', async () => {
+      eprintService.indexEprint.mockResolvedValue(err('index exploded'));
+      await expect(
+        processor()(event('pub.chive.eprint.submission', 'create', submissionRecord()))
+      ).rejects.toThrow(/Failed to create eprint/);
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('changelogs', () => {
+    const changelog = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      version: { major: 1, minor: 1, patch: 0 },
+      sections: [{ category: 'added', items: [{ description: 'A new section.' }] }],
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+
+    it('inserts a changelog into the index', async () => {
+      await processor()(event('pub.chive.eprint.changelog', 'create', changelog));
+      expect(query).toHaveBeenCalledTimes(1);
+      expect(query.mock.calls[0]?.[0]).toMatch(/INSERT INTO changelogs_index/);
+    });
+
+    it('deletes a changelog by URI', async () => {
+      await processor()(event('pub.chive.eprint.changelog', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM changelogs_index/);
+    });
+
+    it('sends a failed changelog insert to the DLQ without throwing', async () => {
+      query.mockRejectedValue(new Error('insert failed'));
+      await expect(
+        processor()(event('pub.chive.eprint.changelog', 'create', changelog))
+      ).resolves.toBeUndefined();
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed changelog delete to the DLQ', async () => {
+      query.mockRejectedValue(new Error('delete failed'));
+      await processor()(event('pub.chive.eprint.changelog', 'delete'));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('eprint versions', () => {
+    const version = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      versionNumber: 2,
+      changes: 'Revised the analysis.',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+
+    it('inserts a version into the index', async () => {
+      await processor()(event('pub.chive.eprint.version', 'create', version));
+      expect(query.mock.calls[0]?.[0]).toMatch(/INSERT INTO eprint_versions_index/);
+    });
+
+    it('deletes a version by URI', async () => {
+      await processor()(event('pub.chive.eprint.version', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM eprint_versions_index/);
+    });
+
+    it('sends a failed version insert to the DLQ', async () => {
+      query.mockRejectedValue(new Error('insert failed'));
+      await processor()(event('pub.chive.eprint.version', 'create', version));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reviews and endorsements', () => {
+    it('indexes a review comment', async () => {
+      await processor()(event('pub.chive.review.comment', 'create', { body: 'A comment.' }));
+      expect(reviewService.indexReview).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a review comment by URI', async () => {
+      await processor()(event('pub.chive.review.comment', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM reviews_index/);
+    });
+
+    it('sends a failed review index to the DLQ', async () => {
+      reviewService.indexReview.mockResolvedValue(err('review failed'));
+      await processor()(event('pub.chive.review.comment', 'create', { body: 'A comment.' }));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('indexes an endorsement', async () => {
+      await processor()(event('pub.chive.review.endorsement', 'create', { rating: 5 }));
+      expect(reviewService.indexEndorsement).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes an endorsement by URI', async () => {
+      await processor()(event('pub.chive.review.endorsement', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM endorsements_index/);
+    });
+
+    it('sends a failed endorsement index to the DLQ', async () => {
+      reviewService.indexEndorsement.mockResolvedValue(err('endorsement failed'));
+      await processor()(event('pub.chive.review.endorsement', 'create', { rating: 5 }));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('annotations', () => {
+    it('indexes an annotation comment', async () => {
+      await processor()(event('pub.chive.annotation.comment', 'create', { body: 'Note.' }));
+      expect(annotationService.indexAnnotation).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes an annotation by URI', async () => {
+      await processor()(event('pub.chive.annotation.comment', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM annotations_index/);
+    });
+
+    it('indexes an entity link', async () => {
+      await processor()(event('pub.chive.annotation.entityLink', 'create', { target: 'x' }));
+      expect(annotationService.indexEntityLink).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes an entity link by URI', async () => {
+      await processor()(event('pub.chive.annotation.entityLink', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM entity_links_index/);
+    });
+
+    it('sends a failed annotation index to the DLQ', async () => {
+      annotationService.indexAnnotation.mockResolvedValue(err('annotation failed'));
+      await processor()(event('pub.chive.annotation.comment', 'create', { body: 'Note.' }));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('user tags', () => {
+    const tag = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      tag: 'Syntax',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+
+    it('inserts a tag into the index', async () => {
+      await processor()(event('pub.chive.eprint.userTag', 'create', tag));
+      expect(query.mock.calls[0]?.[0]).toMatch(/INSERT INTO user_tags_index/);
+    });
+
+    it('mirrors a new tag into the tag graph', async () => {
+      const addTag = vi.fn().mockResolvedValue(undefined);
+      await processor({ tagManager: { addTag, normalizeTag: (t: string) => t } })(
+        event('pub.chive.eprint.userTag', 'create', tag)
+      );
+      expect(addTag).toHaveBeenCalledTimes(1);
+    });
+
+    // The tag graph is a derived index, so a Neo4j failure must not fail the
+    // Postgres insert that the firehose cursor has already advanced past.
+    it('keeps the row indexed when the tag graph rejects the tag', async () => {
+      const addTag = vi.fn().mockRejectedValue(new Error('neo4j down'));
+      await processor({ tagManager: { addTag, normalizeTag: (t: string) => t } })(
+        event('pub.chive.eprint.userTag', 'create', tag)
+      );
+      expect(dlqAdd).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('removes the tag from the graph when the record is deleted', async () => {
+      const removeTag = vi.fn().mockResolvedValue(undefined);
+      query.mockResolvedValue({
+        rows: [{ eprint_uri: tag.eprintUri, tag: 'Syntax' }],
+        rowCount: 1,
+      });
+      await processor({ tagManager: { removeTag, normalizeTag: (t: string) => t } })(
+        event('pub.chive.eprint.userTag', 'delete')
+      );
+      expect(removeTag).toHaveBeenCalledWith(tag.eprintUri, 'Syntax');
+    });
+
+    it('sends a failed tag insert to the DLQ', async () => {
+      query.mockRejectedValue(new Error('insert failed'));
+      await processor()(event('pub.chive.eprint.userTag', 'create', tag));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('citations', () => {
+    const citation = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      citedWork: { title: 'A Cited Work', doi: '10.1000/xyz' },
+      citationType: 'supports',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+    const storage = (): Record<string, unknown> => ({
+      indexCitation: vi.fn().mockResolvedValue(undefined),
+      deleteCitation: vi.fn().mockResolvedValue(undefined),
+      indexRelatedWork: vi.fn().mockResolvedValue(undefined),
+      deleteRelatedWork: vi.fn().mockResolvedValue(undefined),
+    });
+
+    it('indexes a citation through the storage backend', async () => {
+      const s = storage();
+      await processor({ storage: s })(event('pub.chive.eprint.citation', 'create', citation));
+      expect(s.indexCitation).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a citation through the storage backend', async () => {
+      const s = storage();
+      await processor({ storage: s })(event('pub.chive.eprint.citation', 'delete'));
+      expect(s.deleteCitation).toHaveBeenCalledWith(expect.stringContaining('at://'));
+    });
+
+    // Without a storage backend the branch is a no-op rather than a crash.
+    it('ignores a citation when no storage backend is configured', async () => {
+      await processor()(event('pub.chive.eprint.citation', 'create', citation));
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('adds a CITES edge when the cited work lives in Chive', async () => {
+      const upsertCitationsBatch = vi.fn().mockResolvedValue(undefined);
+      await processor({
+        storage: storage(),
+        citationGraph: { upsertCitationsBatch },
+      })(
+        event('pub.chive.eprint.citation', 'create', {
+          ...citation,
+          citedWork: {
+            ...citation.citedWork,
+            chiveUri: `at://${REPO}/pub.chive.eprint.submission/z`,
+          },
+        })
+      );
+      expect(upsertCitationsBatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the citation indexed when the CITES upsert fails', async () => {
+      const upsertCitationsBatch = vi.fn().mockRejectedValue(new Error('graph down'));
+      await processor({
+        storage: storage(),
+        citationGraph: { upsertCitationsBatch },
+      })(
+        event('pub.chive.eprint.citation', 'create', {
+          ...citation,
+          citedWork: {
+            ...citation.citedWork,
+            chiveUri: `at://${REPO}/pub.chive.eprint.submission/z`,
+          },
+        })
+      );
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('sends a failed citation index to the DLQ', async () => {
+      const s = storage();
+      (s.indexCitation as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('insert failed'));
+      await processor({ storage: s })(event('pub.chive.eprint.citation', 'create', citation));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed citation delete to the DLQ', async () => {
+      const s = storage();
+      (s.deleteCitation as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('delete failed'));
+      await processor({ storage: s })(event('pub.chive.eprint.citation', 'delete'));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('related works', () => {
+    const relatedWork = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      relatedUri: `at://${REPO}/pub.chive.eprint.submission/def`,
+      relationType: 'extends',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+    const storage = (): Record<string, unknown> => ({
+      indexRelatedWork: vi.fn().mockResolvedValue(undefined),
+      deleteRelatedWork: vi.fn().mockResolvedValue(undefined),
+    });
+
+    it('indexes a related work through the storage backend', async () => {
+      const s = storage();
+      await processor({ storage: s })(event('pub.chive.eprint.relatedWork', 'create', relatedWork));
+      expect(s.indexRelatedWork).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a related work through the storage backend', async () => {
+      const s = storage();
+      await processor({ storage: s })(event('pub.chive.eprint.relatedWork', 'delete'));
+      expect(s.deleteRelatedWork).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed related-work index to the DLQ', async () => {
+      const s = storage();
+      (s.indexRelatedWork as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+      await processor({ storage: s })(event('pub.chive.eprint.relatedWork', 'create', relatedWork));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('personal graph nodes', () => {
+    // A node authored in a user's own repo (rather than the Governance PDS) is a
+    // personal node, and takes the personalGraphService path.
+    const node = {
+      id: 'n1',
+      kind: 'concept',
+      label: 'Ergativity',
+      status: 'active',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+    const okResult = { ok: true, value: undefined };
+    const errResult = { ok: false, error: new Error('graph rejected it') };
+
+    const services = (): {
+      personalGraphService: Record<string, unknown>;
+      collectionService: Record<string, unknown>;
+    } => ({
+      personalGraphService: {
+        indexNode: vi.fn().mockResolvedValue(okResult),
+        updateNode: vi.fn().mockResolvedValue(okResult),
+        deleteNode: vi.fn().mockResolvedValue(okResult),
+      },
+      collectionService: {
+        indexCollection: vi.fn().mockResolvedValue(okResult),
+        updateCollection: vi.fn().mockResolvedValue(okResult),
+        deleteCollection: vi.fn().mockResolvedValue(okResult),
+      },
+    });
+
+    it('indexes a personal node', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.node', 'create', node));
+      expect(s.personalGraphService.indexNode).toHaveBeenCalledTimes(1);
+      expect(s.collectionService.indexCollection).not.toHaveBeenCalled();
+    });
+
+    it('routes an update to the update path', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.node', 'update', node));
+      expect(s.personalGraphService.updateNode).toHaveBeenCalledTimes(1);
+    });
+
+    // A node whose subkind is 'collection' is indexed twice: once as a
+    // collection, once as an ordinary personal node.
+    it('indexes a collection node through both services', async () => {
+      const s = services();
+      await processor(s)(
+        event('pub.chive.graph.node', 'create', { ...node, subkind: 'collection' })
+      );
+      expect(s.collectionService.indexCollection).toHaveBeenCalledTimes(1);
+      expect(s.personalGraphService.indexNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates a collection node through the collection update path', async () => {
+      const s = services();
+      await processor(s)(
+        event('pub.chive.graph.node', 'update', { ...node, subkind: 'collection' })
+      );
+      expect(s.collectionService.updateCollection).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a personal node from both indexes', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.node', 'delete'));
+      expect(s.collectionService.deleteCollection).toHaveBeenCalledTimes(1);
+      expect(s.personalGraphService.deleteNode).toHaveBeenCalledTimes(1);
+    });
+
+    // A URI that was never a collection makes deleteCollection fail, which is
+    // expected and must not stop the personal-graph delete from running.
+    it('still deletes the node when the collection delete reports a miss', async () => {
+      const s = services();
+      (s.collectionService.deleteCollection as ReturnType<typeof vi.fn>).mockResolvedValue(
+        errResult
+      );
+      await processor(s)(event('pub.chive.graph.node', 'delete'));
+      expect(s.personalGraphService.deleteNode).toHaveBeenCalledTimes(1);
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('tolerates a collection delete that throws', async () => {
+      const s = services();
+      (s.collectionService.deleteCollection as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('boom')
+      );
+      await processor(s)(event('pub.chive.graph.node', 'delete'));
+      expect(s.personalGraphService.deleteNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed personal node delete to the DLQ', async () => {
+      const s = services();
+      (s.personalGraphService.deleteNode as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor(s)(event('pub.chive.graph.node', 'delete'));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed personal node index to the DLQ', async () => {
+      const s = services();
+      (s.personalGraphService.indexNode as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor(s)(event('pub.chive.graph.node', 'create', node));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed collection index to the DLQ without indexing the node', async () => {
+      const s = services();
+      (s.collectionService.indexCollection as ReturnType<typeof vi.fn>).mockResolvedValue(
+        errResult
+      );
+      await processor(s)(
+        event('pub.chive.graph.node', 'create', { ...node, subkind: 'collection' })
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+      expect(s.personalGraphService.indexNode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('personal graph edges', () => {
+    const okResult = { ok: true, value: undefined };
+    const errResult = { ok: false, error: new Error('edge rejected') };
+    const OWNED = `at://${REPO}/pub.chive.graph.node/collection1`;
+    const FOREIGN = 'at://did:plc:someoneelse/pub.chive.graph.node/collection1';
+
+    const edge = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+      id: 'e1',
+      sourceUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      targetUri: OWNED,
+      relationSlug: 'relates-to',
+      createdAt: '2026-08-25T00:00:00.000Z',
+      ...overrides,
+    });
+
+    const services = (): {
+      personalGraphService: Record<string, unknown>;
+      collectionService: Record<string, unknown>;
+      collaborationService: Record<string, unknown>;
+    } => ({
+      personalGraphService: {
+        indexEdge: vi.fn().mockResolvedValue(okResult),
+        updateEdge: vi.fn().mockResolvedValue(okResult),
+        deleteEdge: vi.fn().mockResolvedValue(okResult),
+      },
+      collectionService: {
+        indexCollectionEdge: vi.fn().mockResolvedValue(okResult),
+        deleteCollectionEdge: vi.fn().mockResolvedValue(okResult),
+      },
+      collaborationService: {
+        isCollaborator: vi.fn().mockResolvedValue(true),
+        parkPendingCollectionEdge: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    it('indexes an ordinary personal edge', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.edge', 'create', edge()));
+      expect(s.personalGraphService.indexEdge).toHaveBeenCalledTimes(1);
+      expect(s.collectionService.indexCollectionEdge).not.toHaveBeenCalled();
+    });
+
+    it('routes an edge update to the update path', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.edge', 'update', edge()));
+      expect(s.personalGraphService.updateEdge).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a personal edge', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.edge', 'delete', edge()));
+      expect(s.personalGraphService.deleteEdge).toHaveBeenCalledTimes(1);
+    });
+
+    // 'contains' marks the edge as a collection relation, which takes the
+    // collection path in addition to the personal graph.
+    it('deletes a collection edge through the collection service', async () => {
+      const s = services();
+      await processor(s)(
+        event('pub.chive.graph.edge', 'delete', edge({ relationSlug: 'contains' }))
+      );
+      expect(s.collectionService.deleteCollectionEdge).toHaveBeenCalledTimes(1);
+    });
+
+    it('indexes a collection edge when the author owns the collection', async () => {
+      const s = services();
+      await processor(s)(
+        event('pub.chive.graph.edge', 'create', edge({ relationSlug: 'contains' }))
+      );
+      expect(s.collectionService.indexCollectionEdge).toHaveBeenCalledTimes(1);
+      expect(s.collaborationService.isCollaborator).not.toHaveBeenCalled();
+    });
+
+    it('indexes a foreign collection edge when the author is an active collaborator', async () => {
+      const s = services();
+      await processor(s)(
+        event(
+          'pub.chive.graph.edge',
+          'create',
+          edge({ relationSlug: 'contains', targetUri: FOREIGN })
+        )
+      );
+      expect(s.collaborationService.isCollaborator).toHaveBeenCalledTimes(1);
+      expect(s.collectionService.indexCollectionEdge).toHaveBeenCalledTimes(1);
+    });
+
+    // An unauthorized author must not have their edge indexed into someone
+    // else's collection; it is parked until the collaboration turns active.
+    it('parks a foreign collection edge from a non-collaborator', async () => {
+      const s = services();
+      (s.collaborationService.isCollaborator as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+      await processor(s)(
+        event(
+          'pub.chive.graph.edge',
+          'create',
+          edge({ relationSlug: 'contains', targetUri: FOREIGN })
+        )
+      );
+      expect(s.collaborationService.parkPendingCollectionEdge).toHaveBeenCalledTimes(1);
+      expect(s.collectionService.indexCollectionEdge).not.toHaveBeenCalled();
+    });
+
+    it('sends a failed personal edge delete to the DLQ', async () => {
+      const s = services();
+      (s.personalGraphService.deleteEdge as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor(s)(event('pub.chive.graph.edge', 'delete', edge()));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed personal edge index to the DLQ', async () => {
+      const s = services();
+      (s.personalGraphService.indexEdge as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor(s)(event('pub.chive.graph.edge', 'create', edge()));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('actor profiles', () => {
+    const profile = { displayName: 'Alice Researcher', bio: 'Linguist.' };
+
+    it('upserts a profile into the authors index', async () => {
+      await processor()(event('pub.chive.actor.profile', 'create', profile));
+      expect(query).toHaveBeenCalled();
+    });
+
+    it('deletes a profile by repo DID', async () => {
+      await processor()(event('pub.chive.actor.profile', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM authors_index/);
+      expect(query.mock.calls[0]?.[1]).toEqual([REPO]);
+    });
+
+    it('sends a failed profile upsert to the DLQ', async () => {
+      query.mockRejectedValue(new Error('upsert failed'));
+      await processor()(event('pub.chive.actor.profile', 'create', profile));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed profile delete to the DLQ', async () => {
+      query.mockRejectedValue(new Error('delete failed'));
+      await processor()(event('pub.chive.actor.profile', 'delete'));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('upserts a profile config keyed on the repo DID', async () => {
+      await processor()(event('pub.chive.actor.profileConfig', 'create', { theme: 'dark' }));
+      expect(query).toHaveBeenCalled();
+    });
+
+    it('deletes a profile config by repo DID', async () => {
+      await processor()(event('pub.chive.actor.profileConfig', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM profile_config/);
+    });
+
+    it('sends a failed profile config write to the DLQ', async () => {
+      query.mockRejectedValue(new Error('config failed'));
+      await processor()(event('pub.chive.actor.profileConfig', 'create', { theme: 'dark' }));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('collaboration invites', () => {
+    const okResult = { ok: true, value: undefined };
+    const errResult = { ok: false, error: new Error('invite rejected') };
+    const invite = {
+      subject: { uri: `at://${REPO}/pub.chive.graph.node/collection1` },
+      invitee: 'did:plc:invitee',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+
+    const collaborationService = (): Record<string, unknown> => ({
+      indexInvite: vi.fn().mockResolvedValue(okResult),
+      deleteInvite: vi.fn().mockResolvedValue(okResult),
+      indexAcceptance: vi.fn().mockResolvedValue(okResult),
+      deleteAcceptance: vi.fn().mockResolvedValue(okResult),
+    });
+
+    // Collaboration is optional, so a deployment without the service must skip
+    // the record rather than fail the event.
+    it('ignores an invite when collaboration is not configured', async () => {
+      await processor()(event('pub.chive.collaboration.invite', 'create', invite));
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('indexes an invite', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'create', invite)
+      );
+      expect(c.indexInvite).toHaveBeenCalledTimes(1);
+    });
+
+    // A record missing a lexicon-required field is skipped rather than indexed
+    // half-formed.
+    it('skips an invite missing its subject', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'create', {
+          invitee: 'did:plc:x',
+          createdAt: 'now',
+        })
+      );
+      expect(c.indexInvite).not.toHaveBeenCalled();
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('skips an invite missing its invitee', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'create', {
+          subject: invite.subject,
+          createdAt: 'now',
+        })
+      );
+      expect(c.indexInvite).not.toHaveBeenCalled();
+    });
+
+    it('deletes an invite', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'delete')
+      );
+      expect(c.deleteInvite).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed invite index to the DLQ', async () => {
+      const c = collaborationService();
+      (c.indexInvite as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'create', invite)
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed invite delete to the DLQ', async () => {
+      const c = collaborationService();
+      (c.deleteInvite as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'delete')
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes an invite acceptance', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.inviteAcceptance', 'delete')
+      );
+      expect(c.deleteAcceptance).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed acceptance delete to the DLQ', async () => {
+      const c = collaborationService();
+      (c.deleteAcceptance as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.inviteAcceptance', 'delete')
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unhandled collections', () => {
+    // A foreign lexicon is not an error: the processor should ignore it quietly
+    // rather than filling the DLQ with records Chive never claimed to index.
+    it('ignores a collection outside the pub.chive namespace', async () => {
+      await processor()(event('app.bsky.feed.post', 'create', { text: 'hello' }));
+      expect(dlqAdd).not.toHaveBeenCalled();
+      expect(query).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/services/indexing/event-processor.test.ts
+++ b/tests/unit/services/indexing/event-processor.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the firehose event processor's failure handling.
+ *
+ * @remarks
+ * The cursor advances when an event is queued, not when it is processed, so a
+ * handler failure that neither reaches the DLQ nor rethrows loses the record
+ * permanently. These tests pin the two halves of that contract: a configured
+ * DLQ receives non-critical failures, and an absent one is reported loudly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { DeadLetterQueue } from '@/services/indexing/dlq-handler.js';
+import {
+  createEventProcessor,
+  EventProcessingError,
+  type EventProcessorOptions,
+} from '@/services/indexing/event-processor.js';
+import type { ProcessedEvent } from '@/services/indexing/indexing-service.js';
+
+const REPO = 'did:plc:testrepo';
+
+/**
+ * A vote event whose handler fails non-critically when graphService rejects it.
+ */
+const voteEvent: ProcessedEvent = {
+  $type: 'commit',
+  seq: 42,
+  repo: REPO,
+  time: '2026-08-24T00:00:00.000Z',
+  action: 'create',
+  collection: 'pub.chive.graph.vote',
+  rkey: '3kabc',
+  cid: 'bafyreiabc',
+  record: { proposalUri: `at://${REPO}/pub.chive.graph.nodeProposal/xyz`, vote: 'support' },
+};
+
+describe('createEventProcessor', () => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const indexVote = vi.fn();
+  const dlqAdd = vi.fn();
+
+  const buildOptions = (dlq?: DeadLetterQueue): EventProcessorOptions =>
+    ({
+      pool: { query: vi.fn() },
+      activity: { correlateWithFirehose: vi.fn().mockResolvedValue({ ok: true, value: null }) },
+      eprintService: {},
+      reviewService: {},
+      graphService: { indexVote },
+      identity: { getPDSEndpoint: vi.fn().mockResolvedValue('https://pds.example.com') },
+      logger,
+      dlq,
+    }) as unknown as EventProcessorOptions;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    indexVote.mockResolvedValue({ ok: false, error: new Error('neo4j unavailable') });
+    dlqAdd.mockResolvedValue(1);
+  });
+
+  it('sends non-critical handler failures to the DLQ', async () => {
+    const dlq = { add: dlqAdd } as unknown as DeadLetterQueue;
+    const processor = createEventProcessor(buildOptions(dlq));
+
+    await processor(voteEvent);
+
+    expect(dlqAdd).toHaveBeenCalledTimes(1);
+    const [event, error, retryCount] = dlqAdd.mock.calls[0] as [
+      ProcessedEvent,
+      EventProcessingError,
+      number,
+    ];
+    expect(event.seq).toBe(42);
+    expect(event.collection).toBe('pub.chive.graph.vote');
+    expect(error).toBeInstanceOf(EventProcessingError);
+    expect(error.critical).toBe(false);
+    expect(error.uri).toBe(`at://${REPO}/pub.chive.graph.vote/3kabc`);
+    expect(retryCount).toBe(0);
+  });
+
+  it('does not rethrow when the DLQ accepts the failure', async () => {
+    const dlq = { add: dlqAdd } as unknown as DeadLetterQueue;
+    const processor = createEventProcessor(buildOptions(dlq));
+
+    await expect(processor(voteEvent)).resolves.toBeUndefined();
+  });
+
+  it('warns that the record is dropped when no DLQ is configured', async () => {
+    const processor = createEventProcessor(buildOptions(undefined));
+
+    await processor(voteEvent);
+
+    expect(dlqAdd).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('no DLQ configured'),
+      expect.objectContaining({ collection: 'pub.chive.graph.vote' })
+    );
+  });
+
+  it('still processes the event when the DLQ write itself fails', async () => {
+    dlqAdd.mockRejectedValue(new Error('postgres down'));
+    const dlq = { add: dlqAdd } as unknown as DeadLetterQueue;
+    const processor = createEventProcessor(buildOptions(dlq));
+
+    await expect(processor(voteEvent)).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to send event to DLQ',
+      expect.any(Error),
+      expect.objectContaining({ collection: 'pub.chive.graph.vote' })
+    );
+  });
+});

--- a/tests/unit/services/knowledge-graph/proposal-error-propagation.test.ts
+++ b/tests/unit/services/knowledge-graph/proposal-error-propagation.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for proposal read-failure propagation.
+ *
+ * @remarks
+ * `listProposals` used to swallow every error and return an empty page, which
+ * the UI renders as "no proposals found" with HTTP 200 and which the moderation
+ * badge reads as a zero backlog; `getProposalById` used to return null, which
+ * handlers turn into a 404. Both now surface a typed error so callers can
+ * answer 5xx, while a genuinely absent proposal still reads as null.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { KnowledgeGraphService } from '@/services/knowledge-graph/graph-service.js';
+import { DatabaseError } from '@/types/errors.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+const RKEY = '3mlbhk6h2ne2k';
+const URI = `at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.graph.nodeProposal/${RKEY}`;
+
+const createLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+describe('KnowledgeGraphService proposal read failures', () => {
+  let graph: {
+    listProposals: ReturnType<typeof vi.fn>;
+    getProposal: ReturnType<typeof vi.fn>;
+    getProposalByRkey: ReturnType<typeof vi.fn>;
+  };
+  let logger: ILogger;
+  let service: KnowledgeGraphService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    graph = {
+      listProposals: vi.fn(),
+      getProposal: vi.fn().mockResolvedValue(null),
+      getProposalByRkey: vi.fn().mockResolvedValue(null),
+    };
+    logger = createLogger();
+    service = new KnowledgeGraphService({ graph: graph as never, logger } as never);
+  });
+
+  describe('listProposals', () => {
+    it('should propagate a graph outage as a DatabaseError', async () => {
+      graph.listProposals.mockRejectedValue(new Error('Neo4j unavailable'));
+
+      await expect(service.listProposals({})).rejects.toBeInstanceOf(DatabaseError);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('should preserve a typed error raised by the adapter', async () => {
+      const adapterError = new DatabaseError('QUERY', 'connection pool exhausted');
+      graph.listProposals.mockRejectedValue(adapterError);
+
+      await expect(service.listProposals({})).rejects.toBe(adapterError);
+    });
+
+    it('should still return an empty page when the graph holds no proposals', async () => {
+      graph.listProposals.mockResolvedValue({ proposals: [], total: 0, hasMore: false, offset: 0 });
+
+      const result = await service.listProposals({});
+
+      expect(result).toEqual({
+        proposals: [],
+        cursor: undefined,
+        hasMore: false,
+        total: 0,
+      });
+    });
+  });
+
+  describe('getProposalById', () => {
+    it('should propagate a read failure rather than reporting the proposal as missing', async () => {
+      graph.getProposalByRkey.mockRejectedValue(new Error('Neo4j unavailable'));
+
+      await expect(service.getProposalById(RKEY)).rejects.toBeInstanceOf(DatabaseError);
+    });
+
+    it('should propagate a read failure for the AT-URI lookup too', async () => {
+      graph.getProposal.mockRejectedValue(new Error('Neo4j unavailable'));
+
+      await expect(service.getProposalById(URI)).rejects.toBeInstanceOf(DatabaseError);
+    });
+
+    it('should still return null when the proposal genuinely does not exist', async () => {
+      expect(await service.getProposalById(RKEY)).toBeNull();
+    });
+  });
+});

--- a/tests/unit/storage/neo4j/proposal-mapping.test.ts
+++ b/tests/unit/storage/neo4j/proposal-mapping.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for proposal row mapping in the Neo4j adapter.
+ *
+ * @remarks
+ * A proposal row whose `proposerDid` does not parse used to abort the enclosing
+ * query, so one malformed row emptied the whole governance list. The row is now
+ * skipped for list queries and reported as a read failure for single-record
+ * lookups, where a null would otherwise be rendered as a 404.
+ */
+
+import 'reflect-metadata';
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+import { Neo4jAdapter } from '@/storage/neo4j/adapter.js';
+import type { Neo4jConnection } from '@/storage/neo4j/connection.js';
+import type { AtUri } from '@/types/atproto.js';
+import { DatabaseError } from '@/types/errors.js';
+
+interface MockRecord {
+  get: (key: string) => unknown;
+}
+
+const createProposalRecord = (overrides: Record<string, unknown> = {}): MockRecord => {
+  const properties = {
+    id: 'rkey-good',
+    uri: 'at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.graph.nodeProposal/rkey-good',
+    proposalType: 'create',
+    kind: 'type',
+    subkind: 'field',
+    rationale: 'because',
+    status: 'pending',
+    proposerDid: 'did:plc:izttpdp3l6vss5crelt5kcux',
+    createdAt: '2026-05-07T14:48:40.171Z',
+    ...overrides,
+  };
+
+  return { get: (key: string): unknown => (key === 'p' ? { properties } : undefined) };
+};
+
+const countRecord = (total: number): MockRecord => ({ get: (): unknown => total });
+
+describe('Neo4jAdapter proposal mapping', () => {
+  let executeQuery: Mock;
+  let adapter: Neo4jAdapter;
+
+  beforeEach(() => {
+    executeQuery = vi.fn();
+    adapter = new Neo4jAdapter({ executeQuery } as unknown as Neo4jConnection);
+  });
+
+  describe('listProposals', () => {
+    it('should skip an unmappable row instead of emptying the page', async () => {
+      executeQuery
+        .mockResolvedValueOnce({
+          records: [
+            createProposalRecord({ proposerDid: 'not-a-did' }),
+            createProposalRecord({ id: 'rkey-good' }),
+          ],
+        })
+        .mockResolvedValueOnce({ records: [countRecord(2)] });
+
+      const result = await adapter.listProposals({ limit: 50 });
+
+      expect(result.proposals).toHaveLength(1);
+      expect(result.proposals[0]?.id).toBe('rkey-good');
+      expect(result.total).toBe(2);
+    });
+
+    it('should decide pagination on raw rows so a skipped row does not end it early', async () => {
+      // The query asks for limit + 1 rows; the extra row is the next-page probe.
+      executeQuery
+        .mockResolvedValueOnce({
+          records: [
+            createProposalRecord({ id: 'rkey-a' }),
+            createProposalRecord({ id: 'rkey-b', proposerDid: 'not-a-did' }),
+            createProposalRecord({ id: 'rkey-c' }),
+          ],
+        })
+        .mockResolvedValueOnce({ records: [countRecord(9)] });
+
+      const result = await adapter.listProposals({ limit: 2 });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.proposals.map((p) => p.id)).toEqual(['rkey-a']);
+    });
+  });
+
+  describe('getProposal', () => {
+    it('should report an unmappable row as a read failure, not as absent', async () => {
+      executeQuery.mockResolvedValueOnce({
+        records: [createProposalRecord({ proposerDid: 'not-a-did' })],
+      });
+
+      await expect(adapter.getProposal('at://did:plc:x/c/rkey' as AtUri)).rejects.toBeInstanceOf(
+        DatabaseError
+      );
+    });
+
+    it('should still return null when no row matches', async () => {
+      executeQuery.mockResolvedValueOnce({ records: [] });
+
+      expect(await adapter.getProposal('at://did:plc:x/c/rkey' as AtUri)).toBeNull();
+    });
+  });
+
+  describe('getProposalByRkey', () => {
+    it('should report an unmappable row as a read failure, not as absent', async () => {
+      executeQuery.mockResolvedValueOnce({
+        records: [createProposalRecord({ proposerDid: 'not-a-did' })],
+      });
+
+      await expect(adapter.getProposalByRkey('rkey-good')).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
+  describe('getProposalsForNode', () => {
+    it('should drop an unmappable row and keep the rest', async () => {
+      executeQuery.mockResolvedValueOnce({
+        records: [
+          createProposalRecord({ id: 'rkey-a' }),
+          createProposalRecord({ id: 'rkey-b', proposerDid: '' }),
+        ],
+      });
+
+      const proposals = await adapter.getProposalsForNode('at://did:plc:x/c/node' as AtUri);
+
+      expect(proposals.map((p) => p.id)).toEqual(['rkey-a']);
+    });
+  });
+});

--- a/web/lib/atproto/record-creator.test.ts
+++ b/web/lib/atproto/record-creator.test.ts
@@ -342,6 +342,36 @@ describe('createVoteRecord', () => {
       })
     );
   });
+
+  // VoteRecord carries an index signature, so a misnamed wire field typechecks
+  // silently; only an assertion on the emitted record catches the regression.
+  it('writes the rationale to the lexicon comment field', async () => {
+    const agent = createMockAgent();
+
+    await createVoteRecord(agent, {
+      proposalUri: 'at://did:plc:user/pub.chive.graph.fieldProposal/123',
+      vote: 'approve',
+      rationale: 'This is a well-defined field.',
+    });
+
+    const createRecordCall = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(createRecordCall.record.comment).toBe('This is a well-defined field.');
+    expect(createRecordCall.record.rationale).toBeUndefined();
+  });
+
+  it('omits the comment field when no rationale is given', async () => {
+    const agent = createMockAgent();
+
+    await createVoteRecord(agent, {
+      proposalUri: 'at://did:plc:user/pub.chive.graph.fieldProposal/123',
+      vote: 'reject',
+    });
+
+    const createRecordCall = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(createRecordCall.record).not.toHaveProperty('comment');
+  });
 });
 
 describe('deleteRecord', () => {

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -212,13 +212,19 @@ export interface FieldProposalRecord {
 
 /**
  * Vote record as stored in ATProto.
+ *
+ * @remarks
+ * The free-text justification is named `comment` on the wire because that is
+ * what the `pub.chive.graph.vote` lexicon defines and what the indexer reads.
+ * The UI and form schemas call it `rationale`; {@link createVoteRecord} maps
+ * between the two so the naming divergence stops at this boundary.
  */
 export interface VoteRecord {
   [key: string]: unknown;
   $type: 'pub.chive.graph.vote';
   proposalUri: string;
   vote: 'approve' | 'reject' | 'abstain' | 'request-changes';
-  rationale?: string;
+  comment?: string;
   createdAt: string;
 }
 
@@ -702,6 +708,10 @@ export async function createFieldProposalRecord(
  * Records a vote on a governance proposal.
  * The vote is stored in the voter's PDS and indexed by Chive for tallying.
  *
+ * The caller supplies `rationale`, matching the form and UI vocabulary; it is
+ * written to the lexicon's `comment` field, which is the only one the indexer
+ * reads.
+ *
  * @param agent - Authenticated ATProto Agent
  * @param data - Vote data
  * @returns Created record result
@@ -735,7 +745,7 @@ export async function createVoteRecord(
   };
 
   if (data.rationale) {
-    record.rationale = data.rationale;
+    record.comment = data.rationale;
   }
 
   const response = await agent.com.atproto.repo.createRecord({

--- a/web/lib/hooks/use-governance.test.ts
+++ b/web/lib/hooks/use-governance.test.ts
@@ -15,6 +15,7 @@ import {
   governanceKeys,
   useMyEditorStatus,
   useEditorStatus,
+  useMyVote,
   useTrustedEditors,
   useRequestElevation,
   useGrantDelegation,
@@ -26,6 +27,7 @@ import {
 // Mock functions using vi.hoisted for proper hoisting
 const {
   mockGetEditorStatus,
+  mockGetUserVote,
   mockAuthGetEditorStatus,
   mockListTrustedEditors,
   mockRequestElevation,
@@ -34,6 +36,7 @@ const {
   mockRevokeRole,
 } = vi.hoisted(() => ({
   mockGetEditorStatus: vi.fn(),
+  mockGetUserVote: vi.fn(),
   mockAuthGetEditorStatus: vi.fn(),
   mockListTrustedEditors: vi.fn(),
   mockRequestElevation: vi.fn(),
@@ -48,9 +51,7 @@ vi.mock('@/lib/api/client', () => ({
       chive: {
         governance: {
           getEditorStatus: mockGetEditorStatus,
-          requestElevation: mockRequestElevation,
-          grantDelegation: mockGrantDelegation,
-          revokeDelegation: mockRevokeDelegation,
+          getUserVote: mockGetUserVote,
         },
       },
     },
@@ -61,6 +62,9 @@ vi.mock('@/lib/api/client', () => ({
         governance: {
           getEditorStatus: mockAuthGetEditorStatus,
           listTrustedEditors: mockListTrustedEditors,
+          requestElevation: mockRequestElevation,
+          grantDelegation: mockGrantDelegation,
+          revokeDelegation: mockRevokeDelegation,
           revokeRole: mockRevokeRole,
         },
       },
@@ -104,6 +108,15 @@ const createMockTrustedEditorsResponse = (editors = [createMockEditorStatus()]) 
 describe('governanceKeys', () => {
   it('generates all key', () => {
     expect(governanceKeys.all).toEqual(['governance']);
+  });
+
+  it('generates proposals key as a prefix of every proposals list key', () => {
+    // Invalidation after a vote relies on this prefix relationship: proposalsList()
+    // with no params carries a trailing `undefined` that partial-matches nothing.
+    const params = { status: 'open' as const };
+    expect(governanceKeys.proposals()).toEqual(['governance', 'proposals']);
+    expect(governanceKeys.proposalsList(params).slice(0, 2)).toEqual(governanceKeys.proposals());
+    expect(governanceKeys.proposalsList()).toEqual(['governance', 'proposals', 'list', undefined]);
   });
 
   it('generates trustedEditors key', () => {
@@ -243,6 +256,64 @@ describe('useEditorStatus', () => {
 
     expect(result.current.fetchStatus).toBe('idle');
     expect(mockGetEditorStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('useMyVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null for the #noVote sentinel', async () => {
+    mockGetUserVote.mockResolvedValueOnce({
+      data: { vote: { $type: 'pub.chive.governance.getUserVote#noVote' } },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useMyVote('proposal-1', 'did:plc:user123'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it('returns the vote for the #voteView member', async () => {
+    mockGetUserVote.mockResolvedValueOnce({
+      data: {
+        vote: {
+          $type: 'pub.chive.governance.getUserVote#voteView',
+          id: 'vote-1',
+          uri: 'at://did:plc:user123/pub.chive.graph.vote/vote-1',
+          cid: 'bafyvote',
+          proposalUri: 'at://did:plc:author/pub.chive.graph.nodeProposal/proposal-1',
+          voterDid: 'did:plc:user123',
+          voterRole: 'community-member',
+          vote: 'approve',
+          weight: 1,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useMyVote('proposal-1', 'did:plc:user123'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.id).toBe('vote-1');
+    expect(result.current.data?.vote).toBe('approve');
+    expect(mockGetUserVote).toHaveBeenCalledWith({
+      proposalId: 'proposal-1',
+      userDid: 'did:plc:user123',
+    });
   });
 });
 

--- a/web/lib/hooks/use-governance.ts
+++ b/web/lib/hooks/use-governance.ts
@@ -34,6 +34,7 @@ import { APIError } from '@/lib/errors';
 import { api, authApi } from '@/lib/api/client';
 import { getCurrentAgent } from '@/lib/auth/oauth-client';
 import { createVoteRecord, createNodeProposalRecord } from '@/lib/atproto/record-creator';
+import type { VoteView as UserVoteView } from '@/lib/api/generated/types/pub/chive/governance/getUserVote';
 import type {
   Vote as RecordCreatorVote,
   NodeProposal as RecordCreatorNodeProposal,
@@ -381,9 +382,20 @@ export function useMyVote(proposalId: string, userDid: string, options: UseGover
     queryFn: async (): Promise<Vote | null> => {
       try {
         const response = await api.pub.chive.governance.getUserVote({ proposalId, userDid });
-        // The API returns a VoteView with a different $type discriminator than listVotes.
-        // Cast to Vote since they share the same structural shape.
-        return (response.data?.vote as Vote) ?? null;
+        const vote = response.data?.vote;
+        // The handler answers "this user has not voted" with a `#noVote` sentinel
+        // rather than omitting the field, so the union must be narrowed on its
+        // discriminator. Accepting the sentinel as a cast vote would hide the
+        // voting UI from every user who has yet to vote.
+        if (vote?.$type !== 'pub.chive.governance.getUserVote#voteView') {
+          return null;
+        }
+        // getUserVote#voteView and listVotes#voteView (exported as Vote) are the
+        // same shape under different discriminators, so re-tag rather than reshape.
+        return {
+          ...(vote as UserVoteView),
+          $type: 'pub.chive.governance.listVotes#voteView',
+        };
       } catch (error) {
         if (error instanceof APIError && error.statusCode === 404) {
           return null;
@@ -636,8 +648,10 @@ export function useCreateVote() {
         queryClient.invalidateQueries({
           queryKey: governanceKeys.votes(proposalId),
         });
+        // Invalidate the whole proposals subtree: proposalsList() with no params
+        // yields a trailing `undefined` element that matches no cached list query.
         queryClient.invalidateQueries({
-          queryKey: governanceKeys.proposalsList(),
+          queryKey: governanceKeys.proposals(),
         });
       }, 1000);
     },
@@ -799,7 +813,7 @@ export function useRequestElevation() {
   return useMutation({
     mutationFn: async (): Promise<ElevationResult> => {
       try {
-        const response = await api.pub.chive.governance.requestElevation({
+        const response = await authApi.pub.chive.governance.requestElevation({
           targetRole: 'trusted-editor',
         });
         return response.data;
@@ -840,7 +854,7 @@ export function useGrantDelegation() {
   return useMutation({
     mutationFn: async (input: GrantDelegationInput): Promise<DelegationResult> => {
       try {
-        const response = await api.pub.chive.governance.grantDelegation({
+        const response = await authApi.pub.chive.governance.grantDelegation({
           delegateDid: input.delegateDid,
           collections: input.collections,
           daysValid: input.daysValid ?? 365,
@@ -883,7 +897,7 @@ export function useRevokeDelegation() {
   return useMutation({
     mutationFn: async (input: RevokeDelegationInput): Promise<DelegationResult> => {
       try {
-        const response = await api.pub.chive.governance.revokeDelegation({
+        const response = await authApi.pub.chive.governance.revokeDelegation({
           delegationId: input.delegationId,
         });
         return response.data;


### PR DESCRIPTION
## Summary

Wave 1 of the governance remediation backlog (`notes/backlog-governance-remediation.md`): **G-01, G-05, G-06, G-07, G-08, G-09, G-10, G-15, G-16, G-17, G-18**. Implemented by a swarm with disjoint file ownership, then adversarially reviewed; two blocking findings were fixed before this PR.

### Ingestion durability
- **G-01** — the indexer's event processor was constructed with no DLQ, and every graph/governance handler returns `critical: false`, so a failed write was logged once and discarded *after* the cursor had advanced. A `DeadLetterQueue` is now wired in, and omitting one logs a warning instead of looking benign.
- **Schema drift found during review (blocking).** `DeadLetterQueue.add` inserts `seq`, `repo_did`, `event_type` and `error_type`, and no migration creates any of them. Production acquired the columns out of band, so the drift was invisible there while any database built from migrations — CI, a fresh deploy, a restored backup — raised `column "seq" does not exist` on every write, swallowed into a log line. Migration `1741600000000_firehose-dlq-event-columns.ts` adds them idempotently, so it is a no-op against the drifted production table. Without this, G-01 would have worked in production and silently failed everywhere else.

### Outages must not look like empty results
- **G-05** — `listProposals` returned `{proposals: [], total: 0}` on any error, so a Neo4j outage rendered as "No proposals found" with HTTP 200 and the moderation badge silently read zero. Errors now propagate as typed errors.
- **G-06** — `getProposalById` returned `null` on error, which the handler converted to a 404. `null` now means only "no such proposal".
- **G-07** — one unmappable row threw and emptied the entire proposal list; `mapNeo4jProposal` now skips and logs it.
- **G-08** — `GovernanceSyncJob` counted only successes and always reported `status:'success'`; it now counts failures and reports `partial`.

### Governance authorization
- **G-09** — `ADMIN_DIDS` was parsed in three places with two behaviours: both seeding paths fell back to a hardcoded DID, the governance service did not. On a deployment that never sets it — the documented normal case, and how production is configured — a platform admin existed while governance recognised no administrator, leaving every privileged endpoint unreachable with nothing able to bootstrap one. **This was the second blocking review finding.** Fixed with a single shared resolver, `src/config/admin.ts`, used by all three paths rather than a fourth copy.
- **G-10** — `admin.assignRole` accepted governance roles that only reached Redis, which no governance code reads, reporting success for a no-op grant.

### Frontend
- **G-15** — `useMyVote` treated the `#noVote` sentinel as a real vote, permanently hiding the voting UI for anyone who had not voted.
- **G-16** — vote comments were written to `rationale` while the lexicon and indexer read `comment`, so every comment was silently discarded.
- **G-17** — `requestElevation`, `grantDelegation` and `revokeDelegation` called auth-required endpoints through the unauthenticated client.
- **G-18** — post-vote cache invalidation used a key with an undefined trailing element and matched nothing, so vote counts stayed stale.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- Full unit suite green: **4074 passed, 2 skipped** (up from 4035; wave 1 adds 39 tests).
- `tsc --noEmit` clean, prettier clean, eslint clean across all 22 changed files.
- Each change was reviewed by an independent agent instructed to find regressions — changed signatures with unupdated callers, newly-thrown errors no caller handles, behaviour changes tests do not cover. Four of six approved outright; the two blocking findings above were verified against the code by hand and fixed.

## Checklist

### General
- [x] Self-review
- [x] Lint passes
- [x] Tests added/updated for changes
- [x] All new and existing tests pass
- [x] Documentation updated (TSDoc explaining rationale on each change)

### ATProto Compliance
- [x] Compliance tests pass
- [x] No writes to user PDSes
- [x] BlobRef storage only
- [x] Indexes can be rebuilt from firehose — G-01 and the DLQ migration restore the recovery path that made this true in practice
- [x] PDS source is tracked for staleness detection

### Breaking Changes
- [x] N/A — errors that were previously swallowed now surface as 5xx, which is the intent; no data migration beyond the additive DLQ columns

## Known follow-ups (not in this PR)

- **New P0 found during implementation:** `indexer.ts` has no `edgeService`, so every governance `pub.chive.graph.edge` create/update/delete is a silent no-op — it does not fail, so the DLQ wired here will never see it. Fixing it changes behaviour (governance edges would start reaching Neo4j where today they vanish), so it warrants its own review.
- `triggerGovernanceSync.ts` should call `failOperation` on a partial cycle now that G-08 reports one.
- Schema drift is systemic: nothing verifies that a migration-built database matches production. The DLQ table was one instance; there may be others.
