### PR TITLE
Release 0.8.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ NEO4J_PASSWORD=chive_test_password
 # ATProto Configuration
 ATPROTO_RELAY_URL=wss://bsky.network
 ATPROTO_PDS_URL=https://bsky.social
-GRAPH_PDS_DID=did:plc:chive-governance
+GRAPH_PDS_DID=did:plc:5wzpn4a4nbqtz3q45hyud6hd
 
 # CORS Configuration
 # The API automatically allows localhost/127.0.0.1 variants.

--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ ORCID_CLIENT_ID=
 ORCID_CLIENT_SECRET=
 # ORCID base URL: use https://sandbox.orcid.org for testing, https://orcid.org for production
 ORCID_BASE_URL=https://orcid.org
-# Override the OAuth callback URI (defaults to {API_BASE_URL}/api/v1/auth/orcid/callback)
+# Override the OAuth callback URI (defaults to {API_BASE_URL}/v1/auth/orcid/callback)
 ORCID_REDIRECT_URI=
 DOI_REGISTRATION_ENDPOINT=
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+# Dependabot configuration.
+#
+# The dependency tree carries a large backlog of transitive advisories, most of
+# them in dev and docs tooling. Grouping updates keeps that from arriving as
+# hundreds of separate pull requests: production dependencies are grouped
+# separately from development ones so a runtime change is never buried in a
+# batch of tooling bumps, and the two workspaces that hold their own manifests
+# are covered explicitly, since Dependabot does not follow pnpm workspaces from
+# the root.
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+    open-pull-requests-limit: 5
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types: [minor, patch]
+      development-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+    labels: [dependencies, security]
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+    open-pull-requests-limit: 5
+    groups:
+      web-dependencies:
+        patterns: ['*']
+        update-types: [minor, patch]
+    labels: [dependencies, frontend]
+
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+    open-pull-requests-limit: 3
+    groups:
+      docs-dependencies:
+        patterns: ['*']
+        update-types: [minor, patch]
+    labels: [dependencies, documentation]
+
+  # Workflow actions pin to tags that go stale and are a supply-chain surface in
+  # their own right.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns: ['*']
+    labels: [dependencies, ci]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-pnpm
 
+      # Without `--coverage` the frontend thresholds in web/vitest.config.ts are
+      # never evaluated, which is how the coverage bar came to be unenforced end
+      # to end despite being stated in the project docs.
       - name: Run frontend tests
-        run: pnpm --filter @chive/web test
+        run: pnpm --filter @chive/web test -- --coverage
 
   # ==============================================================================
   # Stage 3: Integration Tests (requires all 4 database services)

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -229,7 +229,12 @@ jobs:
 
             # Force-remove any leftover chive containers (catches orphans from profile changes or failed deploys)
             echo "Removing any leftover chive containers..."
-            docker ps -a --filter "name=chive-" -q | xargs docker rm -f 2>/dev/null || true
+            # `chive-test-*` is the developer test stack (docker/docker-compose.yml).
+            # It shares the `chive-` prefix, so exclude it by name rather than
+            # letting this sweep destroy a running test stack on the same host.
+            docker ps -a --filter "name=chive-" --format '{{.Names}}' \
+              | grep -v '^chive-test-' \
+              | xargs -r docker rm -f 2>/dev/null || true
 
             # Start all services including observability stack
             # --force-recreate ensures containers use the newly built images

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -271,7 +271,12 @@ jobs:
 
             # Force-remove any leftover chive containers (catches orphans from failed deploys)
             echo "Removing any leftover chive containers..."
-            docker ps -a --filter "name=chive-" -q | xargs docker rm -f 2>/dev/null || true
+            # `chive-test-*` is the developer test stack (docker/docker-compose.yml).
+            # It shares the `chive-` prefix, so exclude it by name rather than
+            # letting this sweep destroy a running test stack on the same host.
+            docker ps -a --filter "name=chive-" --format '{{.Names}}' \
+              | grep -v '^chive-test-' \
+              | xargs -r docker rm -f 2>/dev/null || true
 
             # Deploy docs build
             echo "Deploying docs build..."

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -50,6 +50,27 @@ jobs:
           echo "Response: $response"
           echo "status=healthy" >> $GITHUB_OUTPUT
 
+      # `/api/health` is a static 200 that reports nothing about dependencies.
+      # `/ready` is the readiness probe Kubernetes uses and the only endpoint
+      # that actually checks PostgreSQL, Elasticsearch, Neo4j and Redis, so
+      # without it a datastore outage was invisible to this workflow: the API
+      # answered 200 from a pod that could not serve a single query.
+      - name: Check API Readiness
+        id: api_ready
+        continue-on-error: true
+        run: |
+          domain="${{ vars.DOMAIN }}"
+          echo "Checking API readiness at https://$domain/api/ready..."
+
+          response=$(curl -sf --max-time 30 "https://$domain/api/ready" 2>&1) || {
+            echo "status=failed" >> $GITHUB_OUTPUT
+            echo "error=API readiness check failed (a datastore is unreachable)" >> $GITHUB_OUTPUT
+            exit 1
+          }
+
+          echo "Response: $response"
+          echo "status=ready" >> $GITHUB_OUTPUT
+
       - name: Check Admin API
         id: admin_health
         continue-on-error: true
@@ -397,6 +418,13 @@ jobs:
           else
             echo "| Admin API | :x: Failed |" >> $GITHUB_STEP_SUMMARY
             failures="${failures}AdminAPI,"
+          fi
+
+          if [ "${{ steps.api_ready.outcome }}" = "success" ]; then
+            echo "| API Readiness | :white_check_mark: Ready |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| API Readiness | :x: Failed |" >> $GITHUB_STEP_SUMMARY
+            failures="${failures}APIReadiness,"
           fi
 
           if [ "${{ steps.web_health.outcome }}" = "success" ]; then

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,138 @@
+# Security scanning.
+#
+# The repository previously had no scanning of any kind — no CodeQL, no
+# dependency audit, no container scan, no dependabot — despite the architecture
+# overview describing one. This workflow supplies the missing visibility.
+#
+# On enforcement: CodeQL gates, because it analyses code this repository owns
+# and a finding there is actionable now. The dependency and container scans
+# report without failing, because the tree currently carries 343 known
+# advisories (8 critical, 141 high), almost all transitive through dev and docs
+# tooling. A gate switched on today would block every pull request on debt that
+# predates it. The scans make that debt visible and dependabot starts reducing
+# it; turning `audit` into a gate is a follow-up once the count is manageable,
+# and the one-line change is marked below.
+name: Security
+
+on:
+  push:
+    branches: [main, staging, develop]
+  pull_request:
+    branches: [main, staging, develop]
+  schedule:
+    # Weekly, so newly disclosed advisories surface without a push.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'
+
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node-pnpm
+
+      # `|| true` is deliberate: see the enforcement note at the top of this
+      # file. Remove it to turn the audit into a gate.
+      - name: Audit dependencies
+        run: pnpm audit --json > audit.json || true
+
+      - name: Summarize advisories
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+
+          try:
+              with open('audit.json') as handle:
+                  report = json.load(handle)
+          except Exception as error:
+              print(f'Could not parse audit output: {error}')
+              raise SystemExit(0)
+
+          advisories = (report.get('advisories') or {}).values()
+          counts = {}
+          for advisory in advisories:
+              severity = advisory.get('severity', 'unknown')
+              counts[severity] = counts.get(severity, 0) + 1
+
+          print('## Dependency audit')
+          print()
+          if not counts:
+              print('No advisories reported.')
+              raise SystemExit(0)
+
+          order = ['critical', 'high', 'moderate', 'low', 'info', 'unknown']
+          print('| Severity | Count |')
+          print('| --- | --- |')
+          for severity in order:
+              if severity in counts:
+                  print(f'| {severity} | {counts[severity]} |')
+
+          critical = [a for a in advisories if a.get('severity') == 'critical']
+          if critical:
+              print()
+              print('### Critical')
+              print()
+              print('| Package | Advisory |')
+              print('| --- | --- |')
+              for advisory in sorted(critical, key=lambda a: a.get('module_name', '')):
+                  title = (advisory.get('title') or '').replace('|', '\\|')
+                  print(f"| `{advisory.get('module_name')}` | {title} |")
+          PY
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-audit
+          path: audit.json
+          retention-days: 30
+
+  filesystem-scan:
+    name: Filesystem Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scanners: vuln,secret,misconfig
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          # Reports rather than gates, for the reason given at the top.
+          exit-code: '0'
+
+      - name: Upload results to the security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-filesystem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-25
+
+Remediation sweep against the 0.8.0 backlog. Fourteen changes, each with tests
+pinning the specific failure. A recurring shape runs through them: work that
+ran, reported success, and had no effect — telemetry recording into an SDK that
+was never started, metrics nothing could scrape, deletions announced to a
+subscriber that was never written, precomputed graph results with no reader.
+
+### Security
+
+- Service auth tokens are verified against the method being called. A JWT's `lxm` claim scopes it to one lexicon method, and the verifier has always accepted a method to check against — the middleware passed none. The claim was decoded, copied into `user.scopes`, which nothing reads, and never enforced, so a token minted for `pub.chive.metrics.recordView` was accepted at `pub.chive.admin.deleteContent`. Any holder of any valid token could call any endpoint their roles allowed.
+- PDS registration requires authentication and is bound to the caller's own identity. The handler was `auth: 'optional'`, and a registered host is later enumerated by the scanner, which indexes whatever repos that host claims to hold. The ownership check resolves the caller's DID document and fails open when resolution is inconclusive, which is recorded rather than hidden.
+- Server-side request forgery through PDS registration and `did:web` resolution is blocked. Both fetched caller-supplied hosts with no scheme allowlist, no private-address block and no redirect cap, reaching cloud metadata at `169.254.169.254`, loopback and RFC 1918 services. Every resolved address is checked, not just the hostname, and redirects are refused.
+- The E2E authentication bypass cannot be enabled in production. `X-E2E-Auth-Did` supplies an identity and `X-E2E-Auth-Admin: true` grants administrative access, with both header names in the production CORS allowlist; an unset environment variable was the only thing between a deploy and an open admin door. It is now gated on `NODE_ENV` as well, and the process refuses to start if the flag is set in production.
+- Stored cross-site scripting through JSON-LD is closed. The Schema.org payload is rendered with `dangerouslySetInnerHTML` and carries eprint titles, abstracts and author names taken from user-controlled PDS records; `JSON.stringify` does not escape `<`, so a title containing `</script>` closed the element and everything after it parsed as markup.
+- CodeQL, a dependency audit and a Trivy filesystem scan now run on every pull request and weekly. The repository had no scanning of any kind despite the architecture overview describing some. CodeQL gates; the dependency audit reports without failing, because the tree carries 343 known advisories (8 critical, 141 high) and a gate nobody can satisfy is one that gets disabled. Dependabot opens the update pull requests.
+
+### Fixed
+
+- `/ready` reports the state of its dependencies. Each probe was raced against a timeout with `.catch(() => undefined)` applied to the racer, so a dependency refusing connections rejected fast, resolved to `undefined`, and was recorded as passing. The endpoint answered 200 with PostgreSQL, Elasticsearch or Neo4j down, and Kubernetes kept routing to the pod. Only a probe that hung past the timeout could ever trip it.
+- The admin full reindex no longer destroys indexed fields. It rebuilt each search document from a hand-rolled nine-field projection, and Elasticsearch replaces whole documents rather than merging, so DOIs, publication status, external identifiers, funding, repositories, related works, supplementary materials, licence and document metadata were wiped from every eprint the reindex touched. It now uses the same mapper as the reindex script. Facets remain empty, because they live on the PDS record and not in the index.
+- Records deleted from their PDS are removed from the index. The freshness worker emitted `record.deletion_detected` and returned success; no subscriber to that event was ever written, so the scan reported a deletion and deleted nothing. `PDSSyncService.markAsDeleted` was already among the worker's own dependencies.
+- Telemetry is started. `initTelemetry` was referenced only in its own documentation, so the OpenTelemetry SDK never initialised, every `withSpan` executed its callback recording nothing, and no OTLP export happened. Both the API and the firehose indexer start it, since they are separate processes.
+- Request rate, latency and error metrics exist and can be scraped. The counter and histogram had no emission site — the middleware computed status and duration and only logged them — and the only exposure was an admin-authenticated XRPC method returning JSON, which Prometheus can neither authenticate against nor parse. `GET /metrics` now serves the exposition format, exempt from rate limiting, with optional bearer-token protection.
+- Cancelling a long-running admin operation cancels it. `startOperation` returns an `AbortSignal` that all seven trigger handlers discarded, so `cancelBackfill` flipped the operation's state in Redis while the loop ran to completion. The four handlers driving a loop locally now honour it, including both loops of the reindex and citation extraction.
+- Soft-deleted eprints no longer appear in author profiles, the counts beside them, field browse, or tag and keyword browse. The partial index the soft-delete migration created for exactly this filter was never used by any read path. The tag lookup needed a join rather than a predicate, since a tag row carries only the eprint URI.
+- Eprint deletion is reversible and reconcilable. It hard-deleted the PostgreSQL row and then removed the Elasticsearch document best-effort; when that failed the row was already gone, so nothing recorded that a document still needed removing and no sweep could find it. Deletion now marks the row, and `reconcileDeletedFromSearch` re-issues the removal.
+- A verified ORCID iD survives indexing. Verification wrote only to `authors_index`, which is rebuilt from the firehose, and both profile upserts assigned `orcid` straight from the incoming record — so a verified value was overwritten, usually with null, on the next profile update. An author who verified before being indexed lost it outright. Verification is now stored in its own table and seeded into new rows.
+- The child-facet hierarchy resolves. `getChildFacets` asked Cypher for `*1..$maxDepth`; a parameter is not accepted as a variable-length bound, so the query was a syntax error and the method threw on every call.
+- Recommendation and collaboration queries match the labels the write side creates. Fields are created as `(:Node:Field)` and were read as `(:FieldNode)`; authors are created as `(:Node:Object:Person)` keyed on `metadata.did` and were read as `(:Author {did})`, so collaboration strength was null for every pair of authors who had in fact collaborated. Cypher returns no rows for a label that matches nothing, so both read as "no data yet". Interest-based paths remain empty: nothing creates `INTERESTED_IN` at all.
+- Precomputed community and trending results are read. Two handlers looked for `services.graphAlgorithmCache`, which `ServerConfig` had no field for and nothing constructed, so `getCommunities` returned an empty list on every request while the graph algorithm job wrote results nobody read.
+- Trending pagination advances. The cursor was parsed only to build the next cursor and never passed to either data source, so every page returned the same entries while the cursor climbed.
+- The ORCID verification flow resolves. The callback is registered at `/v1/auth/orcid/callback` while the default redirect URI pointed at `/api/v1/...`, a prefix only one Traefik router strips.
+- Methods declared as procedures are served on POST. The router ignored a handler's `type` when no lexicon was registered, so a `procedure` was mounted as GET and its POST callers received 404. `pub.chive.claiming.dismissSuggestion`, the concrete victim, also gains the lexicon it never had.
+- Author autocomplete issues one query per page instead of one per hit — up to 75 sequential round trips per keystroke — and faceted browse one query per facet instead of one per edge.
+- Search is billed against the relaxed rate-limit tier. The autocomplete list named `pub.chive.search.searchSubmissions`, a method that does not exist; the real NSID is `pub.chive.eprint.searchSubmissions`, so search never matched and every anonymous request took the low tier.
+- Endorsement views carry the record CID. Handlers returned the literal string `'placeholder'` for a field the lexicon marks required, with a comment claiming the CID was not stored — it has always been stored, and the queries simply did not select it. Optimistic-concurrency writes were comparing against a constant that could never match.
+- The WhiteWind backlink plugin tracks `com.whtwnd.blog.entry`, the collection that exists. It subscribed to `com.whitewind.blog.entry` and so could never have matched a post.
+- The governance PDS DID is validated at load. Every environment file set `did:plc:chive-governance`, which is not a PLC identifier, overriding the correct default — so the governance sync resolved nothing and imported an empty graph. An ill-formed value now fails startup rather than being carried.
+- Thread loads no longer scan the whole review table. `parent_comment` carries a foreign key with no index, and PostgreSQL does not index foreign keys automatically.
+- A second paper login within five minutes no longer hangs. The popup's poll interval and timeout lived only in the promise closure, so the success path could not clear them and a stale timeout closed the next attempt's popup, leaving its promise unsettled.
+
+### Changed
+
+- Manual reindex accepts every collection the firehose indexes. Three lists described "the collections we index" and disagreed; `sync.indexRecord` accepted 13 while the event processor handled 20, so seven were unrecoverable by manual reindex — `pub.chive.graph.edgeProposal` among them. One list now serves both, derived from the event processor's own dispatch and asserted by test.
+- The scheduled health check probes `/ready` as well as `/api/health`. The latter is a static 200 that reports nothing about dependencies, so a datastore outage was invisible to monitoring.
+- `pnpm test` runs the backend suite. The root package is not a workspace member, so `turbo test` reached only the frontend and the command exited zero having run none of the 4,000-plus backend tests.
+- The developer test stack no longer collides with production containers, and the deploy sweep excludes it. Both used `chive-` names — `chive-grobid` identically — and `docker ps --filter "name=chive-"` matched the test stack, so a deploy could delete it mid-run.
+- Frontend coverage is measured and enforced. The config declared no thresholds and CI ran the suite without `--coverage`, so the stated 70% bar was unenforced end to end; the real figure is 41%. Thresholds are set just below current levels as a ratchet, and both configs now record the gap to the documented bar rather than a bare TODO.
+- Every environment variable the code reads is documented — 75 of 103 were not. Three clusters are marked as inert rather than presented as working configuration: the R2/CDN variables select an adapter that is never chosen, the governance PDS writer is never constructed, and the SMTP path is never invoked.
+- The XRPC method verb is resolved once, so the OpenAPI specification and the router cannot disagree and generate a client for a verb the server does not serve.
+
+### Removed
+
+- The second-factor authentication layer. WebAuthn, TOTP and JWT session management — 2,334 lines plus a 688-line authentication service — were unreachable: no route, handler or service imported them, and credentials were held in Redis under TTLs rather than in the tables built for them. No user could enrol, because no endpoint existed. Chive does not offer 2FA; the code and its two tables are gone rather than completed.
+- `document_base64` from the search document. It carried a base64 document body into Elasticsearch — implemented, typed and tested — which contradicts the rule that only BlobRefs are stored. Nothing populated it.
+- The `repo:pub.chive.graph.fieldProposal` scope, for a record type renamed to node/edgeProposal that has no lexicon.
+
 ## [0.7.1] - 2026-08-24
 
 ### Fixed

--- a/docker/.env.production.example
+++ b/docker/.env.production.example
@@ -74,7 +74,7 @@ ATPROTO_RELAY_URL=wss://bsky.network
 # Default PDS for user resolution
 ATPROTO_PDS_URL=https://bsky.social
 # Chive Graph PDS DID (for authority records)
-GRAPH_PDS_DID=did:plc:chive-governance
+GRAPH_PDS_DID=did:plc:5wzpn4a4nbqtz3q45hyud6hd
 
 # -----------------------------------------------------------------------------
 # Application Configuration

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   postgres:
     image: postgres:16-alpine
-    container_name: chive-postgres
+    container_name: chive-test-postgres
     environment:
-      POSTGRES_DB: chive
+      POSTGRES_DB: chive_test
       POSTGRES_USER: chive
       POSTGRES_PASSWORD: chive_test_password
     ports:
@@ -18,7 +18,7 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: chive-redis
+    container_name: chive-test-redis
     ports:
       - "6379:6379"
     volumes:
@@ -31,7 +31,7 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
-    container_name: chive-elasticsearch
+    container_name: chive-test-elasticsearch
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
@@ -49,7 +49,7 @@ services:
 
   neo4j:
     image: neo4j:5-community
-    container_name: chive-neo4j
+    container_name: chive-test-neo4j
     environment:
       NEO4J_AUTH: neo4j/chive_test_password
       NEO4J_PLUGINS: '["apoc", "graph-data-science"]'
@@ -69,7 +69,7 @@ services:
 
   grobid:
     image: lfoppiano/grobid:0.8.2.1-crf
-    container_name: chive-grobid
+    container_name: chive-test-grobid
     restart: unless-stopped
     environment:
       - GROBID_MAX_CONCURRENCY=4

--- a/k8s/base/appview/configmap.yaml
+++ b/k8s/base/appview/configmap.yaml
@@ -32,7 +32,7 @@ data:
   # ATProto
   ATPROTO_RELAY_URL: "wss://bsky.network"
   ATPROTO_PDS_URL: "https://bsky.social"
-  GRAPH_PDS_DID: "did:plc:chive-governance"
+  GRAPH_PDS_DID: "did:plc:5wzpn4a4nbqtz3q45hyud6hd"
 
   # Application
   LOG_LEVEL: "info"

--- a/lexicons/pub/chive/claiming/dismissSuggestion.json
+++ b/lexicons/pub/chive/claiming/dismissSuggestion.json
@@ -1,0 +1,55 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.claiming.dismissSuggestion",
+  "revision": 1,
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Record that the authenticated user does not want to see a particular paper suggestion. The paper is filtered out of future suggestions.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["source", "externalId"],
+          "properties": {
+            "source": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64,
+              "description": "External catalogue the suggestion came from, for example openalex or crossref"
+            },
+            "externalId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 512,
+              "description": "Identifier of the suggested work within that catalogue"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["success"],
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "description": "Whether the suggestion was recorded as dismissed"
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "AuthenticationRequired",
+          "description": "Authentication is required to dismiss a suggestion"
+        },
+        {
+          "name": "InvalidRequest",
+          "description": "The source or external identifier was missing or malformed"
+        }
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dev:indexer": "tsx watch src/indexer.ts",
     "dev:turbo": "turbo dev",
     "build": "turbo build",
-    "test": "turbo test",
+    "test": "pnpm run test:unit && turbo test",
     "test:unit": "vitest run --config vitest.unit.config.ts",
     "test:unit:watch": "vitest --config vitest.unit.config.ts",
     "test:unit:ui": "vitest --ui --config vitest.unit.config.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -135,12 +135,12 @@ export default defineConfig({
         // Database credentials - use env vars if set (CI), otherwise defaults for local
         POSTGRES_USER: process.env.POSTGRES_USER ?? 'chive',
         POSTGRES_PASSWORD: process.env.POSTGRES_PASSWORD ?? 'chive_test_password',
-        POSTGRES_DB: process.env.POSTGRES_DB ?? 'chive',
+        POSTGRES_DB: process.env.POSTGRES_DB ?? 'chive_test',
         POSTGRES_HOST: process.env.POSTGRES_HOST ?? '127.0.0.1',
         POSTGRES_PORT: process.env.POSTGRES_PORT ?? '5432',
         DATABASE_URL:
           process.env.DATABASE_URL ??
-          `postgresql://${process.env.POSTGRES_USER ?? 'chive'}:${process.env.POSTGRES_PASSWORD ?? 'chive_test_password'}@${process.env.POSTGRES_HOST ?? '127.0.0.1'}:${process.env.POSTGRES_PORT ?? '5432'}/${process.env.POSTGRES_DB ?? 'chive'}`,
+          `postgresql://${process.env.POSTGRES_USER ?? 'chive'}:${process.env.POSTGRES_PASSWORD ?? 'chive_test_password'}@${process.env.POSTGRES_HOST ?? '127.0.0.1'}:${process.env.POSTGRES_PORT ?? '5432'}/${process.env.POSTGRES_DB ?? 'chive_test'}`,
         NEO4J_USER: process.env.NEO4J_USER ?? 'neo4j',
         NEO4J_PASSWORD: process.env.NEO4J_PASSWORD ?? 'chive_test_password',
         NEO4J_URI: process.env.NEO4J_URI ?? 'bolt://127.0.0.1:7687',

--- a/scripts/seed-admin.ts
+++ b/scripts/seed-admin.ts
@@ -12,24 +12,16 @@
  */
 
 import { createClient, type RedisClientType } from 'redis';
+import { getAdminDids } from '../src/config/admin.js';
 
-const DEFAULT_ADMIN_DIDS = 'did:plc:34mbm5v3umztwvvgnttvcz6e';
 const ROLE_PREFIX = 'chive:authz:roles:';
 const ASSIGNMENT_PREFIX = 'chive:authz:assignments:';
 
 async function main(): Promise<void> {
   const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  const adminDidsRaw = process.env.ADMIN_DIDS ?? DEFAULT_ADMIN_DIDS;
-
-  const adminDids = adminDidsRaw
-    .split(',')
-    .map((d) => d.trim())
-    .filter(Boolean);
-
-  if (adminDids.length === 0) {
-    console.log('No admin DIDs to seed.');
-    return;
-  }
+  // Resolved through the shared helper so the seeded platform admins and the
+  // governance role service can never disagree about who the admins are.
+  const adminDids = getAdminDids();
 
   console.log(`Connecting to Redis at ${redisUrl}...`);
   const redis: RedisClientType = createClient({ url: redisUrl });

--- a/src/api/handlers/rest/health.ts
+++ b/src/api/handlers/rest/health.ts
@@ -13,7 +13,7 @@
 import type { Context } from 'hono';
 import type { Hono } from 'hono';
 
-import type { DID } from '../../../types/atproto.js';
+import type { AtUri, DID } from '../../../types/atproto.js';
 import { getAppVersion } from '../../../utils/app-version.js';
 import { HEALTH_PATHS } from '../../config.js';
 import type { ChiveEnv } from '../../types/context.js';
@@ -26,6 +26,73 @@ import type { ChiveEnv } from '../../types/context.js';
  * Queries with this DID are expected to return no results.
  */
 const HEALTH_CHECK_DID = 'did:plc:health-check' as DID;
+
+/**
+ * Node URI used for Neo4j connectivity checks.
+ *
+ * @remarks
+ * Synthetic URI that is never expected to match a node; the probe exists only
+ * to force a round trip to Neo4j.
+ */
+const HEALTH_CHECK_NODE_URI = 'health-check-field' as AtUri;
+
+/**
+ * Timeout applied to each dependency probe in the readiness check.
+ */
+const DEPENDENCY_CHECK_TIMEOUT_MS = 5000;
+
+/**
+ * Settlement of a dependency probe, captured without discarding a rejection.
+ */
+type ProbeOutcome = { ok: true } | { ok: false; error: unknown };
+
+/**
+ * Runs a dependency probe under a timeout and surfaces its failure to the caller.
+ *
+ * @param probe - In-flight probe, or `undefined` when the injected service does not
+ *   expose the probe method (partial test doubles)
+ * @returns Resolves once the probe succeeds within {@link DEPENDENCY_CHECK_TIMEOUT_MS}
+ * @throws The probe's rejection reason, or `Error('Timeout')` when it does not settle in time
+ *
+ * @remarks
+ * The probe's settlement is captured with a `then(onFulfilled, onRejected)` pair
+ * before the race rather than a `.catch(() => undefined)` applied to the racer. A
+ * discarded rejection made a dependency that refuses connections outright — which
+ * rejects fast, well inside the timeout — resolve to `undefined` and get recorded
+ * as a passing check, so `/ready` answered 200 while PostgreSQL, Elasticsearch or
+ * Neo4j was down and Kubernetes kept routing traffic to the pod. Only a hang past
+ * the timeout could trip the old race.
+ *
+ * Capturing rather than discarding also keeps the timeout path free of unhandled
+ * rejections when a probe rejects after losing the race.
+ */
+async function runDependencyProbe(probe: Promise<unknown> | undefined): Promise<void> {
+  if (probe === undefined) {
+    return;
+  }
+
+  const settled: Promise<ProbeOutcome> = probe.then(
+    (): ProbeOutcome => ({ ok: true }),
+    (error: unknown): ProbeOutcome => ({ ok: false, error })
+  );
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const outcome = await Promise.race([
+    settled,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error('Timeout')), DEPENDENCY_CHECK_TIMEOUT_MS);
+    }),
+  ]).finally(() => {
+    // Release the timer so a fast probe does not hold the event loop for 5s.
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  });
+
+  if (!outcome.ok) {
+    throw outcome.error instanceof Error ? outcome.error : new Error(String(outcome.error));
+  }
+}
 
 /**
  * Health check response.
@@ -117,13 +184,12 @@ export async function readinessHandler(c: Context<ChiveEnv>): Promise<Response> 
     const services = c.get('services');
     if (services?.eprint) {
       const pgStart = performance.now();
-      // A simple existence check: if the service is available and responds, PostgreSQL is up
-      // In a full implementation, we'd call a health-specific method on the adapter
-      await Promise.race([
-        // Use a dummy query that will fail fast if DB is down
-        services.eprint.getEprintsByAuthor?.(HEALTH_CHECK_DID, { limit: 1 }).catch(() => undefined), // Swallow expected not-found errors
-        new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 5000)),
-      ]);
+      // A simple existence check: if the service is available and responds, PostgreSQL is up.
+      // An unknown author yields an empty list rather than an error, so any rejection here
+      // means the database itself is unreachable and must fail the check.
+      await runDependencyProbe(
+        services.eprint.getEprintsByAuthor?.(HEALTH_CHECK_DID, { limit: 1 })
+      );
       const pgLatency = Math.round(performance.now() - pgStart);
 
       checks.postgresql = {
@@ -153,10 +219,7 @@ export async function readinessHandler(c: Context<ChiveEnv>): Promise<Response> 
     if (services?.search) {
       const esStart = performance.now();
       // A simple search that validates ES connectivity
-      await Promise.race([
-        services.search.search?.({ q: '', limit: 1 }).catch(() => undefined),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 5000)),
-      ]);
+      await runDependencyProbe(services.search.search?.({ q: '', limit: 1 }));
       const esLatency = Math.round(performance.now() - esStart);
 
       checks.elasticsearch = {
@@ -185,11 +248,15 @@ export async function readinessHandler(c: Context<ChiveEnv>): Promise<Response> 
     const services = c.get('services');
     if (services?.graph) {
       const neo4jStart = performance.now();
-      // A simple field query that validates Neo4j connectivity
-      await Promise.race([
-        services.graph.getNode?.('health-check-field').catch(() => undefined),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 5000)),
-      ]);
+      // A simple node lookup that validates Neo4j connectivity. The probe goes through
+      // NodeRepository rather than KnowledgeGraphService because the latter's getNode
+      // catches its own driver errors and returns null, which would report a healthy
+      // Neo4j no matter what. Fall back to the service only when the repository is
+      // absent (partial test doubles).
+      await runDependencyProbe(
+        services.nodeRepository?.getNode?.(HEALTH_CHECK_NODE_URI) ??
+          services.graph.getNode?.(HEALTH_CHECK_NODE_URI)
+      );
       const neo4jLatency = Math.round(performance.now() - neo4jStart);
 
       checks.neo4j = {

--- a/src/api/handlers/rest/index.ts
+++ b/src/api/handlers/rest/index.ts
@@ -10,6 +10,7 @@ import type { Hono } from 'hono';
 import type { ChiveEnv } from '../../types/context.js';
 
 import { registerHealthRoutes } from './health.js';
+import { registerMetricsRoutes } from './metrics.js';
 import { registerV1Routes } from './v1/index.js';
 import { registerWellKnownRoutes } from './well-known.js';
 
@@ -21,6 +22,7 @@ import { registerWellKnownRoutes } from './well-known.js';
  * @remarks
  * Registers:
  * - Health check routes (`/health`, `/ready`)
+ * - Prometheus scrape endpoint (`/metrics`)
  * - Well-known routes (`/.well-known/*`)
  * - REST API v1 routes (`/api/v1/*`)
  *
@@ -28,10 +30,12 @@ import { registerWellKnownRoutes } from './well-known.js';
  */
 export function registerRESTRoutes(app: Hono<ChiveEnv>): void {
   registerHealthRoutes(app);
+  registerMetricsRoutes(app);
   registerWellKnownRoutes(app);
   registerV1Routes(app);
 }
 
 export { registerHealthRoutes, livenessHandler, readinessHandler } from './health.js';
+export { registerMetricsRoutes, METRICS_PATH } from './metrics.js';
 export { registerWellKnownRoutes, standardPublicationHandler } from './well-known.js';
 export { registerV1Routes } from './v1/index.js';

--- a/src/api/handlers/rest/metrics.ts
+++ b/src/api/handlers/rest/metrics.ts
@@ -1,0 +1,55 @@
+/**
+ * Prometheus scrape endpoint.
+ *
+ * @remarks
+ * The service registered Prometheus metrics but exposed no scrape endpoint. The
+ * only way to read them was `pub.chive.admin.getPrometheusMetrics`, an
+ * admin-authenticated XRPC method returning JSON — which Prometheus cannot
+ * scrape, since it speaks neither the auth flow nor that format. The metrics
+ * existed and nothing could collect them.
+ *
+ * Access: the endpoint is unauthenticated by default so an in-network scraper
+ * works without credentials, which is the usual arrangement for a metrics port
+ * on a private network. That is only safe while the endpoint is not reachable
+ * from outside, and this deployment fronts the API with a public router, so
+ * `METRICS_TOKEN` is supported and enforced whenever it is set. Operators
+ * exposing the API publicly should set it, or block `/metrics` at the edge.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type { Hono } from 'hono';
+
+import { getMetrics, metricsContentType } from '../../../observability/prometheus-registry.js';
+import type { ChiveEnv } from '../../types/context.js';
+
+/**
+ * Path the metrics are served on.
+ *
+ * @public
+ */
+export const METRICS_PATH = '/metrics';
+
+/**
+ * Registers the Prometheus scrape endpoint.
+ *
+ * @param app - Hono application instance
+ *
+ * @public
+ */
+export function registerMetricsRoutes(app: Hono<ChiveEnv>): void {
+  app.get(METRICS_PATH, async (c) => {
+    const token = process.env.METRICS_TOKEN?.trim();
+
+    if (token) {
+      const provided = c.req.header('authorization');
+      if (provided !== `Bearer ${token}`) {
+        return c.text('Unauthorized', 401);
+      }
+    }
+
+    const body = await getMetrics();
+    return c.text(body, 200, { 'Content-Type': metricsContentType });
+  });
+}

--- a/src/api/handlers/rest/v1/orcid-auth.ts
+++ b/src/api/handlers/rest/v1/orcid-auth.ts
@@ -153,17 +153,48 @@ export function registerOrcidAuthRoutes(app: Hono<ChiveEnv>): void {
         return c.redirect(buildRedirectUrl('error', { message: 'Internal error' }));
       }
 
-      // Update authors_index with verified ORCID (UPDATE only, since INSERT
-      // would require all NOT NULL columns like pds_url that we don't have here)
+      // Record the verification durably first. `authors_index` is rebuilt from
+      // the firehose, so a verification stored only there is lost the next time
+      // the author's profile is indexed — and, for an author who has not been
+      // indexed yet, the UPDATE below matches no rows and the verification used
+      // to be discarded outright with a log line claiming indexing would pick
+      // it up. Nothing persisted it, so nothing could.
+      //
+      // An ORCID iD identifies one researcher, so a second DID claiming one
+      // already verified is rejected rather than silently reassigned.
+      try {
+        await pool.query(
+          `INSERT INTO orcid_verifications (did, orcid, verified_at)
+           VALUES ($1, $2, NOW())
+           ON CONFLICT (did) DO UPDATE SET orcid = EXCLUDED.orcid, verified_at = NOW()`,
+          [did, orcid]
+        );
+      } catch (insertError) {
+        const message = insertError instanceof Error ? insertError.message : String(insertError);
+        if (message.includes('orcid_verifications_orcid_unique')) {
+          logger.warn('ORCID already verified by a different account', { did, orcid });
+          return c.redirect(
+            buildRedirectUrl('error', {
+              message: 'This ORCID iD is already linked to another account',
+            })
+          );
+        }
+        throw insertError;
+      }
+
+      // Denormalized copy for queries that read the author index.
       const updateResult = await pool.query(
         `UPDATE authors_index SET orcid = $1, orcid_verified_at = NOW() WHERE did = $2`,
         [orcid, did]
       );
 
       if (updateResult.rowCount === 0) {
-        // User not yet in authors_index (not indexed from firehose yet).
-        // Verification still succeeded - it will be picked up when they are indexed.
-        logger.info('ORCID verified but user not yet in authors_index', { did, orcid });
+        // Not indexed yet. The verification is safe in orcid_verifications and
+        // the indexing path reads it when the author's row is first written.
+        logger.info('ORCID verified before the author was indexed; stored for indexing', {
+          did,
+          orcid,
+        });
       }
 
       logger.info('ORCID verification completed', { did, orcid });

--- a/src/api/handlers/rest/v1/orcid-auth.ts
+++ b/src/api/handlers/rest/v1/orcid-auth.ts
@@ -70,7 +70,7 @@ interface OrcidTokenResponse {
  *
  * @remarks
  * Routes:
- * - `GET /api/v1/auth/orcid/callback` - ORCID OAuth redirect callback
+ * - `GET /v1/auth/orcid/callback` - ORCID OAuth redirect callback
  *
  * @public
  */

--- a/src/api/handlers/xrpc/admin/assignRole.ts
+++ b/src/api/handlers/xrpc/admin/assignRole.ts
@@ -2,8 +2,9 @@
  * XRPC handler for pub.chive.admin.assignRole.
  *
  * @remarks
- * Assigns a role to a user via the authorization service.
- * Requires admin authentication.
+ * Assigns a platform role to a user via the authorization service.
+ * Requires admin authentication. Governance roles are rejected here; they are
+ * granted through the pub.chive.governance.* endpoints.
  *
  * @packageDocumentation
  * @public
@@ -24,14 +25,40 @@ interface AssignRoleOutput {
   readonly role: string;
 }
 
+/**
+ * Roles this endpoint can grant.
+ *
+ * @remarks
+ * These are the platform roles held in Redis and read back by the
+ * authentication middleware. Governance roles are deliberately absent: they
+ * live in the `governance_roles` table and are granted through the governance
+ * endpoints, so writing one here would report success while changing nothing
+ * the governance code reads.
+ */
 const VALID_ROLES: readonly string[] = [
   'admin',
   'moderator',
-  'graph-editor',
   'author',
   'reader',
   'alpha-tester',
   'premium',
+];
+
+/**
+ * Roles that only the governance endpoints can grant.
+ *
+ * @remarks
+ * Listed separately from the generic invalid-role case so the caller is told
+ * which endpoint actually grants the role rather than that it does not exist.
+ * `graph-editor` overlaps the platform role vocabulary, which is what made the
+ * silent no-op easy to hit.
+ */
+const GOVERNANCE_ROLES: readonly string[] = [
+  'community-member',
+  'trusted-editor',
+  'graph-editor',
+  'domain-expert',
+  'administrator',
 ];
 
 export const assignRole: XRPCMethod<void, AssignRoleInput, AssignRoleOutput> = {
@@ -45,6 +72,14 @@ export const assignRole: XRPCMethod<void, AssignRoleInput, AssignRoleOutput> = {
 
     if (!input?.did || !input.role) {
       throw new ValidationError('DID and role are required', 'input', 'required');
+    }
+
+    if (GOVERNANCE_ROLES.includes(input.role)) {
+      throw new ValidationError(
+        `Role ${input.role} is a governance role and cannot be assigned here; grant it with pub.chive.governance.approveElevation`,
+        'role',
+        'governance-role'
+      );
     }
 
     if (!VALID_ROLES.includes(input.role)) {

--- a/src/api/handlers/xrpc/admin/triggerCitationExtraction.ts
+++ b/src/api/handlers/xrpc/admin/triggerCitationExtraction.ts
@@ -36,7 +36,7 @@ export const triggerCitationExtraction: XRPCMethod<void, void, unknown> = {
       throw new ServiceUnavailableError('Admin service is not configured');
     }
 
-    const { operation } = await backfillManager.startOperation('citationExtraction');
+    const { operation, signal } = await backfillManager.startOperation('citationExtraction');
 
     logger.info('Citation extraction triggered', { operationId: operation.id });
 
@@ -50,6 +50,13 @@ export const triggerCitationExtraction: XRPCMethod<void, void, unknown> = {
         let hasMore = true;
 
         while (hasMore) {
+          if (signal.aborted) {
+            logger.info('citation extraction cancelled while collecting URIs', {
+              operationId: operation.id,
+            });
+            return;
+          }
+
           const batch = await admin.listImports(batchSize, offset);
           allUris = allUris.concat(batch.items.map((item) => item.uri));
           offset += batchSize;
@@ -60,6 +67,11 @@ export const triggerCitationExtraction: XRPCMethod<void, void, unknown> = {
         let totalExtracted = 0;
 
         for (const eprintUri of allUris) {
+          if (signal.aborted) {
+            logger.info('citation extraction cancelled', { operationId: operation.id });
+            return;
+          }
+
           try {
             const extractionResult = await citationExtraction.extractCitations(eprintUri as AtUri, {
               useCrossref: true,

--- a/src/api/handlers/xrpc/admin/triggerFreshnessScan.ts
+++ b/src/api/handlers/xrpc/admin/triggerFreshnessScan.ts
@@ -31,7 +31,7 @@ export const triggerFreshnessScan: XRPCMethod<void, void, unknown> = {
       throw new ServiceUnavailableError('PDS sync service is not configured');
     }
 
-    const { operation } = await backfillManager.startOperation('freshnessScan');
+    const { operation, signal } = await backfillManager.startOperation('freshnessScan');
 
     logger.info('Freshness scan triggered', { operationId: operation.id });
 
@@ -42,6 +42,11 @@ export const triggerFreshnessScan: XRPCMethod<void, void, unknown> = {
         let refreshed = 0;
 
         for (const uri of staleUris) {
+          if (signal.aborted) {
+            logger.info('freshness scan cancelled', { operationId: operation.id });
+            return;
+          }
+
           const result = await pdsSync.refreshRecord(uri);
           if (result.ok) {
             refreshed++;

--- a/src/api/handlers/xrpc/admin/triggerFullReindex.ts
+++ b/src/api/handlers/xrpc/admin/triggerFullReindex.ts
@@ -7,13 +7,51 @@
  * The actual work runs in the background; the handler returns immediately
  * with the operation ID.
  *
+ * Search documents are built with {@link mapEprintToDocument}, the same mapper
+ * `scripts/reindex-all-eprints.ts` uses. Elasticsearch indexing replaces the
+ * whole document rather than merging into it, so any field a projection omits
+ * is destroyed for every eprint the reindex touches. A hand-rolled projection
+ * here previously wrote about nine fields and thereby wiped DOIs, publication
+ * status, external IDs, funding, repositories, related works, supplementary
+ * materials, license and document metadata across the index.
+ *
  * @packageDocumentation
  * @public
  */
 
+import type { EprintView } from '../../../../services/eprint/eprint-service.js';
+import { mapEprintToDocument } from '../../../../storage/elasticsearch/document-mapper.js';
+import { toTimestamp } from '../../../../types/atproto-validators.js';
 import type { AtUri } from '../../../../types/atproto.js';
 import { AuthorizationError, ServiceUnavailableError } from '../../../../types/errors.js';
+import type { IndexableEprintDocument as SimpleIndexableDocument } from '../../../../types/interfaces/search.interface.js';
+import type { Eprint } from '../../../../types/models/eprint.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/**
+ * Projects an indexed eprint back onto the {@link Eprint} domain model.
+ *
+ * @param stored - Eprint as held by Chive's PostgreSQL index
+ * @returns Domain record accepted by {@link mapEprintToDocument}
+ *
+ * @remarks
+ * PostgreSQL holds every field the Elasticsearch mapper reads except `facets`,
+ * which ride on the PDS record and are never persisted to the index. They are
+ * therefore empty here: restoring facets requires reading the PDS, which is
+ * what `scripts/reindex-all-eprints.ts` does.
+ *
+ * `version` is normalized to the integer form the mapper expects by taking the
+ * major component of a semantic version — the inverse of `integerToSemantic`.
+ */
+function toDomainEprint(stored: EprintView): Eprint {
+  return {
+    ...stored,
+    keywords: stored.keywords ?? [],
+    facets: [],
+    version: typeof stored.version === 'number' ? stored.version : stored.version.major,
+    createdAt: toTimestamp(stored.createdAt),
+  };
+}
 
 export const triggerFullReindex: XRPCMethod<void, void, unknown> = {
   type: 'procedure',
@@ -69,27 +107,16 @@ export const triggerFullReindex: XRPCMethod<void, void, unknown> = {
               continue;
             }
 
-            // Build an IndexableEprintDocument from the stored eprint
-            const primaryAuthor = stored.authors?.find((a) => a.order === 1) ?? stored.authors?.[0];
-            const authorDid = primaryAuthor?.did ?? stored.submittedBy;
-            const authorName = primaryAuthor?.name ?? stored.submittedBy ?? 'Unknown';
+            const document = mapEprintToDocument(toDomainEprint(stored), stored.pdsUrl);
 
-            const fieldNodes =
-              stored.fields
-                ?.filter((f): f is typeof f & { id: string } => f.id !== undefined)
-                .map((f) => ({ id: f.id, label: f.label })) ?? [];
-
-            const result = await searchService.indexEprintForSearch({
-              uri: uri as AtUri,
-              author: authorDid,
-              authorName,
-              title: stored.title,
-              abstract: stored.abstractPlainText ?? '',
-              keywords: (stored.keywords as string[]) ?? [],
-              fieldNodes,
-              createdAt: stored.createdAt ?? new Date(),
-              indexedAt: stored.indexedAt ?? new Date(),
-            });
+            // `ISearchEngine.indexEprint` is typed for the narrow document the
+            // live indexing path writes, but the Elasticsearch adapter accepts
+            // the mapper's full document too and dispatches on it. Widening the
+            // interface is the real fix; until then the cast is what keeps a
+            // reindex from replacing complete documents with partial ones.
+            const result = await searchService.indexEprintForSearch(
+              document as unknown as SimpleIndexableDocument
+            );
 
             if (result.ok) {
               indexed++;

--- a/src/api/handlers/xrpc/admin/triggerFullReindex.ts
+++ b/src/api/handlers/xrpc/admin/triggerFullReindex.ts
@@ -76,7 +76,11 @@ export const triggerFullReindex: XRPCMethod<void, void, unknown> = {
       throw new ServiceUnavailableError('Admin service is not configured');
     }
 
-    const { operation } = await backfillManager.startOperation('fullReindex');
+    // `startOperation` hands back an AbortSignal alongside the operation.
+    // Dropping it meant `admin.cancelBackfill` flipped the operation's state in
+    // Redis while this loop kept running to completion — a cancel button that
+    // reported success and cancelled nothing.
+    const { operation, signal } = await backfillManager.startOperation('fullReindex');
 
     logger.info('Full Elasticsearch reindex triggered', { operationId: operation.id });
 
@@ -90,6 +94,13 @@ export const triggerFullReindex: XRPCMethod<void, void, unknown> = {
         let hasMore = true;
 
         while (hasMore) {
+          if (signal.aborted) {
+            logger.info('Full reindex cancelled while collecting URIs', {
+              operationId: operation.id,
+              collected: allUris.length,
+            });
+            return;
+          }
           const batch = await admin.listImports(batchSize, offset);
           allUris = allUris.concat(batch.items.map((item) => item.uri));
           offset += batchSize;
@@ -100,6 +111,16 @@ export const triggerFullReindex: XRPCMethod<void, void, unknown> = {
         let failed = 0;
 
         for (const uri of allUris) {
+          if (signal.aborted) {
+            logger.info('Full reindex cancelled', {
+              operationId: operation.id,
+              indexed,
+              failed,
+              remaining: allUris.length - indexed - failed,
+            });
+            return;
+          }
+
           try {
             const stored = await eprintService.getEprint(uri as AtUri);
             if (!stored) {

--- a/src/api/handlers/xrpc/admin/triggerPDSScan.ts
+++ b/src/api/handlers/xrpc/admin/triggerPDSScan.ts
@@ -31,7 +31,7 @@ export const triggerPDSScan: XRPCMethod<void, void, unknown> = {
       throw new ServiceUnavailableError('PDS discovery services are not configured');
     }
 
-    const { operation } = await backfillManager.startOperation('pdsScan');
+    const { operation, signal } = await backfillManager.startOperation('pdsScan');
 
     logger.info('PDS scan triggered', { operationId: operation.id });
 
@@ -52,6 +52,11 @@ export const triggerPDSScan: XRPCMethod<void, void, unknown> = {
 
         let recordsProcessed = 0;
         for (const [, scanResult] of scanResults) {
+          if (signal.aborted) {
+            logger.info('PDS scan cancelled', { operationId: operation.id });
+            return;
+          }
+
           if (!(scanResult instanceof Error)) {
             recordsProcessed += scanResult.chiveRecordCount;
           }

--- a/src/api/handlers/xrpc/author/searchAuthors.ts
+++ b/src/api/handlers/xrpc/author/searchAuthors.ts
@@ -49,9 +49,16 @@ async function searchAuthorsInIndex(
     const queryLower = query.toLowerCase();
     const queryWords = queryLower.split(/\s+/).filter(Boolean);
 
+    // One query for the whole page rather than one per hit. This ran on every
+    // keystroke of author autocomplete with a limit of `limit * 3`, so it cost
+    // up to 75 sequential database round trips per character typed, each
+    // waiting on the one before it.
+    const eprintsByUri = await c
+      .get('services')
+      .eprint.getEprints(searchResults.hits.map((hit) => hit.uri));
+
     for (const hit of searchResults.hits) {
-      // Get the full eprint data to access authors
-      const eprint = await c.get('services').eprint.getEprint(hit.uri);
+      const eprint = eprintsByUri.get(hit.uri);
       if (!eprint) continue;
 
       for (const author of eprint.authors) {

--- a/src/api/handlers/xrpc/governance/listProposals.ts
+++ b/src/api/handlers/xrpc/governance/listProposals.ts
@@ -63,34 +63,49 @@ export const listProposals: XRPCMethod<QueryParams, void, OutputSchema> = {
       proposerDids.add(p.proposedBy);
     }
 
-    // Batch lookup node labels
+    // Both of these were labelled "batch lookup" and were sequential awaits, one
+    // round trip per item, so listing a page of proposals cost as many serial
+    // queries as it had distinct nodes and proposers. They are independent
+    // lookups, so they run concurrently.
+    //
+    // A miss is expected — a node may be gone, a proposer may not be a trusted
+    // editor — and leaves the label undefined, which the response tolerates. The
+    // rejection is logged rather than swallowed: an empty catch here made a
+    // datastore outage look identical to a page of unlabelled proposals.
     const nodeLabels = new Map<string, string>();
-    for (const nodeUri of nodeUris) {
-      try {
-        const node = await graphService.getNode(nodeUri);
-        if (node) {
-          nodeLabels.set(nodeUri, node.label);
-        }
-      } catch {
-        // Node not found, label will be undefined
-      }
-    }
-
-    // Batch lookup proposer names from authors_index
     const proposerNames = new Map<string, string>();
     const trustedEditorService = c.get('services').trustedEditor;
-    if (trustedEditorService) {
-      for (const did of proposerDids) {
+
+    await Promise.all([
+      ...[...nodeUris].map(async (nodeUri) => {
         try {
-          const status = await trustedEditorService.getEditorStatus(did as DID);
-          if (status.ok && status.value.displayName) {
-            proposerNames.set(did, status.value.displayName);
+          const node = await graphService.getNode(nodeUri);
+          if (node) {
+            nodeLabels.set(nodeUri, node.label);
           }
-        } catch {
-          // Proposer not found, name will be undefined
+        } catch (error) {
+          logger.debug('Could not resolve node label for proposal listing', {
+            nodeUri,
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
-      }
-    }
+      }),
+      ...(trustedEditorService
+        ? [...proposerDids].map(async (did) => {
+            try {
+              const status = await trustedEditorService.getEditorStatus(did as DID);
+              if (status.ok && status.value.displayName) {
+                proposerNames.set(did, status.value.displayName);
+              }
+            } catch (error) {
+              logger.debug('Could not resolve proposer name for proposal listing', {
+                did,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          })
+        : []),
+    ]);
 
     // Map to API response format with enriched data
     const proposals: ProposalView[] = result.proposals.map((p) => ({

--- a/src/api/handlers/xrpc/graph/browseFaceted.ts
+++ b/src/api/handlers/xrpc/graph/browseFaceted.ts
@@ -103,9 +103,13 @@ export const browseFaceted: XRPCMethod<QueryParams, void, OutputSchema> = {
       const values: { value: string; label?: string; count: number }[] = [];
       const seenUris = new Set<string>();
 
+      // One query per facet rather than one per edge. With a limit of 100 this
+      // was 100 sequential Neo4j round trips for every facet on the page, each
+      // waiting on the one before it.
+      const valueNodes = await nodeService.getNodes(valueEdges.edges.map((e) => e.targetUri));
+
       for (const edge of valueEdges.edges) {
-        // Get the target node (the value node)
-        const valueNode = await nodeService.getNode(edge.targetUri);
+        const valueNode = valueNodes.get(edge.targetUri);
         if (valueNode?.uri) {
           const valueUri = valueNode.uri as string;
 

--- a/src/api/handlers/xrpc/metrics/getTrending.ts
+++ b/src/api/handlers/xrpc/metrics/getTrending.ts
@@ -45,6 +45,13 @@ export const getTrending: XRPCMethod<QueryParams, void, OutputSchema> = {
       fieldUriCount: fieldUriSet?.size ?? 0,
     });
 
+    // The cursor is an offset into the ranked list. It was parsed only at the
+    // end, to build the next cursor, and never passed to either data source, so
+    // every page returned the same first `limit` entries while the cursor kept
+    // advancing — paging that looked like it worked and never moved.
+    const parsedCursor = params.cursor ? Number.parseInt(params.cursor, 10) : 0;
+    const offset = Number.isFinite(parsedCursor) && parsedCursor > 0 ? parsedCursor : 0;
+
     // Try graph algorithm cache first for faster response
     let trendingEntries: { uri: string; score: number; velocity?: number }[] = [];
 
@@ -52,7 +59,7 @@ export const getTrending: XRPCMethod<QueryParams, void, OutputSchema> = {
       try {
         const cachedTrending = await graphAlgorithmCache.getTrending(window);
         if (cachedTrending && cachedTrending.length > 0) {
-          trendingEntries = cachedTrending.slice(0, limit).map((paper) => ({
+          trendingEntries = cachedTrending.slice(offset, offset + limit).map((paper) => ({
             uri: paper.uri as string,
             score: paper.viewCount ?? paper.score,
             velocity: undefined,
@@ -68,7 +75,7 @@ export const getTrending: XRPCMethod<QueryParams, void, OutputSchema> = {
 
     // Fall back to metrics service if no cached data
     if (trendingEntries.length === 0) {
-      const metricsEntries = await metrics.getTrending(window, limit);
+      const metricsEntries = await metrics.getTrending(window, limit, offset);
       trendingEntries = metricsEntries.map((entry) => ({
         uri: entry.uri as string,
         score: entry.score,
@@ -221,7 +228,6 @@ export const getTrending: XRPCMethod<QueryParams, void, OutputSchema> = {
       }
     }
 
-    const offset = params.cursor ? parseInt(params.cursor, 10) : 0;
     const hasMore = validEntries.length >= limit;
 
     const response: OutputSchema = {

--- a/src/api/handlers/xrpc/sync/indexRecord.ts
+++ b/src/api/handlers/xrpc/sync/indexRecord.ts
@@ -35,6 +35,7 @@ import type {
 } from '../../../../lexicons/generated/types/pub/chive/sync/indexRecord.js';
 import type { RecordMetadata } from '../../../../services/eprint/eprint-service.js';
 import { transformPDSRecord } from '../../../../services/eprint/pds-record-transformer.js';
+import { isIndexedCollection } from '../../../../services/indexing/indexed-collections.js';
 import { migrateRecord, needsMigration } from '../../../../services/migration/index.js';
 import type { AtUri, CID, DID } from '../../../../types/atproto.js';
 import {
@@ -171,24 +172,8 @@ export const indexRecord: XRPCMethod<void, InputSchema, OutputSchema> = {
       throw new ValidationError('Can only index your own records', 'uri');
     }
 
-    // Supported collections for manual indexing
-    const supportedCollections = [
-      'pub.chive.eprint.submission',
-      'pub.chive.review.comment',
-      'pub.chive.review.endorsement',
-      'pub.chive.annotation.comment',
-      'pub.chive.annotation.entityLink',
-      'pub.chive.eprint.userTag',
-      'pub.chive.eprint.citation',
-      'pub.chive.eprint.relatedWork',
-      'pub.chive.graph.node',
-      'pub.chive.graph.edge',
-      'pub.chive.graph.nodeProposal',
-      'pub.chive.graph.vote',
-      'pub.chive.actor.profileConfig',
-    ];
-
-    if (!supportedCollections.includes(collection)) {
+    // One shared list rather than a copy that drifts; see indexed-collections.ts.
+    if (!isIndexedCollection(collection)) {
       throw new ValidationError(
         `Collection ${collection} not supported for manual indexing`,
         'uri'

--- a/src/api/handlers/xrpc/sync/registerPDS.ts
+++ b/src/api/handlers/xrpc/sync/registerPDS.ts
@@ -2,8 +2,14 @@
  * XRPC handler for pub.chive.sync.registerPDS.
  *
  * @remarks
- * Allows users to register a PDS for scanning. This ensures records
- * from non-relay PDSes can be discovered and indexed.
+ * Allows an authenticated user to register the PDS they belong to for
+ * scanning. This ensures records from non-relay PDSes can be discovered
+ * and indexed.
+ *
+ * Registration is authenticated: a registered host is later enumerated by
+ * the PDS scanner, which indexes whatever repos that host claims to hold,
+ * so an anonymous caller must not be able to add arbitrary hosts to the
+ * scan registry.
  *
  * @packageDocumentation
  * @public
@@ -13,8 +19,80 @@ import type {
   InputSchema,
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/sync/registerPDS.js';
-import { ServiceUnavailableError, ValidationError } from '../../../../types/errors.js';
+import type { DID } from '../../../../types/atproto.js';
+import {
+  AuthenticationError,
+  ServiceUnavailableError,
+  ValidationError,
+} from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/**
+ * Resolves the PDS endpoint recorded in a DID document.
+ *
+ * @remarks
+ * Mirrors the resolution used by the `indexRecord` handler. Returns `null`
+ * when the DID cannot be resolved — a directory outage, an unsupported DID
+ * method, or a document without an `#atproto_pds` service — so callers can
+ * treat the result as inconclusive rather than as a mismatch.
+ *
+ * @param did - DID whose PDS endpoint should be resolved
+ * @returns The PDS endpoint URL, or null if it could not be determined
+ */
+async function resolvePdsEndpoint(did: DID): Promise<string | null> {
+  try {
+    if (did.startsWith('did:plc:')) {
+      const response = await fetch(`https://plc.directory/${did}`, {
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!response.ok) {
+        return null;
+      }
+      const doc = (await response.json()) as {
+        service?: { id: string; type: string; serviceEndpoint: string }[];
+      };
+      const pdsService = doc.service?.find(
+        (s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'
+      );
+      return pdsService?.serviceEndpoint ?? null;
+    }
+
+    if (did.startsWith('did:web:')) {
+      const domain = did.replace('did:web:', '').replace(/%3A/g, ':');
+      const response = await fetch(`https://${domain}/.well-known/did.json`, {
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!response.ok) {
+        return null;
+      }
+      const doc = (await response.json()) as {
+        service?: { id: string; type: string; serviceEndpoint: string }[];
+      };
+      const pdsService = doc.service?.find(
+        (s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'
+      );
+      return pdsService?.serviceEndpoint ?? null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extracts the host (hostname and port) of a URL for comparison.
+ *
+ * @param url - URL string to parse
+ * @returns Lowercased host, or null if the string is not a parseable URL
+ */
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
 
 /**
  * XRPC method for pub.chive.sync.registerPDS.
@@ -22,7 +100,7 @@ import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
  * @public
  */
 export const registerPDS: XRPCMethod<void, InputSchema, OutputSchema> = {
-  auth: 'optional',
+  auth: true,
   handler: async ({ input, c }): Promise<XRPCResponse<OutputSchema>> => {
     const logger = c.get('logger');
     const user = c.get('user');
@@ -46,6 +124,14 @@ export const registerPDS: XRPCMethod<void, InputSchema, OutputSchema> = {
       );
     }
 
+    // Defense in depth: `auth: true` makes the XRPC adapter reject
+    // unauthenticated requests before this handler runs, so this restates the
+    // invariant for direct invocation. It is checked after the registry probe
+    // so an unavailable registry still reports service unavailability.
+    if (!user) {
+      throw new AuthenticationError('Authentication required');
+    }
+
     // Check if PDS is already registered
     const existing = await registry.getPDS(pdsUrl);
 
@@ -55,7 +141,7 @@ export const registerPDS: XRPCMethod<void, InputSchema, OutputSchema> = {
       // Even if PDS is registered, scan the authenticated user's DID
       // This ensures their historical records get indexed
       let recordsIndexed = 0;
-      if (user && scanner) {
+      if (scanner) {
         try {
           logger.info('Scanning authenticated user DID on existing PDS', { pdsUrl, did: user.did });
           recordsIndexed = await scanner.scanDID(pdsUrl, user.did);
@@ -80,6 +166,37 @@ export const registerPDS: XRPCMethod<void, InputSchema, OutputSchema> = {
       };
 
       return { encoding: 'application/json', body };
+    }
+
+    // Registering a new host adds it to the scan registry, and the scanner
+    // later indexes every repo that host claims to hold. Bind the registration
+    // to the caller's own identity: the host must be the one named in the
+    // caller's DID document.
+    const callerPdsUrl = await resolvePdsEndpoint(user.did);
+    const callerHost = callerPdsUrl ? hostOf(callerPdsUrl) : null;
+    const requestedHost = hostOf(pdsUrl);
+
+    if (callerHost && requestedHost && callerHost !== requestedHost) {
+      logger.warn('Rejected PDS registration for a host the caller does not belong to', {
+        pdsUrl,
+        did: user.did,
+        callerPdsUrl,
+      });
+      throw new ValidationError(
+        'PDS URL does not match the PDS in your DID document',
+        'pdsUrl',
+        'not_your_pds'
+      );
+    }
+
+    if (!callerHost) {
+      // Resolution is inconclusive (directory outage, unsupported DID method,
+      // or a document without a PDS service). Fail open so a transient outage
+      // cannot block indexing, but leave a trace for auditing.
+      logger.warn('Could not resolve caller PDS; registering without ownership check', {
+        pdsUrl,
+        did: user.did,
+      });
     }
 
     // Validate that the URL is reachable
@@ -114,9 +231,9 @@ export const registerPDS: XRPCMethod<void, InputSchema, OutputSchema> = {
 
     logger.info('PDS registered successfully', { pdsUrl });
 
-    // If user is authenticated and scanner is available, scan their DID immediately
+    // If scanner is available, scan the authenticated user's DID immediately
     let recordsIndexed = 0;
-    if (user && scanner) {
+    if (scanner) {
       try {
         logger.info('Scanning authenticated user DID', { pdsUrl, did: user.did });
         recordsIndexed = await scanner.scanDID(pdsUrl, user.did);

--- a/src/api/handlers/xrpc/sync/registerPDS.ts
+++ b/src/api/handlers/xrpc/sync/registerPDS.ts
@@ -25,6 +25,7 @@ import {
   ServiceUnavailableError,
   ValidationError,
 } from '../../../../types/errors.js';
+import { assertFetchableUrl, SsrfBlockedError } from '../../../../utils/ssrf-guard.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 /**
@@ -44,6 +45,7 @@ async function resolvePdsEndpoint(did: DID): Promise<string | null> {
     if (did.startsWith('did:plc:')) {
       const response = await fetch(`https://plc.directory/${did}`, {
         signal: AbortSignal.timeout(10000),
+        redirect: 'error',
       });
       if (!response.ok) {
         return null;
@@ -59,8 +61,11 @@ async function resolvePdsEndpoint(did: DID): Promise<string | null> {
 
     if (did.startsWith('did:web:')) {
       const domain = did.replace('did:web:', '').replace(/%3A/g, ':');
-      const response = await fetch(`https://${domain}/.well-known/did.json`, {
+      // The domain comes from the caller's DID, so it is user-controlled.
+      const didDocUrl = await assertFetchableUrl(`https://${domain}/.well-known/did.json`);
+      const response = await fetch(didDocUrl, {
         signal: AbortSignal.timeout(10000),
+        redirect: 'error',
       });
       if (!response.ok) {
         return null;
@@ -200,10 +205,33 @@ export const registerPDS: XRPCMethod<void, InputSchema, OutputSchema> = {
     }
 
     // Validate that the URL is reachable
+    // The submitted URL is fetched by the server and, once registered, revisited
+    // by the scanner. Reject anything that would point that reach at hosts the
+    // caller cannot get to themselves — cloud metadata, loopback, RFC 1918 —
+    // before the first request goes out. Plain HTTP is tolerated outside
+    // production so local test stacks keep working.
+    let probeUrl: URL;
     try {
-      const response = await fetch(`${pdsUrl}/xrpc/com.atproto.server.describeServer`, {
+      probeUrl = await assertFetchableUrl(`${pdsUrl}/xrpc/com.atproto.server.describeServer`, {
+        allowHttp: process.env.NODE_ENV !== 'production',
+      });
+    } catch (error) {
+      if (error instanceof SsrfBlockedError) {
+        logger.warn('Rejected PDS registration for a non-public URL', {
+          pdsUrl,
+          did: user.did,
+          reason: error.message,
+        });
+        throw new ValidationError(error.message, 'pdsUrl', 'not_publicly_routable');
+      }
+      throw error;
+    }
+
+    try {
+      const response = await fetch(probeUrl, {
         headers: { Accept: 'application/json' },
         signal: AbortSignal.timeout(10000),
+        redirect: 'error',
       });
 
       if (!response.ok) {

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -75,6 +75,30 @@ function extractBearerToken(header: string | undefined): string | null {
  * @public
  */
 /**
+ * Extracts the lexicon method an XRPC request targets.
+ *
+ * @param path - Request path
+ * @returns The NSID for an XRPC route, or undefined for any other path
+ *
+ * @remarks
+ * XRPC routes are mounted as `/xrpc/<nsid>`, so the method name is the segment
+ * after the prefix. REST routes have no lexicon method and pass undefined,
+ * which leaves the token's scope unchecked for them — they are not what `lxm`
+ * scopes.
+ *
+ * @public
+ */
+export function lexiconMethodForPath(path: string): string | undefined {
+  const prefix = '/xrpc/';
+  if (!path.startsWith(prefix)) {
+    return undefined;
+  }
+
+  const nsid = path.slice(prefix.length).split('/')[0]?.split('?')[0];
+  return nsid && nsid.length > 0 ? nsid : undefined;
+}
+
+/**
  * Refuses to start a production process that enables the E2E auth bypass.
  *
  * @throws Error when `ENABLE_E2E_AUTH_BYPASS` is `true` while `NODE_ENV` is
@@ -153,10 +177,21 @@ export function authenticateServiceAuth(
     const endTimer = authMetrics.duration.startTimer({ method: 'service_auth' });
 
     try {
-      // Verify the service auth JWT.
-      // The lxm (lexicon method) claim, when present, is extracted into user
-      // scopes for downstream authorization checks.
-      const result = await verifier.verify(token);
+      // Verify the service auth JWT against the method actually being called.
+      //
+      // The `lxm` claim scopes a service auth token to one lexicon method. The
+      // verifier has always supported checking it, but the method was never
+      // passed, so the claim was decoded, copied into `user.scopes` — which
+      // nothing reads — and never enforced. A token minted for
+      // `pub.chive.metrics.recordView` was therefore accepted at
+      // `pub.chive.admin.deleteContent`: any holder of any valid token could
+      // call any endpoint their roles allowed, which is the whole point of the
+      // claim.
+      //
+      // A token carrying no `lxm` is unscoped and still verifies; passing the
+      // NSID only tightens tokens that declared a scope. Non-XRPC routes have
+      // no lexicon method, so nothing is passed for them.
+      const result = await verifier.verify(token, lexiconMethodForPath(c.req.path));
 
       if (!result) {
         // Invalid token; log and continue as anonymous

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -74,14 +74,48 @@ function extractBearerToken(header: string | undefined): string | null {
  *
  * @public
  */
+/**
+ * Refuses to start a production process that enables the E2E auth bypass.
+ *
+ * @throws Error when `ENABLE_E2E_AUTH_BYPASS` is `true` while `NODE_ENV` is
+ *   `production`
+ *
+ * @remarks
+ * The bypass turns `X-E2E-Auth-Did` and `X-E2E-Auth-Admin` into an
+ * unauthenticated route to full administrative access, and both header names
+ * are in the production CORS allowlist. The middleware already ignores the
+ * variable outside development, but silently ignoring it would leave an
+ * operator believing the bypass is active — or, worse, leave the flag set in a
+ * deploy that a later refactor honours again. Failing the boot makes the
+ * misconfiguration impossible to miss.
+ *
+ * @public
+ */
+export function assertNoAuthBypassInProduction(env: NodeJS.ProcessEnv = process.env): void {
+  if (env.ENABLE_E2E_AUTH_BYPASS === 'true' && env.NODE_ENV === 'production') {
+    throw new Error(
+      'ENABLE_E2E_AUTH_BYPASS is set in production. This header-based bypass grants ' +
+        'full admin access and must never be enabled outside development or E2E runs. ' +
+        'Unset it and redeploy.'
+    );
+  }
+}
+
 export function authenticateServiceAuth(
   verifier: IServiceAuthVerifier,
   authzService: IAuthorizationService
 ): MiddlewareHandler<ChiveEnv> {
   return async (c, next) => {
-    // E2E test bypass: when enabled, accept X-E2E-Auth-Did header
-    // This is standard practice for E2E testing OAuth-protected APIs
-    const e2eAuthBypass = process.env.ENABLE_E2E_AUTH_BYPASS === 'true';
+    // E2E test bypass: when enabled, accept X-E2E-Auth-Did header.
+    // This is standard practice for E2E testing OAuth-protected APIs, but it
+    // hands out full admin from a request header — `X-E2E-Auth-Admin: true` —
+    // and the header names sit in the production CORS allowlist. An env var is
+    // the only thing that stood between a misconfigured deploy and an open
+    // admin door, so the bypass is additionally compiled out of production by
+    // NODE_ENV. `assertNoAuthBypassInProduction` refuses to boot a production
+    // process that sets it, rather than starting up silently ignoring it.
+    const e2eAuthBypass =
+      process.env.ENABLE_E2E_AUTH_BYPASS === 'true' && process.env.NODE_ENV !== 'production';
     const e2eAuthDid = c.req.header('x-e2e-auth-did');
 
     if (e2eAuthBypass && e2eAuthDid) {

--- a/src/api/middleware/rate-limit.ts
+++ b/src/api/middleware/rate-limit.ts
@@ -300,7 +300,7 @@ export function conditionalRateLimiter(
  * @example
  * ```typescript
  * // Apply to autocomplete endpoints
- * app.get('/xrpc/pub.chive.search.searchSubmissions', autocompleteRateLimiter(), handler);
+ * app.get('/xrpc/pub.chive.eprint.searchSubmissions', autocompleteRateLimiter(), handler);
  * app.get('/xrpc/pub.chive.search.autocomplete', autocompleteRateLimiter(), handler);
  * ```
  *

--- a/src/api/middleware/request-context.ts
+++ b/src/api/middleware/request-context.ts
@@ -13,6 +13,7 @@
 
 import type { MiddlewareHandler } from 'hono';
 
+import { httpMetrics } from '../../observability/prometheus-registry.js';
 import type { ChiveEnv } from '../types/context.js';
 
 /**
@@ -161,6 +162,19 @@ export function requestContext(): MiddlewareHandler<ChiveEnv> {
           durationMs: duration,
         });
       }
+
+      // Record the request in Prometheus. The counter and histogram existed
+      // with no emission site anywhere, so the service exposed no request rate,
+      // latency or error-rate metrics at all — the middleware computed exactly
+      // these numbers and then only logged them.
+      //
+      // The endpoint label uses the matched route pattern rather than the raw
+      // path: labelling by path would mint a new time series per URI and blow
+      // up cardinality within a day of real traffic.
+      const endpoint = c.req.routePath ?? 'unmatched';
+      const labels = { method: c.req.method, endpoint, status: String(status) };
+      httpMetrics.requestsTotal.inc(labels);
+      httpMetrics.requestDuration.observe(labels, duration / 1000);
 
       // Set server timing header
       c.header('Server-Timing', `total;dur=${duration}`);

--- a/src/api/rate-limit-paths.ts
+++ b/src/api/rate-limit-paths.ts
@@ -1,0 +1,22 @@
+/**
+ * Paths that receive the relaxed autocomplete rate limit.
+ *
+ * @remarks
+ * Exported so the XRPC entries can be checked against the registered method
+ * NSIDs. One of them named `pub.chive.search.searchSubmissions`, a method that
+ * does not exist — the real NSID is `pub.chive.eprint.searchSubmissions` — so
+ * search never matched the relaxed tier and every anonymous search was billed
+ * against the low tier instead. A stale name in a list like this is invisible:
+ * it fails by silently not matching.
+ *
+ * @public
+ */
+export const AUTOCOMPLETE_RATE_LIMIT_PATHS: readonly string[] = [
+  '/xrpc/pub.chive.eprint.searchSubmissions',
+  '/xrpc/pub.chive.actor.autocompleteOrcid',
+  '/xrpc/pub.chive.actor.autocompleteAffiliation',
+  '/xrpc/pub.chive.actor.autocompleteKeyword',
+  '/xrpc/pub.chive.actor.autocompleteOpenReview',
+  '/xrpc/pub.chive.claiming.autocomplete',
+  '/api/v1/search', // REST search endpoint
+];

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -64,6 +64,7 @@ import type { ILogger } from '../types/interfaces/logger.interface.js';
 import type { IndexRetryWorker } from '../workers/index-retry-worker.js';
 
 import { CORS_CONFIG, HEALTH_PATHS } from './config.js';
+import { METRICS_PATH } from './handlers/rest/metrics.js';
 import { authenticateServiceAuth, requireAuth, requireAdmin } from './middleware/auth.js';
 import { errorHandler } from './middleware/error-handler.js';
 import { conditionalRateLimiter, autocompleteRateLimiter } from './middleware/rate-limit.js';
@@ -426,8 +427,11 @@ export function createServer(config: ServerConfig): Hono<ChiveEnv> {
   const isAutocompleteEndpoint = (path: string): boolean =>
     AUTOCOMPLETE_RATE_LIMIT_PATHS.some((pattern) => path.startsWith(pattern));
 
+  // The metrics endpoint is scraped on a fixed interval, so counting it against
+  // a rate limit would eventually starve the scraper of the very data that
+  // would show it happening.
   const isHealthCheck = (path: string): boolean =>
-    path === HEALTH_PATHS.liveness || path === HEALTH_PATHS.readiness;
+    path === HEALTH_PATHS.liveness || path === HEALTH_PATHS.readiness || path === METRICS_PATH;
 
   // Apply autocomplete rate limiter to search/autocomplete endpoints
   // Note: Hono matches exact paths; query strings are not part of the path

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -68,6 +68,7 @@ import { authenticateServiceAuth, requireAuth, requireAdmin } from './middleware
 import { errorHandler } from './middleware/error-handler.js';
 import { conditionalRateLimiter, autocompleteRateLimiter } from './middleware/rate-limit.js';
 import { requestContext } from './middleware/request-context.js';
+import { AUTOCOMPLETE_RATE_LIMIT_PATHS } from './rate-limit-paths.js';
 import { registerRoutes } from './routes.js';
 import type { ChiveEnv, ChiveServices } from './types/context.js';
 
@@ -422,25 +423,15 @@ export function createServer(config: ServerConfig): Hono<ChiveEnv> {
 
   // 6. Rate limiting
   // Autocomplete endpoints get higher rate limits (5x for anonymous)
-  const autocompletePatterns = [
-    '/xrpc/pub.chive.search.searchSubmissions',
-    '/xrpc/pub.chive.actor.autocompleteOrcid',
-    '/xrpc/pub.chive.actor.autocompleteAffiliation',
-    '/xrpc/pub.chive.actor.autocompleteKeyword',
-    '/xrpc/pub.chive.actor.autocompleteOpenReview',
-    '/xrpc/pub.chive.claiming.autocomplete',
-    '/api/v1/search', // REST search endpoint
-  ];
-
   const isAutocompleteEndpoint = (path: string): boolean =>
-    autocompletePatterns.some((pattern) => path.startsWith(pattern));
+    AUTOCOMPLETE_RATE_LIMIT_PATHS.some((pattern) => path.startsWith(pattern));
 
   const isHealthCheck = (path: string): boolean =>
     path === HEALTH_PATHS.liveness || path === HEALTH_PATHS.readiness;
 
   // Apply autocomplete rate limiter to search/autocomplete endpoints
   // Note: Hono matches exact paths; query strings are not part of the path
-  for (const pattern of autocompletePatterns) {
+  for (const pattern of AUTOCOMPLETE_RATE_LIMIT_PATHS) {
     app.use(pattern, autocompleteRateLimiter());
   }
 

--- a/src/api/xrpc/hono-adapter.ts
+++ b/src/api/xrpc/hono-adapter.ts
@@ -94,8 +94,13 @@ export function createXRPCRouter(
       // Lexicon not found - will use config only
     }
 
-    // Determine if this is a query (GET) or procedure (POST)
-    const isQueryMethod = def ? isQuery(def) : true; // Default to query if no lexicon
+    // Determine if this is a query (GET) or procedure (POST). The lexicon is
+    // authoritative when one is registered; otherwise the method's own
+    // `type` decides. Falling straight through to `true` ignored `type` and
+    // registered every lexicon-less procedure as a GET, so a handler declared
+    // `procedure` silently answered on the wrong verb — and its POST callers
+    // got a 404.
+    const isQueryMethod = def ? isQuery(def) : config.type !== 'procedure';
     const httpMethod = isQueryMethod ? 'get' : 'post';
 
     // Store method with metadata

--- a/src/auth/scopes/chive-scopes.ts
+++ b/src/auth/scopes/chive-scopes.ts
@@ -45,7 +45,10 @@ export const REPO_SCOPES = {
   ANNOTATION_ENTITY_LINK: 'repo:pub.chive.annotation.entityLink',
 
   // Graph collections
-  GRAPH_FIELD_PROPOSAL: 'repo:pub.chive.graph.fieldProposal',
+  // `pub.chive.graph.fieldProposal` was renamed to node/edgeProposal and has no
+  // lexicon. It is not listed here: a scope naming a record type that cannot
+  // exist can only ever be granted and never used, and it made the field
+  // promotion path look like it wrote a record type it does not.
   GRAPH_NODE_PROPOSAL: 'repo:pub.chive.graph.nodeProposal',
   GRAPH_EDGE_PROPOSAL: 'repo:pub.chive.graph.edgeProposal',
   GRAPH_VOTE: 'repo:pub.chive.graph.vote',

--- a/src/config/admin.ts
+++ b/src/config/admin.ts
@@ -1,0 +1,61 @@
+/**
+ * Platform administrator identity configuration.
+ *
+ * @remarks
+ * Single source of truth for who the platform administrators are. The list was
+ * previously parsed in three places with two different behaviours: the seeding
+ * paths in `src/index.ts` and `scripts/seed-admin.ts` each fell back to a
+ * hardcoded DID when `ADMIN_DIDS` was unset, while the governance role service
+ * parsed the same variable with no fallback.
+ *
+ * On a deployment that never sets `ADMIN_DIDS` — which is the documented normal
+ * case, and is how the production compose file is configured — those paths
+ * diverged: a platform admin was seeded, but the governance layer saw an empty
+ * list and recognised no administrator. Every privileged governance endpoint
+ * was therefore unreachable, with nothing able to create the first
+ * administrator.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type { DID } from '../types/atproto.js';
+
+/**
+ * Administrator used when `ADMIN_DIDS` is unset.
+ *
+ * @remarks
+ * Preserves the behaviour the seeding scripts already relied on. Kept here so
+ * the governance layer and the seeding paths cannot disagree about it again.
+ *
+ * @public
+ */
+export const DEFAULT_ADMIN_DID = 'did:plc:34mbm5v3umztwvvgnttvcz6e' as DID;
+
+/**
+ * Resolves the configured platform administrator DIDs.
+ *
+ * @param raw - Raw `ADMIN_DIDS` value; defaults to the environment variable
+ * @returns The administrator DIDs, falling back to {@link DEFAULT_ADMIN_DID}
+ *
+ * @remarks
+ * A blank or whitespace-only value counts as unset: an environment variable
+ * interpolated from an undefined deploy variable yields an empty string, and
+ * treating that as "no administrators" is what silently disabled governance.
+ *
+ * @example
+ * ```typescript
+ * getAdminDids('did:plc:abc, did:plc:def'); // ['did:plc:abc', 'did:plc:def']
+ * getAdminDids(undefined);                  // [DEFAULT_ADMIN_DID]
+ * ```
+ *
+ * @public
+ */
+export function getAdminDids(raw: string | undefined = process.env.ADMIN_DIDS): DID[] {
+  const configured = (raw ?? '')
+    .split(',')
+    .map((did) => did.trim())
+    .filter(Boolean) as DID[];
+
+  return configured.length > 0 ? configured : [DEFAULT_ADMIN_DID];
+}

--- a/src/config/graph.ts
+++ b/src/config/graph.ts
@@ -11,6 +11,7 @@
  * @packageDocumentation
  */
 
+import { isPlcDid } from '../types/atproto-validators.js';
 import type { DID } from '../types/atproto.js';
 
 /**
@@ -27,11 +28,36 @@ import type { DID } from '../types/atproto.js';
  *
  * @public
  */
+/**
+ * PLC identity of the Chive governance PDS used when none is configured.
+ *
+ * @public
+ */
+export const DEFAULT_GRAPH_PDS_DID = 'did:plc:5wzpn4a4nbqtz3q45hyud6hd' as DID;
+
 export const GRAPH_PDS_DID: DID = ((): DID => {
   // A deploy step that interpolates an undefined repository variable yields an
   // empty string, which nullish coalescing would accept as a real value.
   const configured = process.env.GRAPH_PDS_DID?.trim();
-  return configured ? (configured as DID) : ('did:plc:5wzpn4a4nbqtz3q45hyud6hd' as DID);
+  if (!configured) {
+    return DEFAULT_GRAPH_PDS_DID;
+  }
+
+  // Every environment file shipped `did:plc:chive-governance`, which is not a
+  // PLC identifier — they are 24 base32-sortable characters — so it overrode
+  // the correct default with a DID that resolves to nothing, and the governance
+  // sync imported an empty graph for as long as it was set. Nothing rejected
+  // it, because nothing checked. Refuse the value rather than carry it: a
+  // governance DID that cannot resolve is not a degraded mode, it is silence.
+  if (!isPlcDid(configured)) {
+    throw new Error(
+      `GRAPH_PDS_DID is not a valid PLC DID: ${configured}. ` +
+        'Expected did:plc: followed by 24 base32-sortable characters ' +
+        `(for example ${DEFAULT_GRAPH_PDS_DID}).`
+    );
+  }
+
+  return configured as DID;
 })();
 
 /**

--- a/src/config/orcid.ts
+++ b/src/config/orcid.ts
@@ -54,7 +54,17 @@ export interface OrcidConfig {
    * Must match the redirect URI registered in the ORCID developer dashboard.
    *
    * Environment variable: `ORCID_REDIRECT_URI`
-   * Default: `{API_BASE_URL}/api/v1/auth/orcid/callback`
+   * Default: `{API_BASE_URL}/v1/auth/orcid/callback`
+   *
+   * @remarks
+   * The path has no `/api` prefix because the application does not register
+   * one: REST routes are mounted at `/v1/...` directly. In production the
+   * `/api` prefix exists only on the `Host(DOMAIN) && PathPrefix(/api)`
+   * Traefik router, which strips it before the request reaches the app; the
+   * `api.DOMAIN` router does not. Defaulting to `/api/v1/...` therefore 404ed
+   * everywhere the request reached the app directly, local development
+   * included. Set `ORCID_REDIRECT_URI` explicitly when fronting the API
+   * through the path-prefixed router.
    */
   readonly redirectUri: string;
 }
@@ -85,7 +95,7 @@ export function getOrcidConfig(): OrcidConfig {
 
   const baseUrl = process.env.ORCID_BASE_URL ?? 'https://orcid.org';
   const apiBaseUrl = process.env.API_BASE_URL ?? 'http://localhost:3001';
-  const redirectUri = process.env.ORCID_REDIRECT_URI ?? `${apiBaseUrl}/api/v1/auth/orcid/callback`;
+  const redirectUri = process.env.ORCID_REDIRECT_URI ?? `${apiBaseUrl}/v1/auth/orcid/callback`;
 
   return { clientId, clientSecret, baseUrl, redirectUri };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { createServer, type ServerConfig } from './api/server.js';
 import { ATRepository } from './atproto/repository/at-repository.js';
 import { AuthorizationService } from './auth/authorization/authorization-service.js';
 import { DIDResolver } from './auth/did/did-resolver.js';
+import { getAdminDids } from './config/admin.js';
 import { getGrobidConfig } from './config/grobid.js';
 import { CitationExtractionJob } from './jobs/citation-extraction-job.js';
 import { CollaborativeFilteringSyncJob } from './jobs/collaborative-filtering-sync.js';
@@ -1022,13 +1023,7 @@ async function seedAdminRoles(
   authzService: InstanceType<typeof AuthorizationService>,
   logger: PinoLogger
 ): Promise<void> {
-  const defaultAdminDids = 'did:plc:34mbm5v3umztwvvgnttvcz6e';
-  const adminDidsRaw = process.env.ADMIN_DIDS ?? defaultAdminDids;
-
-  const adminDids = adminDidsRaw
-    .split(',')
-    .map((d) => d.trim())
-    .filter(Boolean);
+  const adminDids = getAdminDids();
 
   if (adminDids.length === 0) {
     logger.info('No admin DIDs to seed');
@@ -1038,7 +1033,7 @@ async function seedAdminRoles(
   logger.info('Seeding admin roles...', { count: adminDids.length });
 
   for (const did of adminDids) {
-    await authzService.assignRole(did as DID, 'admin', 'system-startup' as DID);
+    await authzService.assignRole(did, 'admin', 'system-startup' as DID);
     logger.info('Admin role assigned', { did });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { GovernanceSyncJob } from './jobs/governance-sync-job.js';
 import { PDSScanSchedulerJob } from './jobs/pds-scan-scheduler-job.js';
 import { TagSyncJob } from './jobs/tag-sync-job.js';
 import { PinoLogger } from './observability/logger.js';
+import { initTelemetry } from './observability/telemetry.js';
 import { registerPluginDependencies } from './plugins/core/plugin-di-helpers.js';
 import {
   registerPluginSystem,
@@ -1056,6 +1057,22 @@ async function main(): Promise<void> {
     environment: config.nodeEnv,
     pretty: config.nodeEnv === 'development',
   });
+
+  // Telemetry has to be started explicitly. It never was, so every `withSpan`
+  // in the codebase executed its callback without recording anything and no
+  // OTLP export ever happened — the tracing existed only as dead decoration.
+  // It stays off without a configured endpoint outside production, so local
+  // runs do not spend the process retrying a collector that is not there.
+  if (process.env.OTEL_SDK_DISABLED === 'true') {
+    logger.info('Telemetry disabled by OTEL_SDK_DISABLED');
+  } else if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT || config.nodeEnv === 'production') {
+    initTelemetry({ serviceName: 'chive-appview', environment: config.nodeEnv });
+    logger.info('Telemetry initialized', {
+      endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? '(default)',
+    });
+  } else {
+    logger.info('Telemetry not initialized: no OTEL_EXPORTER_OTLP_ENDPOINT configured');
+  }
 
   logger.info('Starting Chive AppView...', {
     nodeEnv: config.nodeEnv,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { Redis } from 'ioredis';
 const { EventEmitter2 } = EventEmitter2Module;
 type EventEmitter2Type = InstanceType<typeof EventEmitter2>;
 
+import { assertNoAuthBypassInProduction } from './api/middleware/auth.js';
 import { createServer, type ServerConfig } from './api/server.js';
 import { ATRepository } from './atproto/repository/at-repository.js';
 import { AuthorizationService } from './auth/authorization/authorization-service.js';
@@ -1044,6 +1045,10 @@ async function seedAdminRoles(
  * Main entry point.
  */
 async function main(): Promise<void> {
+  // Refuse to boot a production process with the header auth bypass enabled,
+  // before any listener is bound.
+  assertNoAuthBypassInProduction();
+
   const config = loadConfig();
   const logger = new PinoLogger({
     level: config.nodeEnv === 'production' ? 'info' : 'debug',

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -54,6 +54,7 @@ import { AutomaticProposalService } from './services/governance/automatic-propos
 import { GovernancePDSWriter } from './services/governance/governance-pds-writer.js';
 import { NodeService } from './services/governance/node-service.js';
 import { PersonalGraphService } from './services/graph/personal-graph-service.js';
+import { DeadLetterQueue } from './services/indexing/dlq-handler.js';
 import { createEventProcessor } from './services/indexing/event-processor.js';
 import {
   type FirehoseHealthServer,
@@ -542,9 +543,18 @@ async function main(): Promise<void> {
       logger.error('Failed to load Margin plugins', err instanceof Error ? err : undefined);
     }
 
+    // The cursor advances as soon as an event is queued, well before the
+    // processor runs, so a handler failure without a DLQ loses the record
+    // permanently — there is no sequence number left to rewind to. The DLQ is
+    // backed entirely by the `firehose_dlq` table, so this instance and the one
+    // IndexingService builds for queue-level failures are the same queue; only
+    // the alert thresholds are per-instance, and neither configures alerts.
+    const dlq = new DeadLetterQueue({ db: pgPool });
+
     // Create event processor with PDS auto-discovery
     const processor = createEventProcessor({
       pool: pgPool,
+      dlq, // Capture handler failures for replay; the cursor has already moved on
       activity: activityService,
       eprintService,
       reviewService,

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -11,7 +11,7 @@
  * - pub.chive.review.comment
  * - pub.chive.review.endorsement
  * - pub.chive.eprint.userTag
- * - pub.chive.graph.fieldProposal
+ * - pub.chive.graph.nodeProposal
  * - pub.chive.graph.vote
  * - pub.chive.actor.profile
  *

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -30,6 +30,7 @@ import { CitationExtractionJob } from './jobs/citation-extraction-job.js';
 import { FieldLabelResolutionJob } from './jobs/field-label-resolution-job.js';
 import { FieldPromotionJob } from './jobs/field-promotion-job.js';
 import { PinoLogger } from './observability/logger.js';
+import { initTelemetry } from './observability/telemetry.js';
 import { CosmikBacklinksPlugin } from './plugins/builtin/cosmik-backlinks.js';
 import { CosmikConnectionsPlugin } from './plugins/builtin/cosmik-connections.js';
 import { CosmikFollowsPlugin } from './plugins/builtin/cosmik-follows.js';
@@ -308,6 +309,20 @@ async function main(): Promise<void> {
     environment: config.nodeEnv,
     pretty: config.nodeEnv === 'development',
   });
+
+  // The indexer is its own process, so it needs its own telemetry start; see
+  // the note in src/index.ts. Without it the firehose pipeline's spans were
+  // recorded nowhere.
+  if (process.env.OTEL_SDK_DISABLED === 'true') {
+    logger.info('Telemetry disabled by OTEL_SDK_DISABLED');
+  } else if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT || config.nodeEnv === 'production') {
+    initTelemetry({ serviceName: 'chive-indexer', environment: config.nodeEnv });
+    logger.info('Telemetry initialized', {
+      endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? '(default)',
+    });
+  } else {
+    logger.info('Telemetry not initialized: no OTEL_EXPORTER_OTLP_ENDPOINT configured');
+  }
 
   logger.info('Starting Chive Firehose Indexer...', {
     nodeEnv: config.nodeEnv,

--- a/src/jobs/field-promotion-job.ts
+++ b/src/jobs/field-promotion-job.ts
@@ -9,7 +9,7 @@
  * - qualityScore >= 0.7
  * - spamScore < 0.3
  *
- * Tags meeting these criteria are promoted to `pub.chive.graph.fieldProposal`
+ * Tags meeting these criteria are promoted to `pub.chive.graph.nodeProposal`
  * records in the Governance PDS, where they enter the community voting workflow.
  *
  * **ATProto Compliance:**

--- a/src/jobs/governance-sync-job.ts
+++ b/src/jobs/governance-sync-job.ts
@@ -55,6 +55,37 @@ export interface GovernanceSyncJobConfig {
 }
 
 /**
+ * Outcome of a single sync cycle.
+ *
+ * @remarks
+ * A cycle that indexed every record it read is `success`; a cycle in which at
+ * least one record failed to index is `partial`. Callers that track the sync as
+ * an operation — e.g. the admin trigger endpoint — should treat `partial` as a
+ * failure, since a partial cycle silently leaves the Neo4j index behind the
+ * Governance PDS.
+ *
+ * @public
+ */
+export interface GovernanceSyncResult {
+  /** Nodes successfully indexed into Neo4j. */
+  nodesIndexed: number;
+  /** Edges successfully indexed into Neo4j. */
+  edgesIndexed: number;
+  /** Records that were read but could not be indexed. */
+  failedCount: number;
+  /** Whether every record read was indexed. */
+  status: 'success' | 'partial';
+}
+
+/**
+ * Per-collection sync tallies.
+ */
+interface SyncCounts {
+  indexed: number;
+  failed: number;
+}
+
+/**
  * Node record value from ATProto listRecords.
  */
 interface NodeRecordValue {
@@ -176,11 +207,19 @@ export class GovernanceSyncJob {
 
   /**
    * Runs a single sync cycle.
+   *
+   * @returns The cycle outcome, `partial` when some records failed to index.
+   *
+   * @remarks
+   * Per-record indexing failures do not abort the cycle — one poisoned record
+   * should not block the rest of the graph — but they are counted and surfaced
+   * so a caller cannot mistake a lossy cycle for a complete one.
    */
-  async run(): Promise<void> {
+  async run(): Promise<GovernanceSyncResult> {
     if (this.isRunning) {
       this.config.logger.debug('Sync already in progress, skipping');
-      return;
+      // Nothing was read, so nothing was dropped: not a partial cycle.
+      return { nodesIndexed: 0, edgesIndexed: 0, failedCount: 0, status: 'success' };
     }
 
     this.isRunning = true;
@@ -188,26 +227,46 @@ export class GovernanceSyncJob {
     const endTimer = jobMetrics.duration.startTimer({ job: 'governance_sync' });
 
     try {
-      await withSpan('job.governance_sync', async () => {
+      return await withSpan('job.governance_sync', async () => {
         this.config.logger.debug('Starting governance sync');
 
-        const nodeCount = await this.syncNodes();
-        const edgeCount = await this.syncEdges();
+        const nodes = await this.syncNodes();
+        const edges = await this.syncEdges();
+
+        const nodeCount = nodes.indexed;
+        const edgeCount = edges.indexed;
+        const failedCount = nodes.failed + edges.failed;
+        const status = failedCount > 0 ? 'partial' : 'success';
 
         const duration = Date.now() - startTime;
-        this.config.logger.info('Governance sync completed', {
-          nodesIndexed: nodeCount,
-          edgesIndexed: edgeCount,
-          durationMs: duration,
-        });
+        if (failedCount > 0) {
+          this.config.logger.warn('Governance sync completed with failures', {
+            nodesIndexed: nodeCount,
+            edgesIndexed: edgeCount,
+            nodesFailed: nodes.failed,
+            edgesFailed: edges.failed,
+            durationMs: duration,
+          });
+        } else {
+          this.config.logger.info('Governance sync completed', {
+            nodesIndexed: nodeCount,
+            edgesIndexed: edgeCount,
+            durationMs: duration,
+          });
+        }
 
-        jobMetrics.executionsTotal.inc({ job: 'governance_sync', status: 'success' });
+        jobMetrics.executionsTotal.inc({ job: 'governance_sync', status });
         jobMetrics.lastRunTimestamp.set({ job: 'governance_sync' }, Date.now() / 1000);
         jobMetrics.itemsProcessed.inc(
           { job: 'governance_sync', status: 'success' },
           nodeCount + edgeCount
         );
-        endTimer({ status: 'success' });
+        if (failedCount > 0) {
+          jobMetrics.itemsProcessed.inc({ job: 'governance_sync', status: 'error' }, failedCount);
+        }
+        endTimer({ status });
+
+        return { nodesIndexed: nodeCount, edgesIndexed: edgeCount, failedCount, status };
       });
     } catch (error) {
       this.config.logger.error(
@@ -226,9 +285,12 @@ export class GovernanceSyncJob {
 
   /**
    * Syncs all node records from the Governance PDS.
+   *
+   * @returns Indexed and failed record counts for this collection.
    */
-  private async syncNodes(): Promise<number> {
+  private async syncNodes(): Promise<SyncCounts> {
     let indexedCount = 0;
+    let failedCount = 0;
     let cursor: string | undefined;
 
     do {
@@ -270,20 +332,24 @@ export class GovernanceSyncJob {
             error instanceof Error ? error : undefined,
             { uri: record.uri }
           );
+          failedCount++;
         }
       }
 
       cursor = response.data.cursor;
     } while (cursor);
 
-    return indexedCount;
+    return { indexed: indexedCount, failed: failedCount };
   }
 
   /**
    * Syncs all edge records from the Governance PDS.
+   *
+   * @returns Indexed and failed record counts for this collection.
    */
-  private async syncEdges(): Promise<number> {
+  private async syncEdges(): Promise<SyncCounts> {
     let indexedCount = 0;
+    let failedCount = 0;
     let cursor: string | undefined;
 
     do {
@@ -322,12 +388,13 @@ export class GovernanceSyncJob {
             error instanceof Error ? error : undefined,
             { uri: record.uri }
           );
+          failedCount++;
         }
       }
 
       cursor = response.data.cursor;
     } while (cursor);
 
-    return indexedCount;
+    return { indexed: indexedCount, failed: failedCount };
   }
 }

--- a/src/plugins/builtin/leaflet-backlinks.ts
+++ b/src/plugins/builtin/leaflet-backlinks.ts
@@ -11,6 +11,25 @@
  *
  * Reading list schema: xyz.leaflet.list
  *
+ * WARNING: `xyz.leaflet.list` does not exist. Leaflet publishes
+ * `pub.leaflet.document` and `pub.leaflet.comment`; this NSID, and the
+ * `LeafletList` interface below with its `items` / `visibility` / `tags`
+ * fields, were invented rather than taken from a published lexicon. The plugin
+ * therefore matches no record that any repository actually holds, and indexes
+ * nothing however it is wired up.
+ *
+ * It is left pointing at the fictional NSID deliberately. Repointing it at
+ * `pub.leaflet.document` while the parser still expects this invented shape
+ * would turn "indexes nothing" into "indexes wrong backlinks", which is the
+ * worse failure — a real record would be read against a schema it does not
+ * have. Fixing this properly means reading Leaflet's published lexicon and
+ * rewriting the record handling against it, which is integration work rather
+ * than remediation.
+ *
+ * Note also that nothing loads this plugin today, and the event filter drops
+ * every non-`pub.chive.*` record before the plugin bus in any case (INT-1), so
+ * no wiring change alone would bring it to life.
+ *
  * ATProto Compliance:
  * - All backlinks indexed from firehose (rebuildable via replay)
  * - Tracks deletions to honor record removal

--- a/src/plugins/builtin/whitewind-backlinks.ts
+++ b/src/plugins/builtin/whitewind-backlinks.ts
@@ -9,7 +9,7 @@
  * When a WhiteWind blog post mentions or embeds a Chive eprint,
  * this plugin creates a backlink for aggregation and discovery.
  *
- * Blog entry schema: com.whitewind.blog.entry
+ * Blog entry schema: com.whtwnd.blog.entry
  *
  * ATProto Compliance:
  * - All backlinks indexed from firehose (rebuildable via replay)
@@ -33,7 +33,7 @@ import { BacklinkTrackingPlugin } from '../core/backlink-plugin.js';
  * @internal
  */
 interface WhiteWindEntry {
-  $type: 'com.whitewind.blog.entry';
+  $type: 'com.whtwnd.blog.entry';
   title: string;
   content: string;
   contentFormat: 'markdown' | 'html' | 'plaintext';
@@ -50,7 +50,7 @@ interface WhiteWindEntry {
  * @internal
  */
 interface WhiteWindEmbed {
-  $type: 'com.whitewind.blog.embed#record';
+  $type: 'com.whtwnd.blog.embed#record';
   uri: string;
   cid?: string;
 }
@@ -85,7 +85,7 @@ export class WhiteWindBacklinksPlugin extends BacklinkTrackingPlugin {
   /**
    * ATProto collection to track.
    */
-  readonly trackedCollection = 'com.whitewind.blog.entry';
+  readonly trackedCollection = 'com.whtwnd.blog.entry';
 
   /**
    * Backlink source type.
@@ -103,7 +103,7 @@ export class WhiteWindBacklinksPlugin extends BacklinkTrackingPlugin {
     author: 'Aaron Steven White',
     license: 'MIT',
     permissions: {
-      hooks: ['firehose.com.whitewind.blog.entry'],
+      hooks: ['firehose.com.whtwnd.blog.entry'],
       storage: {
         maxSize: 10 * 1024 * 1024, // 10MB
       },

--- a/src/services/backlink/backlink-service.ts
+++ b/src/services/backlink/backlink-service.ts
@@ -15,7 +15,7 @@
  * Backlink Sources:
  * - Cosmik collections (network.cosmik.collection)
  * - Leaflet reading lists (xyz.leaflet.list)
- * - WhiteWind blog posts (com.whitewind.blog.entry)
+ * - WhiteWind blog posts (com.whtwnd.blog.entry)
  * - Bluesky posts/embeds (app.bsky.feed.post)
  * - Chive comments (pub.chive.review.comment)
  * - Chive endorsements (pub.chive.review.endorsement)

--- a/src/services/eprint/eprint-service.ts
+++ b/src/services/eprint/eprint-service.ts
@@ -629,6 +629,36 @@ export class EprintService {
     };
   }
 
+  /**
+   * Fetches several eprints in one query.
+   *
+   * @param uris - Eprint URIs to fetch
+   * @returns Map of URI to eprint view, omitting URIs with no row
+   *
+   * @remarks
+   * Unlike {@link EprintService.getEprint} this does not resolve version
+   * chains, which would reintroduce a query per eprint. It is for callers that
+   * need the record body across a page of results — author autocomplete was
+   * issuing up to 75 sequential `getEprint` calls per keystroke, each waiting
+   * on the last.
+   *
+   * @public
+   */
+  async getEprints(uris: readonly AtUri[]): Promise<Map<AtUri, EprintView>> {
+    const stored = await this.storage.getEprints(uris);
+    const views = new Map<AtUri, EprintView>();
+
+    for (const [uri, eprint] of stored) {
+      views.set(uri, {
+        ...eprint,
+        versions: [],
+        metrics: { views: 0, downloads: 0, endorsements: 0 },
+      });
+    }
+
+    return views;
+  }
+
   async getEprintsByAuthor(did: DID, options?: EprintQueryOptions): Promise<EprintList> {
     const eprints = await this.storage.getEprintsByAuthor(did, options);
 

--- a/src/services/eprint/eprint-service.ts
+++ b/src/services/eprint/eprint-service.ts
@@ -544,6 +544,25 @@ export class EprintService {
         }
       }
 
+      // Remove the eprint node itself from Neo4j. Dropping tag relationships
+      // above leaves the (:Node:Object:Eprint) node and every other edge it
+      // carries — CITES, CLASSIFIED_AS, INTERACTED_WITH — pointing at a record
+      // that no longer exists, so recommendations and citation queries keep
+      // surfacing it. DETACH DELETE inside deleteNode clears node and edges.
+      // Errors here should not prevent overall deletion (log and continue).
+      if (this.graph) {
+        try {
+          await this.graph.deleteNode(uri);
+          this.logger.debug('Removed eprint node from Neo4j', { uri });
+        } catch (graphError) {
+          this.logger.warn('Neo4j node cleanup failed, PostgreSQL is source of truth', {
+            uri,
+            error: graphError instanceof Error ? graphError.message : String(graphError),
+          });
+          // Continue; PostgreSQL is the primary index
+        }
+      }
+
       this.logger.info('Deleted eprint from indexes', { uri });
 
       return { ok: true, value: undefined };
@@ -576,11 +595,15 @@ export class EprintService {
       case 'pub.chive.review.endorsement':
         await this.storage.deleteByUri('endorsements_index', uri);
         break;
+      // Citations and related works are not reachable through deleteByUri:
+      // extracted_citations is keyed by user_record_uri rather than uri, and
+      // both have dedicated delete methods that the firehose event processor
+      // already uses.
       case 'pub.chive.eprint.citation':
-        await this.storage.deleteByUri('citations_index', uri);
+        await this.storage.deleteCitation(uri);
         break;
       case 'pub.chive.eprint.relatedWork':
-        await this.storage.deleteByUri('related_works_index', uri);
+        await this.storage.deleteRelatedWork(uri);
         break;
       default:
         this.logger.debug('No index table for collection', { collection, uri });

--- a/src/services/governance/automatic-proposal-service.ts
+++ b/src/services/governance/automatic-proposal-service.ts
@@ -472,7 +472,7 @@ export class AutomaticProposalService {
    * Queries the tag manager for tags that have reached the promotion threshold
    * (usageCount >= 10, uniqueUsers >= 5, qualityScore >= 0.7, spamScore < 0.3).
    * For each candidate, checks whether a field proposal already exists in the
-   * governance system. Creates new `pub.chive.graph.fieldProposal` records
+   * governance system. Creates new `pub.chive.graph.nodeProposal` records
    * via GovernancePDSWriter for candidates without existing proposals.
    *
    * @returns Summary of the promotion check: proposals created, evaluated, and skipped

--- a/src/services/governance/governance-pds-connector.ts
+++ b/src/services/governance/governance-pds-connector.ts
@@ -173,6 +173,33 @@ const COLLECTIONS = {
 } as const;
 
 /**
+ * Governance collections that have no lexicon in `lexicons/pub/chive/graph/`.
+ *
+ * @remarks
+ * Nothing can publish a record under an NSID that has no schema, so listing
+ * these collections returns an empty page every time. That is indistinguishable
+ * from a governance PDS that simply holds no facets yet, which is why it went
+ * unnoticed: the sync reported success having imported nothing, forever.
+ *
+ * Authoring the schemas is the real fix, and it is design work rather than
+ * remediation — a wrong schema published under one of these names is harder to
+ * withdraw than no schema at all. Until then the connector says plainly that
+ * the collection cannot yield records, so an empty import reads as a missing
+ * schema rather than as an empty community.
+ *
+ * `pub.chive.graph.authority` also disagrees with the namespace listed in
+ * `CLAUDE.md`, which names `pub.chive.graph.authorityRecord`. Left alone here:
+ * renaming the collection would change what the connector reads, and which
+ * name the governance PDS actually holds needs checking against the live repo
+ * rather than guessing.
+ */
+const COLLECTIONS_WITHOUT_LEXICONS: ReadonlySet<string> = new Set([
+  COLLECTIONS.AUTHORITY_RECORD,
+  COLLECTIONS.FACET,
+  COLLECTIONS.ORGANIZATION,
+]);
+
+/**
  * Governance PDS Connector.
  *
  * @remarks
@@ -225,6 +252,29 @@ export class GovernancePDSConnector {
   private readonly pool?: Pool;
 
   private governancePdsUrl?: string;
+
+  /** Collections already reported as having no lexicon, so the warning fires once. */
+  private readonly reportedSchemaless = new Set<string>();
+
+  /**
+   * Warns, once per collection, that a listing cannot return records.
+   *
+   * @param collection - Governance collection about to be listed
+   *
+   * @remarks
+   * Without this an empty result is silent and reads as "no records yet"
+   * rather than "no schema exists, so there can never be records".
+   */
+  private warnIfCollectionHasNoLexicon(collection: string): void {
+    if (!COLLECTIONS_WITHOUT_LEXICONS.has(collection) || this.reportedSchemaless.has(collection)) {
+      return;
+    }
+    this.reportedSchemaless.add(collection);
+    this.logger.warn(
+      'Governance collection has no published lexicon; this listing cannot return records',
+      { collection }
+    );
+  }
 
   constructor(options: GovernancePDSConnectorOptions) {
     this.graphPdsDid = options.graphPdsDid;
@@ -346,6 +396,7 @@ export class GovernancePDSConnector {
     options?: GovernanceListOptions
   ): AsyncIterable<GovernanceAuthorityRecord> {
     const pdsUrl = await this.getPdsUrl();
+    this.warnIfCollectionHasNoLexicon(COLLECTIONS.AUTHORITY_RECORD);
     const records = this.repository.listRecords<RawAuthorityRecord>(
       this.graphPdsDid,
       COLLECTIONS.AUTHORITY_RECORD,
@@ -432,6 +483,7 @@ export class GovernancePDSConnector {
     options?: GovernanceListOptions
   ): AsyncIterable<GovernanceFacet> {
     const pdsUrl = await this.getPdsUrl();
+    this.warnIfCollectionHasNoLexicon(COLLECTIONS.FACET);
     const records = this.repository.listRecords<RawFacetRecord>(
       this.graphPdsDid,
       COLLECTIONS.FACET,
@@ -513,6 +565,7 @@ export class GovernancePDSConnector {
    */
   async *listOrganizations(options?: GovernanceListOptions): AsyncIterable<GovernanceOrganization> {
     const pdsUrl = await this.getPdsUrl();
+    this.warnIfCollectionHasNoLexicon(COLLECTIONS.ORGANIZATION);
     const records = this.repository.listRecords<RawOrganizationRecord>(
       this.graphPdsDid,
       COLLECTIONS.ORGANIZATION,

--- a/src/services/governance/node-service.ts
+++ b/src/services/governance/node-service.ts
@@ -187,6 +187,52 @@ export class NodeService {
   }
 
   /**
+   * Get several nodes by URI, using the cache where possible.
+   *
+   * @param uris - Node AT-URIs
+   * @returns Map of URI to node, omitting URIs with no node
+   *
+   * @remarks
+   * Cached entries are served without touching Neo4j; whatever is left is
+   * fetched in a single query rather than one per URI. Faceted browse
+   * previously issued one `getNode` per edge inside a per-facet loop, which at
+   * a limit of 100 meant 100 sequential round trips for every facet on the
+   * page.
+   *
+   * @public
+   */
+  async getNodes(uris: readonly AtUri[]): Promise<Map<AtUri, GraphNode>> {
+    const found = new Map<AtUri, GraphNode>();
+    const unresolved: AtUri[] = [];
+
+    for (const uri of new Set(uris)) {
+      if (this.cache) {
+        const cached = await this.cache.get(this.cacheKey(uri));
+        if (cached) {
+          found.set(uri, JSON.parse(cached) as GraphNode);
+          continue;
+        }
+      }
+      unresolved.push(uri);
+    }
+
+    if (unresolved.length === 0) {
+      return found;
+    }
+
+    const fetched = await this.nodeRepository.getNodesByUris(unresolved);
+
+    for (const [uri, node] of fetched) {
+      found.set(uri, node);
+      if (this.cache) {
+        await this.cache.setex(this.cacheKey(uri), this.cacheTtlSeconds, JSON.stringify(node));
+      }
+    }
+
+    return found;
+  }
+
+  /**
    * Get a node by ID.
    */
   async getNodeById(id: string): Promise<GraphNode | null> {

--- a/src/services/governance/trusted-editor-service.ts
+++ b/src/services/governance/trusted-editor-service.ts
@@ -25,6 +25,7 @@
 
 import type { Pool } from 'pg';
 
+import { getAdminDids } from '../../config/admin.js';
 import type { DID, NSID, Timestamp } from '../../types/atproto.js';
 import { DatabaseError, ValidationError } from '../../types/errors.js';
 import type { ILogger } from '../../types/interfaces/logger.interface.js';
@@ -138,7 +139,24 @@ export interface TrustedEditorServiceOptions {
   pool: Pool;
   /** Logger instance */
   logger: ILogger;
+  /**
+   * DIDs that hold the administrator role without a `governance_roles` grant.
+   *
+   * @remarks
+   * Every administrator-only governance endpoint resolves the caller's role
+   * through this service, and the only way to obtain the administrator role is
+   * for an administrator to approve an elevation request — so a fresh
+   * deployment has no way to create its first administrator. Platform admins
+   * (the DIDs seeded into the `admin` authorization role at startup) are
+   * therefore accepted as administrators here. Defaults to the same
+   * `ADMIN_DIDS` environment variable that seeds those platform admins.
+   */
+  platformAdminDids?: readonly DID[];
 }
+
+/**
+ * Parse a comma-separated DID list, as carried by `ADMIN_DIDS`.
+ */
 
 /**
  * Criteria thresholds for automatic elevation.
@@ -175,10 +193,26 @@ const TRUSTED_EDITOR_CRITERIA = {
 export class TrustedEditorService {
   private readonly pool: Pool;
   private readonly logger: ILogger;
+  private readonly platformAdminDids: ReadonlySet<DID>;
 
   constructor(options: TrustedEditorServiceOptions) {
     this.pool = options.pool;
     this.logger = options.logger;
+    this.platformAdminDids = new Set(options.platformAdminDids ?? getAdminDids());
+  }
+
+  /**
+   * Resolve the effective governance role for a DID.
+   *
+   * @remarks
+   * Platform admins outrank whatever `governance_roles` holds, so that the
+   * first administrator of a deployment exists before any elevation request
+   * can be approved.
+   *
+   * @internal
+   */
+  private resolveRole(did: DID, storedRole: GovernanceRole): GovernanceRole {
+    return this.platformAdminDids.has(did) ? 'administrator' : storedRole;
   }
 
   /**
@@ -191,25 +225,27 @@ export class TrustedEditorService {
    */
   async getEditorStatus(did: DID): Promise<Result<EditorStatus, DatabaseError>> {
     try {
-      // Get user info and role
+      // Get user info and role. The query drives from the requested DID rather
+      // than from authors_index so that a granted role still resolves when the
+      // actor's profile has not been indexed; the display name is best-effort.
       const userResult = await this.pool.query<{
-        did: string;
         display_name: string | null;
         role: string;
         role_granted_at: Date | null;
         role_granted_by: string | null;
-        created_at: Date;
+        created_at: Date | null;
       }>(
         `SELECT
-          a.did,
           a.display_name,
           COALESCE(gr.role, 'community-member') as role,
           gr.granted_at as role_granted_at,
           gr.granted_by as role_granted_by,
           a.indexed_at as created_at
-        FROM authors_index a
-        LEFT JOIN governance_roles gr ON gr.did = a.did AND gr.active = true
-        WHERE a.did = $1`,
+        FROM (SELECT $1::text AS did) t
+        LEFT JOIN governance_roles gr ON gr.did = t.did AND gr.active = true
+        LEFT JOIN authors_index a ON a.did = t.did
+        ORDER BY gr.granted_at DESC
+        LIMIT 1`,
         [did]
       );
 
@@ -243,7 +279,7 @@ export class TrustedEditorService {
         value: {
           did,
           displayName: user?.display_name ?? undefined,
-          role: (user?.role ?? 'community-member') as GovernanceRole,
+          role: this.resolveRole(did, (user?.role ?? 'community-member') as GovernanceRole),
           roleGrantedAt: user?.role_granted_at?.getTime() as Timestamp | undefined,
           roleGrantedBy: user?.role_granted_by as DID | undefined,
           hasDelegation: !!delegation,
@@ -275,22 +311,28 @@ export class TrustedEditorService {
    */
   async calculateReputationMetrics(did: DID): Promise<Result<ReputationMetrics, DatabaseError>> {
     try {
-      // Get account info
+      // Get account info. As in getEditorStatus, the role comes from
+      // governance_roles rather than from an indexed profile.
       const accountResult = await this.pool.query<{
-        created_at: Date;
+        created_at: Date | null;
         role: string;
       }>(
         `SELECT
           a.indexed_at as created_at,
           COALESCE(gr.role, 'community-member') as role
-        FROM authors_index a
-        LEFT JOIN governance_roles gr ON gr.did = a.did AND gr.active = true
-        WHERE a.did = $1`,
+        FROM (SELECT $1::text AS did) t
+        LEFT JOIN governance_roles gr ON gr.did = t.did AND gr.active = true
+        LEFT JOIN authors_index a ON a.did = t.did
+        ORDER BY gr.granted_at DESC
+        LIMIT 1`,
         [did]
       );
 
       const accountCreatedAt = accountResult.rows[0]?.created_at ?? new Date();
-      const role = (accountResult.rows[0]?.role ?? 'community-member') as GovernanceRole;
+      const role = this.resolveRole(
+        did,
+        (accountResult.rows[0]?.role ?? 'community-member') as GovernanceRole
+      );
       const accountAgeDays = Math.floor(
         (Date.now() - accountCreatedAt.getTime()) / (1000 * 60 * 60 * 24)
       );
@@ -644,6 +686,8 @@ export class TrustedEditorService {
     cursor?: string
   ): Promise<Result<{ editors: EditorStatus[]; cursor?: string }, DatabaseError>> {
     try {
+      // The join to authors_index is a LEFT JOIN because an editor whose
+      // profile has not been indexed still holds the role.
       const result = await this.pool.query<{
         did: string;
         display_name: string | null;
@@ -653,7 +697,7 @@ export class TrustedEditorService {
       }>(
         `SELECT gr.did, a.display_name, gr.role, gr.granted_at, gr.granted_by
          FROM governance_roles gr
-         JOIN authors_index a ON a.did = gr.did
+         LEFT JOIN authors_index a ON a.did = gr.did
          WHERE gr.active = true AND gr.role IN ('trusted-editor', 'graph-editor')
          ${cursor ? 'AND gr.granted_at < $2' : ''}
          ORDER BY gr.granted_at DESC
@@ -710,7 +754,10 @@ export class TrustedEditorService {
         [did]
       );
 
-      const role = (result.rows[0]?.role ?? 'community-member') as GovernanceRole;
+      const role = this.resolveRole(
+        did,
+        (result.rows[0]?.role ?? 'community-member') as GovernanceRole
+      );
 
       // Authority editors get higher weight on authority proposals
       if (role === 'graph-editor' && (proposalType === 'authority' || proposalType === 'facet')) {

--- a/src/services/indexing/event-processor.ts
+++ b/src/services/indexing/event-processor.ts
@@ -39,11 +39,17 @@ import type {
   EdgeMetadata,
 } from '../../storage/neo4j/types.js';
 import type { AtUri, CID, DID, NSID } from '../../types/atproto.js';
-import { ChiveError, DatabaseError } from '../../types/errors.js';
+import {
+  ChiveError,
+  DatabaseError,
+  ServiceUnavailableError,
+  ValidationError,
+} from '../../types/errors.js';
 import type { ICitationGraph } from '../../types/interfaces/discovery.interface.js';
 import type { IIdentityResolver } from '../../types/interfaces/identity.interface.js';
 import type { ILogger } from '../../types/interfaces/logger.interface.js';
 import type { IStorageBackend } from '../../types/interfaces/storage.interface.js';
+import type { Result } from '../../types/result.js';
 import type { ActivityService } from '../activity/activity-service.js';
 import type { AnnotationService } from '../annotation/annotation-service.js';
 import type { CollaborationService } from '../collaboration/collaboration-service.js';
@@ -570,6 +576,109 @@ interface RecordData {
   readonly cid?: CID;
   readonly record?: unknown;
   readonly pdsUrl: string;
+}
+
+/**
+ * Fields each governance collection's lexicon marks as required.
+ *
+ * @remarks
+ * `KnowledgeGraphService` treats a record missing one of these as a no-op but
+ * still reports success, so the processor would record the event as indexed
+ * and let the cursor advance past a proposal or ballot that never reached
+ * Neo4j. Checking presence here instead means a malformed record is routed to
+ * the DLQ, where it stays visible and replayable. `createdAt` is deliberately
+ * omitted: it is lexicon-required but unused by the indexing path, and
+ * rejecting on it would send otherwise indexable records to the DLQ.
+ */
+const GOVERNANCE_REQUIRED_FIELDS: Readonly<Record<string, readonly string[]>> = {
+  'pub.chive.graph.nodeProposal': ['proposalType', 'rationale'],
+  'pub.chive.graph.edgeProposal': ['proposalType', 'rationale'],
+  'pub.chive.graph.vote': ['proposalUri', 'vote'],
+};
+
+/**
+ * Names the required fields absent from a governance record.
+ *
+ * @param collection - Governance collection the record belongs to
+ * @param record - Decoded record from the firehose, if any
+ * @returns Missing field names; empty when the record is well formed
+ *
+ * @remarks
+ * A create or update carrying no decoded record at all is malformed in the
+ * same way as one missing fields, so it reports every required field.
+ */
+function missingGovernanceFields(collection: string, record: unknown): readonly string[] {
+  const required = GOVERNANCE_REQUIRED_FIELDS[collection] ?? [];
+  if (typeof record !== 'object' || record === null) {
+    return required;
+  }
+  const fields = record as Record<string, unknown>;
+  return required.filter((field) => {
+    const value = fields[field];
+    return value === undefined || value === null || value === '';
+  });
+}
+
+/**
+ * Removes an indexed governance record retracted from its source PDS.
+ */
+type GovernanceRecordDeletion = (uri: AtUri) => Promise<Result<void, Error>>;
+
+/**
+ * Deletion methods the knowledge graph service is expected to expose for
+ * retracted governance records.
+ *
+ * @remarks
+ * `KnowledgeGraphService` does not implement these yet. The processor probes
+ * for them at call time rather than assuming they exist so that a retraction
+ * is never silently counted as indexed: while a method is missing the event
+ * fails non-critically and lands in the DLQ, from which it can be replayed
+ * once the service gains the method.
+ */
+interface GovernanceRecordDeleter {
+  readonly deleteNodeProposal?: GovernanceRecordDeletion;
+  readonly deleteEdgeProposal?: GovernanceRecordDeletion;
+  readonly deleteVote?: GovernanceRecordDeletion;
+}
+
+/**
+ * Applies a governance record deletion via the knowledge graph service.
+ *
+ * @param graphService - Knowledge graph service handling governance records
+ * @param method - Deletion method to invoke
+ * @param uri - URI of the retracted record
+ * @returns Result indicating whether the deletion was applied
+ */
+async function deleteGovernanceRecord(
+  graphService: KnowledgeGraphService,
+  method: keyof GovernanceRecordDeleter,
+  uri: AtUri
+): Promise<Result<void, Error>> {
+  const deleter = graphService as unknown as GovernanceRecordDeleter;
+  const deleteFn = deleter[method];
+
+  if (typeof deleteFn !== 'function') {
+    return {
+      ok: false,
+      error: new ServiceUnavailableError(
+        `Knowledge graph service does not implement ${method}; retraction of ${uri} was not applied`,
+        'knowledge-graph'
+      ),
+    };
+  }
+
+  try {
+    return await deleteFn.call(deleter, uri);
+  } catch (error) {
+    return {
+      ok: false,
+      error: new DatabaseError(
+        'DELETE',
+        error instanceof Error ? error.message : String(error),
+        error instanceof Error ? error : undefined
+      ),
+    };
+  }
 }
 
 /**
@@ -1450,13 +1559,32 @@ async function processRecord(
     case 'pub.chive.graph.nodeProposal': {
       logger.debug('Processing node proposal', { action, uri });
 
-      if (action !== 'delete' && record) {
-        const result = await graphService.indexNodeProposal(record, metadata);
+      if (action === 'delete') {
+        const result = await deleteGovernanceRecord(graphService, 'deleteNodeProposal', uri);
         if (!result.ok) {
-          const error = result.error as Error;
-          logger.error('Failed to index node proposal', error, { uri, action });
-          return failure('Failed to index node proposal', false, error);
+          logger.error('Failed to delete node proposal', result.error, { uri });
+          return failure('Failed to delete node proposal', false, result.error);
         }
+        logger.info('Deleted node proposal from index', { uri });
+        return success();
+      }
+
+      const missingFields = missingGovernanceFields(collection, record);
+      if (missingFields.length > 0) {
+        const error = new ValidationError(
+          `Malformed node proposal: missing ${missingFields.join(', ')}`,
+          missingFields[0],
+          'required'
+        );
+        logger.error('Rejected malformed node proposal', error, { uri, action, missingFields });
+        return failure('Malformed node proposal', false, error);
+      }
+
+      const result = await graphService.indexNodeProposal(record, metadata);
+      if (!result.ok) {
+        const error = result.error as Error;
+        logger.error('Failed to index node proposal', error, { uri, action });
+        return failure('Failed to index node proposal', false, error);
       }
       return success();
     }
@@ -1464,13 +1592,32 @@ async function processRecord(
     case 'pub.chive.graph.edgeProposal': {
       logger.debug('Processing edge proposal', { action, uri });
 
-      if (action !== 'delete' && record) {
-        const result = await graphService.indexEdgeProposal(record, metadata);
+      if (action === 'delete') {
+        const result = await deleteGovernanceRecord(graphService, 'deleteEdgeProposal', uri);
         if (!result.ok) {
-          const error = result.error as Error;
-          logger.error('Failed to index edge proposal', error, { uri, action });
-          return failure('Failed to index edge proposal', false, error);
+          logger.error('Failed to delete edge proposal', result.error, { uri });
+          return failure('Failed to delete edge proposal', false, result.error);
         }
+        logger.info('Deleted edge proposal from index', { uri });
+        return success();
+      }
+
+      const missingFields = missingGovernanceFields(collection, record);
+      if (missingFields.length > 0) {
+        const error = new ValidationError(
+          `Malformed edge proposal: missing ${missingFields.join(', ')}`,
+          missingFields[0],
+          'required'
+        );
+        logger.error('Rejected malformed edge proposal', error, { uri, action, missingFields });
+        return failure('Malformed edge proposal', false, error);
+      }
+
+      const result = await graphService.indexEdgeProposal(record, metadata);
+      if (!result.ok) {
+        const error = result.error as Error;
+        logger.error('Failed to index edge proposal', error, { uri, action });
+        return failure('Failed to index edge proposal', false, error);
       }
       return success();
     }
@@ -1478,13 +1625,34 @@ async function processRecord(
     case 'pub.chive.graph.vote': {
       logger.debug('Processing vote', { action, uri });
 
-      if (action !== 'delete' && record) {
-        const result = await graphService.indexVote(record, metadata);
+      // A retracted ballot must stop counting toward the proposal's tally, so
+      // a deletion that cannot be applied is a failure rather than a no-op.
+      if (action === 'delete') {
+        const result = await deleteGovernanceRecord(graphService, 'deleteVote', uri);
         if (!result.ok) {
-          const error = result.error as Error;
-          logger.error('Failed to index vote', error, { uri, action });
-          return failure('Failed to index vote', false, error);
+          logger.error('Failed to delete vote', result.error, { uri });
+          return failure('Failed to delete vote', false, result.error);
         }
+        logger.info('Deleted vote from index', { uri });
+        return success();
+      }
+
+      const missingFields = missingGovernanceFields(collection, record);
+      if (missingFields.length > 0) {
+        const error = new ValidationError(
+          `Malformed vote: missing ${missingFields.join(', ')}`,
+          missingFields[0],
+          'required'
+        );
+        logger.error('Rejected malformed vote', error, { uri, action, missingFields });
+        return failure('Malformed vote', false, error);
+      }
+
+      const result = await graphService.indexVote(record, metadata);
+      if (!result.ok) {
+        const error = result.error as Error;
+        logger.error('Failed to index vote', error, { uri, action });
+        return failure('Failed to index vote', false, error);
       }
       return success();
     }

--- a/src/services/indexing/event-processor.ts
+++ b/src/services/indexing/event-processor.ts
@@ -504,6 +504,15 @@ export function createEventProcessor(
             }
           );
         }
+      } else {
+        // Non-critical failures are not rethrown, and the cursor has already
+        // advanced past this event, so without a DLQ the record is dropped for
+        // good. Say so loudly rather than letting a missing option look benign.
+        logger.warn('Event failed with no DLQ configured; record will not be indexed', {
+          uri,
+          collection,
+          error: result.error.message,
+        });
       }
 
       // Throw for critical failures to halt processing
@@ -1871,6 +1880,12 @@ export function createBatchEventProcessor(
               }
             );
           }
+        } else {
+          logger.warn('Event failed with no DLQ configured; record will not be indexed', {
+            uri,
+            collection: event.collection,
+            error: result.error.message,
+          });
         }
 
         // Track critical failures

--- a/src/services/indexing/event-processor.ts
+++ b/src/services/indexing/event-processor.ts
@@ -1684,15 +1684,30 @@ async function processRecord(
           const did = data.repo;
 
           await pool.query(
+            // A verified ORCID is Chive's own observation of a completed OAuth
+            // flow, not something the PDS record carries, so it must survive
+            // reindexing. Previously `orcid = EXCLUDED.orcid` overwrote it with
+            // whatever the profile record held — frequently null — on every
+            // profile update. On insert the verification is pulled in from
+            // orcid_verifications, which covers an author who verified before
+            // they were ever indexed.
             `INSERT INTO authors_index (
-              did, handle, display_name, bio, avatar_blob_cid, orcid, affiliations, field_ids,
-              pds_url, indexed_at, last_synced_at
-            ) VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())
+              did, handle, display_name, bio, avatar_blob_cid, orcid, orcid_verified_at,
+              affiliations, field_ids, pds_url, indexed_at, last_synced_at
+            ) VALUES (
+              $1, NULL, $2, $3, $4,
+              COALESCE((SELECT orcid FROM orcid_verifications WHERE did = $1), $5),
+              (SELECT verified_at FROM orcid_verifications WHERE did = $1),
+              $6, $7, $8, NOW(), NOW()
+            )
             ON CONFLICT (did) DO UPDATE SET
               display_name = EXCLUDED.display_name,
               bio = EXCLUDED.bio,
               avatar_blob_cid = EXCLUDED.avatar_blob_cid,
-              orcid = EXCLUDED.orcid,
+              orcid = CASE
+                WHEN authors_index.orcid_verified_at IS NOT NULL THEN authors_index.orcid
+                ELSE EXCLUDED.orcid
+              END,
               affiliations = EXCLUDED.affiliations,
               field_ids = EXCLUDED.field_ids,
               pds_url = EXCLUDED.pds_url,

--- a/src/services/indexing/indexed-collections.ts
+++ b/src/services/indexing/indexed-collections.ts
@@ -1,0 +1,67 @@
+/**
+ * The single list of collections Chive indexes.
+ *
+ * @remarks
+ * Three allow-lists used to describe "the collections we index" and had drifted
+ * apart: the firehose event processor's dispatch, `sync.indexRecord`'s manual
+ * reindex list, and the PDS scanner's backfill filter. A collection present in
+ * one and absent from another produces a different index depending on the path
+ * a record arrives by — a live firehose event indexes it, a manual reindex of
+ * the same record rejects it as unsupported, and a backfill skips it silently.
+ *
+ * `sync.indexRecord` accepted 13 collections while the event processor handled
+ * 20. Seven were unreachable by manual reindex, `pub.chive.graph.edgeProposal`
+ * among them, so an edge proposal that the firehose missed could not be
+ * recovered by force-indexing it.
+ *
+ * The list is derived from what the event processor actually dispatches on,
+ * because that is the live path and therefore the authoritative definition of
+ * "indexed". A test asserts the two agree, so adding a `case` without adding it
+ * here fails rather than silently reintroducing the divergence.
+ *
+ * The PDS scanner's governance subset is deliberately out of scope here; it is
+ * owned separately (G-04).
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+/**
+ * Collections indexed from the firehose and reachable by manual reindex.
+ *
+ * @public
+ */
+export const INDEXED_COLLECTIONS: readonly string[] = [
+  'pub.chive.actor.profile',
+  'pub.chive.actor.profileConfig',
+  'pub.chive.annotation.comment',
+  'pub.chive.annotation.entityLink',
+  'pub.chive.collaboration.invite',
+  'pub.chive.collaboration.inviteAcceptance',
+  'pub.chive.eprint.changelog',
+  'pub.chive.eprint.citation',
+  'pub.chive.eprint.relatedWork',
+  'pub.chive.eprint.submission',
+  'pub.chive.eprint.tag',
+  'pub.chive.eprint.userTag',
+  'pub.chive.eprint.version',
+  'pub.chive.graph.edge',
+  'pub.chive.graph.edgeProposal',
+  'pub.chive.graph.node',
+  'pub.chive.graph.nodeProposal',
+  'pub.chive.graph.vote',
+  'pub.chive.review.comment',
+  'pub.chive.review.endorsement',
+] as const;
+
+/**
+ * Reports whether a collection is one Chive indexes.
+ *
+ * @param collection - Collection NSID
+ * @returns True when the collection is indexed
+ *
+ * @public
+ */
+export function isIndexedCollection(collection: string): boolean {
+  return INDEXED_COLLECTIONS.includes(collection);
+}

--- a/src/services/knowledge-graph/graph-service.ts
+++ b/src/services/knowledge-graph/graph-service.ts
@@ -577,6 +577,13 @@ export class KnowledgeGraphService {
    *
    * @param options - Filter and pagination options
    * @returns Paginated proposals
+   * @throws {DatabaseError} If the graph query fails
+   *
+   * @remarks
+   * A read failure propagates rather than degrading to an empty page. An empty
+   * page is a meaningful answer — the UI renders it as "no proposals found"
+   * with HTTP 200, and the moderation badge reads `total` — so swallowing an
+   * outage here made a broken graph indistinguishable from an empty backlog.
    *
    * @public
    */
@@ -632,12 +639,11 @@ export class KnowledgeGraphService {
         total: result.total,
       };
     } catch (error) {
-      this.logger.error('Failed to list proposals', error instanceof Error ? error : undefined);
-      return {
-        proposals: [],
-        hasMore: false,
-        total: 0,
-      };
+      this.logger.error('Failed to list proposals', error instanceof Error ? error : undefined, {
+        status: options.status,
+        type: options.type,
+      });
+      throw this.asReadError('Failed to list proposals', error);
     }
   }
 
@@ -645,7 +651,12 @@ export class KnowledgeGraphService {
    * Gets a proposal by ID.
    *
    * @param proposalId - Proposal identifier
-   * @returns Proposal view or null if not found
+   * @returns Proposal view, or null when no proposal carries that identifier
+   * @throws {DatabaseError} If the graph query fails
+   *
+   * @remarks
+   * Null means absent and nothing else. Callers turn it into a 404, so a read
+   * failure returned as null reported a proposal that exists as missing.
    *
    * @public
    */
@@ -684,8 +695,29 @@ export class KnowledgeGraphService {
       this.logger.error('Failed to get proposal', error instanceof Error ? error : undefined, {
         proposalId,
       });
-      return null;
+      throw this.asReadError(`Failed to get proposal ${proposalId}`, error);
     }
+  }
+
+  /**
+   * Wraps a caught value as a read-side {@link DatabaseError}.
+   *
+   * @remarks
+   * Errors raised by the graph adapter are already typed; re-wrapping them
+   * would bury the failing operation the adapter recorded, so they pass
+   * through unchanged.
+   *
+   * @internal
+   */
+  private asReadError(context: string, error: unknown): DatabaseError {
+    if (error instanceof DatabaseError) {
+      return error;
+    }
+    return new DatabaseError(
+      'READ',
+      `${context}: ${error instanceof Error ? error.message : String(error)}`,
+      error instanceof Error ? error : undefined
+    );
   }
 
   /**

--- a/src/services/knowledge-graph/graph-service.ts
+++ b/src/services/knowledge-graph/graph-service.ts
@@ -126,6 +126,29 @@ export interface FacetedBrowseQuery {
 }
 
 /**
+ * Resolves the creation timestamp that orders a governance record.
+ *
+ * @remarks
+ * Proposal and vote lists sort on `createdAt`. That sort key has to come from
+ * the record itself, because ingest time is different on every rebuild from the
+ * firehose and would silently reorder governance history each time the index is
+ * rebuilt. Ingest time stays as the fallback for a record that carries no
+ * timestamp — or one that does not parse — since the sort key cannot be null.
+ *
+ * @param recordCreatedAt - `createdAt` as carried by the PDS record
+ * @param indexedAt - Ingest time, used only as a fallback
+ * @returns Authoritative creation timestamp for the record
+ */
+function resolveRecordCreatedAt(recordCreatedAt: string | undefined, indexedAt: Date): Date {
+  if (!recordCreatedAt) {
+    return indexedAt;
+  }
+
+  const parsed = new Date(recordCreatedAt);
+  return Number.isNaN(parsed.getTime()) ? indexedAt : parsed;
+}
+
+/**
  * Knowledge graph service implementation.
  *
  * @example
@@ -256,7 +279,7 @@ export class KnowledgeGraphService {
         proposedNode: proposalRecord.proposedNode as Partial<GraphNode> | undefined,
         rationale: proposalRecord.rationale,
         proposerDid,
-        createdAt: metadata.indexedAt,
+        createdAt: resolveRecordCreatedAt(proposalRecord.createdAt, metadata.indexedAt),
       });
 
       this.logger.info('Indexed node proposal', {
@@ -336,7 +359,7 @@ export class KnowledgeGraphService {
         proposedNode: proposalRecord.proposedEdge as Partial<GraphNode> | undefined,
         rationale: proposalRecord.rationale,
         proposerDid,
-        createdAt: metadata.indexedAt,
+        createdAt: resolveRecordCreatedAt(proposalRecord.createdAt, metadata.indexedAt),
       });
 
       this.logger.info('Indexed edge proposal', {
@@ -400,7 +423,7 @@ export class KnowledgeGraphService {
         voterRole: 'community-member', // Default role; actual role determined by governance service
         vote: voteRecord.vote,
         comment: voteRecord.comment,
-        createdAt: metadata.indexedAt,
+        createdAt: resolveRecordCreatedAt(voteRecord.createdAt, metadata.indexedAt),
       });
 
       this.logger.info('Indexed vote', {

--- a/src/services/metrics/metrics-service.ts
+++ b/src/services/metrics/metrics-service.ts
@@ -476,7 +476,8 @@ export class MetricsService {
    */
   async getTrending(
     window: '24h' | '7d' | '30d',
-    limit: number
+    limit: number,
+    offset = 0
   ): Promise<readonly TrendingEntry[]> {
     try {
       const now = Date.now();
@@ -577,7 +578,9 @@ export class MetricsService {
       } while (cursor !== '0');
 
       // Sort by score descending and take top N
-      const trending = uriScores.sort((a, b) => b.score - a.score).slice(0, limit);
+      // Paging slices the ranked list; without the offset every page returned
+      // the same first `limit` entries and the cursor advanced forever.
+      const trending = uriScores.sort((a, b) => b.score - a.score).slice(offset, offset + limit);
 
       return trending;
     } catch (error) {

--- a/src/services/pds-discovery/pds-scanner.ts
+++ b/src/services/pds-discovery/pds-scanner.ts
@@ -1180,15 +1180,26 @@ export class PDSScanner {
 
     try {
       await this.pool.query(
+        // Mirrors the event processor's profile upsert: a verified ORCID is
+        // Chive's own record of a completed OAuth flow and must survive a
+        // rescan, which would otherwise overwrite it from the PDS record.
         `INSERT INTO authors_index (
-          did, handle, display_name, bio, avatar_blob_cid, orcid, affiliations, field_ids,
-          pds_url, indexed_at, last_synced_at
-        ) VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())
+          did, handle, display_name, bio, avatar_blob_cid, orcid, orcid_verified_at,
+          affiliations, field_ids, pds_url, indexed_at, last_synced_at
+        ) VALUES (
+          $1, NULL, $2, $3, $4,
+          COALESCE((SELECT orcid FROM orcid_verifications WHERE did = $1), $5),
+          (SELECT verified_at FROM orcid_verifications WHERE did = $1),
+          $6, $7, $8, NOW(), NOW()
+        )
         ON CONFLICT (did) DO UPDATE SET
           display_name = EXCLUDED.display_name,
           bio = EXCLUDED.bio,
           avatar_blob_cid = EXCLUDED.avatar_blob_cid,
-          orcid = EXCLUDED.orcid,
+          orcid = CASE
+            WHEN authors_index.orcid_verified_at IS NOT NULL THEN authors_index.orcid
+            ELSE EXCLUDED.orcid
+          END,
           affiliations = EXCLUDED.affiliations,
           field_ids = EXCLUDED.field_ids,
           pds_url = EXCLUDED.pds_url,

--- a/src/storage/neo4j/adapter.ts
+++ b/src/storage/neo4j/adapter.ts
@@ -811,16 +811,22 @@ export class Neo4jAdapter implements IGraphDatabase {
 
   /**
    * Creates a vote on a proposal.
+   *
+   * @remarks
+   * `createdAt` comes from the vote record rather than the clock, and is set on
+   * every write rather than only on create. Ballot order is a sort key, so a
+   * rebuild of the index from the firehose has to reproduce the same order it
+   * had before; wall-clock ingest time would not.
    */
   async createVote(vote: Vote): Promise<void> {
     const query = `
       MERGE (v:Vote {uri: $uri})
-      ON CREATE SET v.createdAt = datetime()
       SET v.proposalUri = $proposalUri,
           v.voterDid = $voterDid,
           v.voterRole = $voterRole,
           v.vote = $vote,
           v.comment = $comment,
+          v.createdAt = datetime($createdAt),
           v.updatedAt = datetime()
       WITH v
       OPTIONAL MATCH (p:Proposal {uri: $proposalUri})
@@ -837,6 +843,7 @@ export class Neo4jAdapter implements IGraphDatabase {
       voterRole: vote.voterRole,
       vote: vote.vote,
       comment: vote.comment ?? null,
+      createdAt: vote.createdAt.toISOString(),
     });
   }
 
@@ -906,7 +913,20 @@ export class Neo4jAdapter implements IGraphDatabase {
   }
 
   /**
-   * Creates a proposal.
+   * Creates or re-indexes a proposal.
+   *
+   * @remarks
+   * `ON MATCH SET` mirrors every field the record carries, not just the
+   * proposed node and rationale: a proposal edited in its PDS can change its
+   * type, kind, subkind or target, and a re-index that copied only two fields
+   * left the rest describing the superseded version.
+   *
+   * `createdAt` is likewise taken from the record on every write. It is the
+   * sort key for the governance lists, so rebuilding the index from the
+   * firehose has to reproduce the order it had before; ingest time would not.
+   * Only `id`, `proposerDid` and `status` stay create-only — the first two are
+   * fixed by the URI, and `status` is set by moderation, so re-indexing the
+   * record must not reset a decided proposal back to pending.
    */
   async createProposal(proposal: {
     readonly uri: AtUri;
@@ -934,8 +954,13 @@ export class Neo4jAdapter implements IGraphDatabase {
         p.createdAt = datetime($createdAt),
         p.updatedAt = datetime()
       ON MATCH SET
+        p.proposalType = $proposalType,
+        p.kind = $kind,
+        p.subkind = $subkind,
+        p.targetUri = $targetUri,
         p.proposedNode = $proposedNode,
         p.rationale = $rationale,
+        p.createdAt = datetime($createdAt),
         p.updatedAt = datetime()
     `;
 

--- a/src/storage/neo4j/adapter.ts
+++ b/src/storage/neo4j/adapter.ts
@@ -12,6 +12,7 @@
 import neo4j, { Integer } from 'neo4j-driver';
 import { singleton } from 'tsyringe';
 
+import { createLogger } from '../../observability/logger.js';
 import { toAtUri, toDID } from '../../types/atproto-validators.js';
 import type { AtUri, DID } from '../../types/atproto.js';
 import { DatabaseError, NotFoundError } from '../../types/errors.js';
@@ -24,6 +25,7 @@ import type {
   ProposalFilters,
   FacetAggregation,
 } from '../../types/interfaces/graph.interface.js';
+import type { ILogger } from '../../types/interfaces/logger.interface.js';
 
 import { Neo4jConnection } from './connection.js';
 import { subkindToLabel } from './labels.js';
@@ -44,6 +46,16 @@ import type {
   UserRole,
   VoteType,
 } from './types.js';
+
+/**
+ * Module-level logger for row-level mapping faults.
+ *
+ * @remarks
+ * The adapter takes only a connection, so a per-row diagnostic has no injected
+ * logger to reach; the same module-level pattern is used by the Neo4j setup
+ * manager and the PostgreSQL connection.
+ */
+const logger: ILogger = createLogger({ service: 'neo4j-adapter' });
 
 /**
  * Neo4j adapter implementing the IGraphDatabase interface.
@@ -638,7 +650,9 @@ export class Neo4jAdapter implements IGraphDatabase {
       limit: neo4j.int(50),
     });
 
-    return result.records.map((record) => this.mapNeo4jProposal(record.get('p')));
+    return result.records
+      .map((record) => this.mapNeo4jProposal(record.get('p')))
+      .filter((proposal): proposal is NodeProposal => proposal !== null);
   }
 
   /**
@@ -704,11 +718,16 @@ export class Neo4jAdapter implements IGraphDatabase {
 
     const result = await this.connection.executeQuery<{ p: Neo4jProposal }>(query, params);
 
-    const proposals = result.records.map((record) => this.mapNeo4jProposal(record.get('p')));
-    const hasMore = proposals.length > (filters.limit ?? 50);
-    if (hasMore) {
-      proposals.pop();
-    }
+    // The query fetches one row beyond the page to detect a next page, so
+    // paging is decided on raw rows: an unmappable row that mapping drops must
+    // not end pagination early.
+    const limit = filters.limit ?? 50;
+    const hasMore = result.records.length > limit;
+    const pageRecords = hasMore ? result.records.slice(0, limit) : result.records;
+
+    const proposals = pageRecords
+      .map((record) => this.mapNeo4jProposal(record.get('p')))
+      .filter((proposal): proposal is NodeProposal => proposal !== null);
 
     // Get total count
     const countQuery = `
@@ -753,7 +772,7 @@ export class Neo4jAdapter implements IGraphDatabase {
       return null;
     }
 
-    return this.mapNeo4jProposal(record.get('p'));
+    return this.requireMappedProposal(record.get('p'), rkey);
   }
 
   async getProposal(uri: AtUri): Promise<NodeProposal | null> {
@@ -769,7 +788,25 @@ export class Neo4jAdapter implements IGraphDatabase {
       return null;
     }
 
-    return this.mapNeo4jProposal(record.get('p'));
+    return this.requireMappedProposal(record.get('p'), uri);
+  }
+
+  /**
+   * Maps a single proposal row, treating an unmappable row as a read failure.
+   *
+   * @throws {DatabaseError} If the row cannot be mapped
+   *
+   * @remarks
+   * Single-record lookups return null for "no such proposal", which callers
+   * render as a 404. A corrupt row is a datastore fault, not a missing
+   * proposal, so it surfaces as an error instead.
+   */
+  private requireMappedProposal(row: Neo4jProposal, identifier: string): NodeProposal {
+    const proposal = this.mapNeo4jProposal(row);
+    if (!proposal) {
+      throw new DatabaseError('READ', `Proposal ${identifier} is stored in an unmappable state`);
+    }
+    return proposal;
   }
 
   /**
@@ -1083,8 +1120,16 @@ export class Neo4jAdapter implements IGraphDatabase {
 
   /**
    * Map Neo4j proposal to NodeProposal.
+   *
+   * @returns The mapped proposal, or null when the row cannot be mapped
+   *
+   * @remarks
+   * Throwing on a malformed row aborted the enclosing query, so one proposal
+   * with an unparseable proposer DID emptied every proposal list. Skipping the
+   * row keeps the rest of the page readable; callers that fetch a single row
+   * turn the null back into a {@link DatabaseError}.
    */
-  private mapNeo4jProposal(proposal: Neo4jProposal): NodeProposal {
+  private mapNeo4jProposal(proposal: Neo4jProposal): NodeProposal | null {
     const props = proposal.properties ?? proposal;
 
     const uriVal = props.uri as string | undefined;
@@ -1110,7 +1155,11 @@ export class Neo4jAdapter implements IGraphDatabase {
 
     const proposerDid = toDID(proposerDidStr);
     if (!proposerDid) {
-      throw new DatabaseError('READ', `Invalid DID in proposal: ${proposerDidStr}`);
+      logger.warn('Skipping proposal with unparseable proposer DID', {
+        uri: uriVal,
+        proposerDid: proposerDidStr,
+      });
+      return null;
     }
 
     const createdAt = createdAtRaw instanceof Date ? createdAtRaw : new Date(String(createdAtRaw));

--- a/src/storage/neo4j/collaboration-graph.ts
+++ b/src/storage/neo4j/collaboration-graph.ts
@@ -225,7 +225,16 @@ export class CollaborationGraph {
    */
   async getCollaborationStrength(did1: DID, did2: DID): Promise<CollaborationStrength | null> {
     const query = `
-      MATCH (a1:Author {did: $did1})-[r:COAUTHORED_WITH]-(a2:Author {did: $did2})
+      // Authors are stored as (:Node:Object:Person) with subkind 'author' and the
+      // DID under metadata.did — see AuthorRepository.createCoauthorship, which
+      // is what writes COAUTHORED_WITH. This query matched (:Author {did}), a
+      // label and property pair nothing ever creates, so collaboration strength
+      // was null for every pair of authors that had ever collaborated.
+      MATCH (a1:Node:Object:Person)
+      WHERE a1.subkind = 'author' AND a1.metadata.did = $did1
+      MATCH (a2:Node:Object:Person)
+      WHERE a2.subkind = 'author' AND a2.metadata.did = $did2
+      MATCH (a1)-[r:COAUTHORED_WITH]-(a2)
       RETURN
         $did1 AS author1Did,
         $did2 AS author2Did,

--- a/src/storage/neo4j/facet-manager.ts
+++ b/src/storage/neo4j/facet-manager.ts
@@ -70,6 +70,16 @@ export interface BatchAssignmentResult {
 }
 
 /**
+ * Largest traversal depth accepted by {@link FacetManager.getChildFacets}.
+ *
+ * @remarks
+ * The depth is interpolated into the Cypher text rather than parameterized,
+ * so it is bounded as well as type-checked: an unbounded variable-length
+ * traversal over a dense facet graph is a cheap way to exhaust the server.
+ */
+const MAX_FACET_DEPTH = 10;
+
+/**
  * Facet manager for 10-dimensional classification system.
  *
  * Manages faceted classification using PMEST (Personality, Matter, Energy, Space, Time)
@@ -311,7 +321,7 @@ export class FacetManager {
    */
   async createFacet(node: GraphNode): Promise<AtUri> {
     const query = `
-      CREATE (f:Node:Node:Facet {
+      CREATE (f:Node:Facet {
         id: $id,
         uri: $uri,
         kind: 'type',
@@ -615,15 +625,25 @@ export class FacetManager {
    * @returns Child facet nodes
    */
   async getChildFacets(parentUri: AtUri, maxDepth = 1): Promise<GraphNode[]> {
+    // Cypher does not accept a parameter as a variable-length bound: `*1..$n`
+    // is a syntax error, so this query failed on every call. The bound has to
+    // be part of the query text, which means it cannot be parameterized and
+    // must be proven to be a plain integer before interpolation.
+    if (!Number.isInteger(maxDepth) || maxDepth < 1 || maxDepth > MAX_FACET_DEPTH) {
+      throw new RangeError(
+        `maxDepth must be an integer between 1 and ${MAX_FACET_DEPTH}, received ${String(maxDepth)}`
+      );
+    }
+
     const query = `
-      MATCH (parent:Node:Node:Facet {uri: $parentUri})<-[:EDGE {relationSlug: 'narrower'}*1..$maxDepth]-(child:Node:Facet)
+      MATCH (parent:Node:Facet {uri: $parentUri})<-[:EDGE {relationSlug: 'narrower'}*1..${maxDepth}]-(child:Node:Facet)
       RETURN DISTINCT child
       ORDER BY child.label
     `;
 
     const result = await this.connection.executeQuery<{
       child: Record<string, string | number | Date | string[]>;
-    }>(query, { parentUri, maxDepth: neo4j.int(maxDepth) });
+    }>(query, { parentUri });
 
     return result.records.map((record) => this.mapFacet(record.get('child')));
   }
@@ -636,7 +656,7 @@ export class FacetManager {
    */
   async getParentFacets(childUri: AtUri): Promise<GraphNode[]> {
     const query = `
-      MATCH (child:Node:Node:Facet {uri: $childUri})-[:EDGE {relationSlug: 'broader'}]->(parent:Node:Facet)
+      MATCH (child:Node:Facet {uri: $childUri})-[:EDGE {relationSlug: 'broader'}]->(parent:Node:Facet)
       RETURN parent
       ORDER BY parent.label
     `;

--- a/src/storage/neo4j/graph-algorithms.ts
+++ b/src/storage/neo4j/graph-algorithms.ts
@@ -25,6 +25,22 @@ import type { Neo4jConnection } from './connection.js';
 import type { RelationshipSlug } from './types.js';
 
 /**
+ * NOTE ON `INTERESTED_IN`
+ *
+ * Nothing in the codebase creates an `INTERESTED_IN` relationship. It appears
+ * only in read queries — here and in graph-algorithms.ts — so any path that
+ * depends on it alone returns an empty result no matter what else is correct.
+ * The node labels in these queries have been aligned with what the write side
+ * actually creates (`:Node:Field`, not `:FieldNode`), which repairs the
+ * `EXPERT_IN` half, but the interest half cannot be repaired by relabelling:
+ * there is no writer to relabel against.
+ *
+ * Recording a user's declared interests is a missing feature rather than a
+ * broken query. Until something writes the relationship, interest-based
+ * recommendations are silently empty, and adding a writer is the fix.
+ */
+
+/**
  * Path between two nodes.
  */
 export interface Path {
@@ -619,10 +635,10 @@ export class GraphAlgorithms {
    */
   async recommendFields(userDid: DID, limit = 20): Promise<Recommendation[]> {
     const query = `
-      MATCH (user:User {did: $userDid})-[:INTERESTED_IN|EXPERT_IN]->(userField:FieldNode)
+      MATCH (user:User {did: $userDid})-[:INTERESTED_IN|EXPERT_IN]->(userField:Node:Field)
 
       // Find similar fields using graph proximity
-      MATCH (userField)-[:RELATED_TO|SUBFIELD_OF*1..2]-(candidate:FieldNode)
+      MATCH (userField)-[:RELATED_TO|SUBFIELD_OF*1..2]-(candidate:Node:Field)
       WHERE NOT (user)-[:INTERESTED_IN|EXPERT_IN]->(candidate)
 
       WITH candidate, count(*) AS proximity

--- a/src/storage/neo4j/node-repository.ts
+++ b/src/storage/neo4j/node-repository.ts
@@ -155,6 +155,47 @@ export class NodeRepository {
   }
 
   /**
+   * Get several nodes by URI in one query.
+   *
+   * @param uris - Node AT-URIs
+   * @returns Map of URI to node, omitting URIs with no node
+   *
+   * @remarks
+   * Faceted browse resolved value labels with one `getNode` per edge inside a
+   * per-facet loop, so a browse with a limit of 100 cost 100 sequential Neo4j
+   * round trips per facet. `WHERE n.uri IN $uris` collapses each facet's
+   * lookups into one.
+   *
+   * @public
+   */
+  async getNodesByUris(uris: readonly AtUri[]): Promise<Map<AtUri, GraphNode>> {
+    const found = new Map<AtUri, GraphNode>();
+
+    if (uris.length === 0) {
+      return found;
+    }
+
+    const query = `
+      MATCH (n:Node)
+      WHERE n.uri IN $uris
+      RETURN n
+    `;
+
+    const result = await this.connection.executeQuery<{ n: GraphNode }>(query, {
+      uris: [...new Set(uris)],
+    });
+
+    for (const record of result.records) {
+      const node = this.mapRecordToNode(record.get('n'));
+      if (node.uri) {
+        found.set(node.uri, node);
+      }
+    }
+
+    return found;
+  }
+
+  /**
    * Get a node by ID.
    *
    * @param id - Node ID (UUID)

--- a/src/storage/neo4j/recommendations.ts
+++ b/src/storage/neo4j/recommendations.ts
@@ -19,6 +19,22 @@ import type { ILogger } from '../../types/interfaces/logger.interface.js';
 import type { Neo4jConnection } from './connection.js';
 
 /**
+ * NOTE ON `INTERESTED_IN`
+ *
+ * Nothing in the codebase creates an `INTERESTED_IN` relationship. It appears
+ * only in read queries — here and in graph-algorithms.ts — so any path that
+ * depends on it alone returns an empty result no matter what else is correct.
+ * The node labels in these queries have been aligned with what the write side
+ * actually creates (`:Node:Field`, not `:FieldNode`), which repairs the
+ * `EXPERT_IN` half, but the interest half cannot be repaired by relabelling:
+ * there is no writer to relabel against.
+ *
+ * Recording a user's declared interests is a missing feature rather than a
+ * broken query. Until something writes the relationship, interest-based
+ * recommendations are silently empty, and adding a writer is the fix.
+ */
+
+/**
  * Paper recommendation result.
  */
 export interface PaperRecommendation {
@@ -150,7 +166,7 @@ export class RecommendationService {
     const query = `
       // Get user's fields of interest
       MATCH (user:User {did: $userDid})
-      OPTIONAL MATCH (user)-[:INTERESTED_IN]->(field:FieldNode)
+      OPTIONAL MATCH (user)-[:INTERESTED_IN]->(field:Node:Field)
       WITH user, collect(DISTINCT field) AS userFields
 
       // Find papers from user's fields and citation network
@@ -474,12 +490,12 @@ export class RecommendationService {
 
     const query = `
       MATCH (user:User {did: $userDid})
-      OPTIONAL MATCH (user)-[:INTERESTED_IN]->(currentField:FieldNode)
+      OPTIONAL MATCH (user)-[:INTERESTED_IN]->(currentField:Node:Field)
       WITH user, collect(currentField) AS currentFields
 
       // Find related fields through graph structure
       UNWIND currentFields AS field
-      MATCH (field)-[:RELATED_TO|SUBFIELD_OF*1..2]-(candidate:FieldNode)
+      MATCH (field)-[:RELATED_TO|SUBFIELD_OF*1..2]-(candidate:Node:Field)
       WHERE NOT candidate IN currentFields
 
       WITH candidate, count(*) AS proximity

--- a/src/storage/postgresql/adapter.ts
+++ b/src/storage/postgresql/adapter.ts
@@ -187,6 +187,16 @@ export class PostgreSQLAdapter implements IStorageBackend {
   }
 
   /**
+   * Fetches several eprints in one query.
+   *
+   * @param uris - Eprint URIs to fetch
+   * @returns Map of URI to eprint, omitting URIs with no row
+   */
+  async getEprints(uris: readonly AtUri[]): Promise<Map<AtUri, StoredEprint>> {
+    return this.eprintsRepo.findByUris(uris);
+  }
+
+  /**
    * Queries eprints by author.
    *
    * @param author - Author DID

--- a/src/storage/postgresql/adapter.ts
+++ b/src/storage/postgresql/adapter.ts
@@ -607,14 +607,20 @@ export class PostgreSQLAdapter implements IStorageBackend {
     limit: number,
     offset: number
   ): Promise<{ uris: AtUri[]; total: number }> {
-    const normTag = PostgreSQLAdapter.normalizeExpr('tag');
+    // Qualified so the tag lookup can join eprints_index and drop tags whose
+    // eprint has been soft-deleted; an unjoined tag row would otherwise keep a
+    // deleted eprint reachable through community tags.
+    const normTag = PostgreSQLAdapter.normalizeExpr('t.tag');
     const normKw = PostgreSQLAdapter.normalizeExpr('k');
 
     const countResult = await this.pool.query<{ count: string }>(
       `SELECT COUNT(*) AS count FROM (
-         SELECT DISTINCT eprint_uri AS uri FROM user_tags_index WHERE ${normTag} = $1
+         SELECT DISTINCT t.eprint_uri AS uri FROM user_tags_index t
+           JOIN eprints_index te ON te.uri = t.eprint_uri
+           WHERE ${normTag} = $1 AND te.deleted_at IS NULL
          UNION
-         SELECT DISTINCT uri FROM eprints_index, LATERAL unnest(keywords) AS k WHERE ${normKw} = $1
+         SELECT DISTINCT uri FROM eprints_index, LATERAL unnest(keywords) AS k
+           WHERE ${normKw} = $1 AND deleted_at IS NULL
        ) combined`,
       [normalizedTerm]
     );
@@ -626,9 +632,12 @@ export class PostgreSQLAdapter implements IStorageBackend {
 
     const result = await this.pool.query<{ uri: string }>(
       `SELECT uri FROM (
-         SELECT DISTINCT eprint_uri AS uri FROM user_tags_index WHERE ${normTag} = $1
+         SELECT DISTINCT t.eprint_uri AS uri FROM user_tags_index t
+           JOIN eprints_index te ON te.uri = t.eprint_uri
+           WHERE ${normTag} = $1 AND te.deleted_at IS NULL
          UNION
-         SELECT DISTINCT uri FROM eprints_index, LATERAL unnest(keywords) AS k WHERE ${normKw} = $1
+         SELECT DISTINCT uri FROM eprints_index, LATERAL unnest(keywords) AS k
+           WHERE ${normKw} = $1 AND deleted_at IS NULL
        ) combined
        ORDER BY uri
        LIMIT $2 OFFSET $3`,

--- a/src/storage/postgresql/adapter.ts
+++ b/src/storage/postgresql/adapter.ts
@@ -673,6 +673,12 @@ export class PostgreSQLAdapter implements IStorageBackend {
 
   /**
    * Deletes a record from an index table by AT-URI.
+   *
+   * @remarks
+   * Only tables that actually exist and are keyed by a `uri` column may be
+   * passed. `extracted_citations` is deliberately absent: it is keyed by
+   * `user_record_uri`, so citation tombstones go through {@link deleteCitation}
+   * instead.
    */
   async deleteByUri(table: string, uri: AtUri): Promise<void> {
     // Allowlist of valid table names to prevent SQL injection
@@ -680,8 +686,7 @@ export class PostgreSQLAdapter implements IStorageBackend {
       'user_tags_index',
       'reviews_index',
       'endorsements_index',
-      'citations_index',
-      'related_works_index',
+      'user_related_works_index',
     ];
     if (!validTables.includes(table)) {
       throw new Error(`Invalid table name: ${table}`);

--- a/src/storage/postgresql/eprints-repository.ts
+++ b/src/storage/postgresql/eprints-repository.ts
@@ -412,6 +412,49 @@ export class EprintsRepository {
   }
 
   /**
+   * Fetches several eprints in one query.
+   *
+   * @param uris - Eprint URIs to fetch
+   * @returns Map of URI to eprint, omitting URIs with no row
+   *
+   * @remarks
+   * Callers that need many eprints were fetching them one at a time. On the
+   * author autocomplete that meant up to 75 sequential round trips per
+   * keystroke, each waiting on the last. One `uri = ANY($1)` replaces the lot.
+   *
+   * A missing URI is simply absent from the map rather than being an error:
+   * the index can legitimately lag a search result.
+   *
+   * @public
+   */
+  async findByUris(uris: readonly AtUri[]): Promise<Map<AtUri, StoredEprint>> {
+    const found = new Map<AtUri, StoredEprint>();
+
+    if (uris.length === 0) {
+      return found;
+    }
+
+    try {
+      const unique = [...new Set(uris)];
+      const result = await this.pool.query<EprintRow>(
+        `SELECT uri, cid, authors, submitted_by, paper_did, title, abstract, abstract_plain_text, document_blob_cid, document_blob_mime_type, document_blob_size, document_format, version, keywords, license, license_uri, publication_status, published_version, external_ids, related_works, repositories, funding, conference_presentation, supplementary_materials, fields, needs_abstract_migration, pds_url, indexed_at, created_at
+         FROM eprints_index
+         WHERE uri = ANY($1::text[]) AND deleted_at IS NULL`,
+        [unique]
+      );
+
+      for (const row of result.rows) {
+        const eprint = this.rowToEprint(row);
+        found.set(eprint.uri, eprint);
+      }
+
+      return found;
+    } catch (error) {
+      throw error instanceof Error ? error : new Error(`Failed to find eprints: ${String(error)}`);
+    }
+  }
+
+  /**
    * Queries eprints by author.
    *
    * @param author - Author DID

--- a/src/storage/postgresql/eprints-repository.ts
+++ b/src/storage/postgresql/eprints-repository.ts
@@ -463,6 +463,7 @@ export class EprintsRepository {
           fields, needs_abstract_migration, pds_url, indexed_at, created_at
         FROM eprints_index
         WHERE authors @> $1::jsonb
+          AND deleted_at IS NULL
         ORDER BY ${sortColumn} ${sortDirection}
         LIMIT $2 OFFSET $3
       `;
@@ -505,6 +506,7 @@ export class EprintsRepository {
         SELECT COUNT(*)::int AS count
         FROM eprints_index
         WHERE authors @> $1::jsonb
+          AND deleted_at IS NULL
       `;
 
       const result = await this.pool.query<{ count: number }>(query, [
@@ -880,7 +882,8 @@ export class EprintsRepository {
     const query = `
       SELECT uri
       FROM eprints_index
-      WHERE ${conditions.join(' OR ')}
+      WHERE (${conditions.join(' OR ')})
+        AND deleted_at IS NULL
       ORDER BY created_at DESC
       LIMIT $${fieldUris.length + 1}
     `;

--- a/src/storage/postgresql/migrations/1741600000000_firehose-dlq-event-columns.ts
+++ b/src/storage/postgresql/migrations/1741600000000_firehose-dlq-event-columns.ts
@@ -1,0 +1,64 @@
+/**
+ * Adds the event-identity and error-classification columns the dead letter
+ * queue has always written to.
+ *
+ * @remarks
+ * `DeadLetterQueue.add` inserts `seq`, `repo_did`, `event_type` and
+ * `error_type`, and `list`/`getStats` select them, but the initial schema never
+ * created them and no later migration added them. Production acquired the
+ * columns out of band, so the drift stayed invisible there while any database
+ * built from migrations — CI, a fresh deploy, a restored backup — had a queue
+ * that raised `column "seq" of relation "firehose_dlq" does not exist` on every
+ * write. The failure is swallowed by the event processor's own error handling,
+ * so the record was dropped exactly as if no queue existed.
+ *
+ * `IF NOT EXISTS` keeps this a no-op against the drifted production table.
+ */
+
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumns(
+    'firehose_dlq',
+    {
+      seq: { type: 'bigint' },
+      repo_did: { type: 'text' },
+      event_type: { type: 'text' },
+      error_type: { type: 'text' },
+    },
+    { ifNotExists: true }
+  );
+
+  // The queue is read by repo, by event type and by error class when triaging
+  // a backlog; the retry worker also scans unprocessed entries by age.
+  pgm.createIndex('firehose_dlq', 'repo_did', {
+    name: 'idx_firehose_dlq_repo_did',
+    ifNotExists: true,
+  });
+  pgm.createIndex('firehose_dlq', 'event_type', {
+    name: 'idx_firehose_dlq_event_type',
+    ifNotExists: true,
+  });
+  pgm.createIndex('firehose_dlq', 'error_type', {
+    name: 'idx_firehose_dlq_error_type',
+    ifNotExists: true,
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropIndex('firehose_dlq', 'error_type', {
+    name: 'idx_firehose_dlq_error_type',
+    ifExists: true,
+  });
+  pgm.dropIndex('firehose_dlq', 'event_type', {
+    name: 'idx_firehose_dlq_event_type',
+    ifExists: true,
+  });
+  pgm.dropIndex('firehose_dlq', 'repo_did', {
+    name: 'idx_firehose_dlq_repo_did',
+    ifExists: true,
+  });
+  pgm.dropColumns('firehose_dlq', ['seq', 'repo_did', 'event_type', 'error_type'], {
+    ifExists: true,
+  });
+}

--- a/src/storage/postgresql/migrations/1741700000000_reviews-parent-comment-index.ts
+++ b/src/storage/postgresql/migrations/1741700000000_reviews-parent-comment-index.ts
@@ -1,0 +1,39 @@
+/**
+ * Indexes the `parent_comment` foreign key on `reviews_index`.
+ *
+ * @remarks
+ * `parent_comment` carries a foreign key to `reviews_index(uri)` with
+ * `ON DELETE CASCADE`, but no index. PostgreSQL does not index foreign keys
+ * automatically, so every thread load — which fetches replies by parent — and
+ * every cascade check on delete had to scan `reviews_index` end to end. The
+ * cost grows with the whole review table rather than with the thread.
+ *
+ * The column was renamed from `parent_review_uri` to `parent_comment` for
+ * lexicon alignment; the rename carried the constraint across but never added
+ * an index, and the absence is invisible until the table is large.
+ *
+ * The index is partial. A top-level comment has a null `parent_comment`, those
+ * are the majority of rows, and none of them are ever looked up by parent.
+ *
+ * Note that the pre-existing `idx_reviews_parent_uri` is deliberately left in
+ * place. It indexes a different column that `reviews-repository.ts` still
+ * selects and filters on, so despite looking like a leftover of the same
+ * rename it is not dead.
+ */
+
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createIndex('reviews_index', 'parent_comment', {
+    name: 'idx_reviews_parent_comment',
+    where: 'parent_comment IS NOT NULL',
+    ifNotExists: true,
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropIndex('reviews_index', 'parent_comment', {
+    name: 'idx_reviews_parent_comment',
+    ifExists: true,
+  });
+}

--- a/src/storage/postgresql/migrations/1741800000000_orcid-verifications.ts
+++ b/src/storage/postgresql/migrations/1741800000000_orcid-verifications.ts
@@ -1,0 +1,53 @@
+/**
+ * Records verified ORCID iDs durably, independent of the author index.
+ *
+ * @remarks
+ * ORCID verification wrote its result with `UPDATE authors_index ... WHERE did`
+ * and, when that matched no rows, logged that the value would "be picked up
+ * when they are indexed" and discarded it. Nothing persisted it, so there was
+ * nothing for indexing to pick up: an author who verified before appearing in
+ * the index lost the verification permanently, and the OAuth round trip that
+ * produced it reported success.
+ *
+ * The index row is also rebuilt from the firehose, and that upsert assigned
+ * `orcid` straight from the incoming profile record — so even for an indexed
+ * author, the next profile update overwrote a verified ORCID with whatever the
+ * PDS record happened to carry, including null. Verification cannot live only
+ * in a table that is reconstructed from someone else's data.
+ *
+ * This table is the source of truth for the verification itself. It is not
+ * firehose-derived and is therefore not rebuildable from it, which is correct:
+ * it records something Chive observed (a completed ORCID OAuth flow) rather
+ * than something a PDS holds. `authors_index.orcid` stays as the denormalized
+ * copy that queries read.
+ *
+ * `orcid` is unique: an ORCID iD identifies one researcher, and two DIDs
+ * claiming the same one is a conflict to surface rather than to store twice.
+ */
+
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable(
+    'orcid_verifications',
+    {
+      did: { type: 'text', primaryKey: true, comment: 'DID of the verified account' },
+      orcid: { type: 'text', notNull: true, comment: 'Verified ORCID iD' },
+      verified_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: pgm.func('NOW()'),
+        comment: 'When the ORCID OAuth flow completed',
+      },
+    },
+    { ifNotExists: true }
+  );
+
+  pgm.createConstraint('orcid_verifications', 'orcid_verifications_orcid_unique', {
+    unique: 'orcid',
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable('orcid_verifications', { ifExists: true });
+}

--- a/src/types/atproto-validators.ts
+++ b/src/types/atproto-validators.ts
@@ -57,6 +57,30 @@ export function toAtUri(uri: string): AtUri | null {
 }
 
 /**
+ * Reports whether a string is a well-formed `did:plc:` identifier.
+ *
+ * @param did - Candidate DID string
+ * @returns True when the value is `did:plc:` followed by 24 base32-sortable characters
+ *
+ * @remarks
+ * PLC identifiers are exactly 24 characters drawn from the base32-sortable
+ * alphabet (`a`–`z`, `2`–`7`). {@link toDID} deliberately does not enforce this:
+ * it accepts any syntactically plausible DID across every method, and hundreds
+ * of test fixtures rely on short readable placeholders.
+ *
+ * This stricter check exists for values that must be a real PLC identity rather
+ * than a plausible-looking string — configuration in particular. The governance
+ * PDS DID was configured as `did:plc:chive-governance` in every environment
+ * file, which is not a PLC identifier at all; nothing rejected it, and the
+ * governance sync resolved nothing for as long as it was set.
+ *
+ * @public
+ */
+export function isPlcDid(did: string): boolean {
+  return /^did:plc:[a-z2-7]{24}$/.test(did);
+}
+
+/**
  * Validates and brands a DID string.
  *
  * @remarks
@@ -112,7 +136,7 @@ export function toDID(did: string): DID | null {
  * Common Chive NSIDs:
  * - `pub.chive.eprint.submission`
  * - `pub.chive.review.comment`
- * - `pub.chive.graph.fieldProposal`
+ * - `pub.chive.graph.nodeProposal`
  *
  * @param nsid - Potential NSID string
  * @returns Branded NSID if valid, null otherwise

--- a/src/types/interfaces/storage.interface.ts
+++ b/src/types/interfaces/storage.interface.ts
@@ -445,6 +445,18 @@ export interface IStorageBackend {
   getEprint(uri: AtUri): Promise<StoredEprint | null>;
 
   /**
+   * Fetches several eprints in a single query.
+   *
+   * @param uris - Eprint URIs to fetch
+   * @returns Map of URI to eprint, omitting URIs with no row
+   *
+   * @remarks
+   * Exists so callers handling a page of results do not issue one round trip
+   * per item; a missing URI is absent from the map rather than an error.
+   */
+  getEprints(uris: readonly AtUri[]): Promise<Map<AtUri, StoredEprint>>;
+
+  /**
    * Queries eprints by author.
    *
    * @param author - Author DID

--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -1,0 +1,177 @@
+/**
+ * Guards against server-side request forgery when fetching user-supplied URLs.
+ *
+ * @remarks
+ * Several handlers fetch hosts that a caller controls: PDS registration probes
+ * the submitted `pdsUrl`, and `did:web` resolution derives its host from the
+ * caller's DID. Without a check, those become a request generator pointed at
+ * whatever the server can reach but the caller cannot — cloud metadata at
+ * `169.254.169.254`, `localhost` admin ports, or private RFC 1918 services.
+ * Registration makes the reach persistent, since the host is stored and the
+ * scanner returns to it later.
+ *
+ * Hostname inspection alone is not enough: a name under the caller's control
+ * can resolve to a private address, and can resolve differently on a second
+ * lookup. Every resolved address is therefore checked, and the caller is
+ * expected to pass `redirect: 'error'` so a public host cannot bounce the
+ * request inward.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+/**
+ * Error raised when a URL is not safe for the server to fetch.
+ *
+ * @public
+ */
+export class SsrfBlockedError extends Error {
+  /**
+   * Creates an SSRF rejection.
+   *
+   * @param message - Human-readable reason the URL was rejected
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfBlockedError';
+  }
+}
+
+/**
+ * Reports whether an IPv4 address is outside the publicly routable range.
+ *
+ * @param address - Dotted-quad IPv4 address
+ * @returns True when the address is private, loopback, link-local or reserved
+ */
+function isPrivateIPv4(address: string): boolean {
+  const parts = address.split('.').map((part) => Number.parseInt(part, 10));
+  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part))) {
+    return true;
+  }
+  const [a = 0, b = 0] = parts;
+
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 127) return true; // loopback
+  if (a === 0) return true; // "this network"
+  if (a === 169 && b === 254) return true; // link-local, incl. cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
+  if (a === 192 && b === 0) return true; // IETF protocol assignments
+  if (a >= 224) return true; // multicast and reserved
+
+  return false;
+}
+
+/**
+ * Reports whether an IPv6 address is outside the publicly routable range.
+ *
+ * @param address - IPv6 address
+ * @returns True when the address is loopback, unique-local, link-local or maps
+ *   onto a non-public IPv4 address
+ */
+function isPrivateIPv6(address: string): boolean {
+  const normalized = address.toLowerCase().split('%')[0] ?? '';
+
+  if (normalized === '::1' || normalized === '::') return true;
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true; // unique-local
+  if (normalized.startsWith('fe80')) return true; // link-local
+  if (normalized.startsWith('ff')) return true; // multicast
+
+  // IPv4-mapped (::ffff:169.254.169.254) reaches the same hosts as IPv4.
+  const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(normalized);
+  if (mapped?.[1]) {
+    return isPrivateIPv4(mapped[1]);
+  }
+
+  return false;
+}
+
+/**
+ * Reports whether an IP address is safe for the server to connect to.
+ *
+ * @param address - IPv4 or IPv6 address
+ * @returns True when the address is not publicly routable
+ *
+ * @public
+ */
+export function isPrivateAddress(address: string): boolean {
+  const version = isIP(address);
+  if (version === 4) return isPrivateIPv4(address);
+  if (version === 6) return isPrivateIPv6(address);
+  return true; // not an IP literal at all: treat as unsafe
+}
+
+/**
+ * Validates that a user-supplied URL is safe for the server to fetch.
+ *
+ * @param rawUrl - URL as supplied by the caller
+ * @param options - `allowHttp` permits plain HTTP, for test stacks only
+ * @returns The parsed URL when it passes every check
+ * @throws SsrfBlockedError when the URL is malformed, uses a rejected scheme,
+ *   carries embedded credentials, or resolves to a non-public address
+ *
+ * @public
+ */
+export async function assertFetchableUrl(
+  rawUrl: string,
+  options: { readonly allowHttp?: boolean } = {}
+): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new SsrfBlockedError('URL is not parseable');
+  }
+
+  const allowedProtocols = options.allowHttp ? ['https:', 'http:'] : ['https:'];
+  if (!allowedProtocols.includes(url.protocol)) {
+    throw new SsrfBlockedError(
+      `URL scheme ${url.protocol} is not allowed; expected ${allowedProtocols.join(' or ')}`
+    );
+  }
+
+  // Credentials in the URL are never appropriate here and can confuse parsers
+  // that split on '@' differently from the one used for validation.
+  if (url.username !== '' || url.password !== '') {
+    throw new SsrfBlockedError('URL must not contain embedded credentials');
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+
+  // An IP literal is checked directly; there is nothing to resolve.
+  if (isIP(hostname) !== 0) {
+    if (isPrivateAddress(hostname)) {
+      throw new SsrfBlockedError(`URL resolves to a non-public address (${hostname})`);
+    }
+    return url;
+  }
+
+  if (hostname.toLowerCase() === 'localhost' || hostname.toLowerCase().endsWith('.localhost')) {
+    throw new SsrfBlockedError('URL resolves to a non-public address (localhost)');
+  }
+
+  let resolved: { address: string }[];
+  try {
+    resolved = await lookup(hostname, { all: true });
+  } catch {
+    throw new SsrfBlockedError(`Could not resolve host ${hostname}`);
+  }
+
+  if (resolved.length === 0) {
+    throw new SsrfBlockedError(`Could not resolve host ${hostname}`);
+  }
+
+  // Every answer must be public: a name that resolves to both a public and a
+  // private address would otherwise be reachable on a retry.
+  for (const { address } of resolved) {
+    if (isPrivateAddress(address)) {
+      throw new SsrfBlockedError(`URL resolves to a non-public address (${address})`);
+    }
+  }
+
+  return url;
+}

--- a/src/workers/freshness-worker.ts
+++ b/src/workers/freshness-worker.ts
@@ -31,7 +31,7 @@ import type { EventEmitter2 as EventEmitter2Type } from 'eventemitter2';
 
 import { workerMetrics } from '../observability/prometheus-registry.js';
 import type { PDSRateLimiter } from '../services/pds-sync/pds-rate-limiter.js';
-import type { PDSSyncService } from '../services/pds-sync/sync-service.js';
+import type { DeletionSource, PDSSyncService } from '../services/pds-sync/sync-service.js';
 import type { AtUri } from '../types/atproto.js';
 import { RateLimitError } from '../types/errors.js';
 import type { ILogger } from '../types/interfaces/logger.interface.js';
@@ -398,7 +398,7 @@ export class FreshnessWorker {
         // Check if this is a 404 (record deleted from PDS)
         if (error.name === 'NotFoundError') {
           // Mark as deleted
-          this.markAsDeleted(uri, 'pds_404');
+          await this.markAsDeleted(uri, 'pds_404');
 
           return {
             uri,
@@ -437,10 +437,22 @@ export class FreshnessWorker {
    *
    * @param uri - Record URI
    * @param source - Deletion source
+   * @returns Resolves once the record is marked deleted in the index
    */
-  private markAsDeleted(uri: AtUri, source: string): void {
-    // This would call a method on PDSSyncService or storage to mark deleted
-    // For now, emit event for handler to process
+  private async markAsDeleted(uri: AtUri, source: DeletionSource): Promise<void> {
+    // This used to only emit `record.deletion_detected` and rely on a handler
+    // to do the work. No subscriber was ever written, so a record the freshness
+    // scan found gone from its PDS stayed in the index indefinitely — the scan
+    // reported a successful deletion detection and nothing was deleted.
+    // `PDSSyncService.markAsDeleted` was available on this worker the whole
+    // time. The event is still emitted, for plugins that want to observe it,
+    // but it is no longer what performs the deletion.
+    const result = await this.syncService.markAsDeleted(uri, source);
+
+    if (!result.ok) {
+      this.logger.error('Failed to mark record as deleted', result.error, { uri, source });
+    }
+
     this.eventBus.emit('record.deletion_detected', {
       uri,
       source,

--- a/tests/compliance/core-services-compliance.test.ts
+++ b/tests/compliance/core-services-compliance.test.ts
@@ -97,6 +97,10 @@ function createTrackedStorage(): IStorageBackend & {
       operations.push({ method: 'getEprint', args: [uri] });
       return Promise.resolve(null);
     }),
+    getEprints: vi.fn().mockImplementation((uris: readonly AtUri[]) => {
+      operations.push({ method: 'getEprints', args: [uris] });
+      return Promise.resolve(new Map());
+    }),
     getEprintsByAuthor: vi.fn().mockImplementation((author: DID) => {
       operations.push({ method: 'getEprintsByAuthor', args: [author] });
       return Promise.resolve([]);

--- a/tests/integration/services/metrics/metrics-service.integration.test.ts
+++ b/tests/integration/services/metrics/metrics-service.integration.test.ts
@@ -70,6 +70,7 @@ function createMockStorage(): IStorageBackend {
   return {
     storeEprint: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
     getEprint: vi.fn().mockResolvedValue(null),
+    getEprints: vi.fn().mockResolvedValue(new Map()),
     getEprintsByAuthor: vi.fn().mockResolvedValue([]),
     countEprintsByAuthor: vi.fn().mockResolvedValue(0),
     listEprintUris: vi.fn().mockResolvedValue([]),

--- a/tests/integration/services/pds-discovery/pds-discovery.integration.test.ts
+++ b/tests/integration/services/pds-discovery/pds-discovery.integration.test.ts
@@ -33,7 +33,7 @@ const TEST_DB_CONFIG = {
   port: parseInt(process.env.POSTGRES_PORT ?? '5432', 10),
   user: process.env.POSTGRES_USER ?? 'chive',
   password: process.env.POSTGRES_PASSWORD ?? 'chive_test_password',
-  database: process.env.POSTGRES_DB ?? 'chive',
+  database: process.env.POSTGRES_DB ?? 'chive_test',
 };
 
 const TEST_REDIS_CONFIG = {

--- a/tests/unit/api/handlers/rest/health.test.ts
+++ b/tests/unit/api/handlers/rest/health.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for the liveness and readiness probe handlers.
+ *
+ * @remarks
+ * The readiness probe gates Kubernetes traffic and deploy verification, so these
+ * tests pin down both halves of its contract: a dependency that rejects (fast or
+ * slow) must be recorded as a failing check, and the response shape — the `checks`
+ * map, the healthy/degraded/unhealthy status and the 200/503 split — must not drift.
+ *
+ * @packageDocumentation
+ */
+
+import { Hono } from 'hono';
+import type { Redis } from 'ioredis';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { registerHealthRoutes } from '@/api/handlers/rest/health.js';
+import type { ChiveEnv, ChiveServices } from '@/api/types/context.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+interface HealthBody {
+  status: 'healthy' | 'degraded' | 'unhealthy';
+  timestamp: string;
+  version: string;
+  uptime: number;
+  checks?: Record<string, { status: 'pass' | 'fail'; latencyMs?: number; message?: string }>;
+}
+
+type Probe = () => Promise<unknown>;
+
+interface AppOptions {
+  redisPing?: Probe;
+  eprintProbe?: Probe;
+  searchProbe?: Probe;
+  nodeProbe?: Probe;
+  /** Replaces the whole services container (used for the "not configured" cases). */
+  services?: Partial<ChiveServices>;
+}
+
+function createLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  } as unknown as ILogger;
+}
+
+function buildApp(options: AppOptions = {}): { app: Hono<ChiveEnv>; logger: ILogger } {
+  const logger = createLogger();
+
+  const services = (options.services ?? {
+    eprint: {
+      getEprintsByAuthor: options.eprintProbe ?? ((): Promise<unknown> => Promise.resolve([])),
+    },
+    search: {
+      search: options.searchProbe ?? ((): Promise<unknown> => Promise.resolve({ hits: [] })),
+    },
+    graph: { getNode: (): Promise<unknown> => Promise.resolve(null) },
+    nodeRepository: {
+      getNode: options.nodeProbe ?? ((): Promise<unknown> => Promise.resolve(null)),
+    },
+  }) as unknown as ChiveServices;
+
+  const redis = {
+    ping: options.redisPing ?? ((): Promise<unknown> => Promise.resolve('PONG')),
+  } as unknown as Redis;
+
+  const app = new Hono<ChiveEnv>();
+  app.use('*', async (c, next) => {
+    c.set('services', services);
+    c.set('redis', redis);
+    c.set('logger', logger);
+    await next();
+  });
+  registerHealthRoutes(app);
+
+  return { app, logger };
+}
+
+async function readBody(res: Response): Promise<HealthBody> {
+  return (await res.json()) as HealthBody;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe('livenessHandler', () => {
+  it('returns 200 and healthy while the process is running', async () => {
+    const { app } = buildApp();
+
+    const res = await app.request('/health');
+    const body = await readBody(res);
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('healthy');
+    expect(body.checks).toBeUndefined();
+  });
+});
+
+describe('readinessHandler', () => {
+  it('returns 200 with every dependency passing when all probes resolve', async () => {
+    const { app } = buildApp();
+
+    const res = await app.request('/ready');
+    const body = await readBody(res);
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('healthy');
+    expect(body.checks?.redis?.status).toBe('pass');
+    expect(body.checks?.postgresql?.status).toBe('pass');
+    expect(body.checks?.elasticsearch?.status).toBe('pass');
+    expect(body.checks?.neo4j?.status).toBe('pass');
+  });
+
+  it('fails the PostgreSQL check when the probe rejects immediately', async () => {
+    const { app, logger } = buildApp({
+      eprintProbe: () => Promise.reject(new Error('ECONNREFUSED 127.0.0.1:5432')),
+    });
+
+    const res = await app.request('/ready');
+    const body = await readBody(res);
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe('degraded');
+    expect(body.checks?.postgresql).toMatchObject({
+      status: 'fail',
+      message: 'ECONNREFUSED 127.0.0.1:5432',
+    });
+    expect(body.checks?.redis?.status).toBe('pass');
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('fails the Elasticsearch check when the probe rejects immediately', async () => {
+    const { app } = buildApp({
+      searchProbe: () => Promise.reject(new Error('connect ECONNREFUSED 9200')),
+    });
+
+    const res = await app.request('/ready');
+    const body = await readBody(res);
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe('degraded');
+    expect(body.checks?.elasticsearch).toMatchObject({
+      status: 'fail',
+      message: 'connect ECONNREFUSED 9200',
+    });
+  });
+
+  it('fails the Neo4j check when the probe rejects immediately', async () => {
+    const { app } = buildApp({
+      nodeProbe: () => Promise.reject(new Error('ServiceUnavailable: bolt://neo4j:7687')),
+    });
+
+    const res = await app.request('/ready');
+    const body = await readBody(res);
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe('degraded');
+    expect(body.checks?.neo4j).toMatchObject({
+      status: 'fail',
+      message: 'ServiceUnavailable: bolt://neo4j:7687',
+    });
+  });
+
+  it('reports unhealthy when Redis fails, outranking a degraded dependency', async () => {
+    const { app, logger } = buildApp({
+      redisPing: () => Promise.reject(new Error('Redis down')),
+      eprintProbe: () => Promise.reject(new Error('PostgreSQL down')),
+    });
+
+    const res = await app.request('/ready');
+    const body = await readBody(res);
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe('unhealthy');
+    expect(body.checks?.redis).toMatchObject({ status: 'fail', message: 'Redis down' });
+    expect(body.checks?.postgresql?.status).toBe('fail');
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('normalizes a non-Error rejection into a failing check', async () => {
+    const { app } = buildApp({
+      // Deliberately not an Error: drivers occasionally reject with a bare string,
+      // and the check must still report it rather than pass.
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+      eprintProbe: () => Promise.reject('pool exhausted'),
+    });
+
+    const res = await app.request('/ready');
+    const body = await readBody(res);
+
+    expect(res.status).toBe(503);
+    expect(body.checks?.postgresql).toMatchObject({
+      status: 'fail',
+      message: 'pool exhausted',
+    });
+  });
+
+  it('fails the check with a timeout when a probe hangs past 5 seconds', async () => {
+    vi.useFakeTimers();
+    // A probe that never settles: only the timeout can decide this check.
+    const { app } = buildApp({ eprintProbe: () => new Promise(() => {}) });
+
+    const pending = app.request('/ready');
+    await vi.advanceTimersByTimeAsync(5000);
+    const res = await pending;
+    const body = await readBody(res);
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe('degraded');
+    expect(body.checks?.postgresql).toMatchObject({ status: 'fail', message: 'Timeout' });
+  });
+
+  it('does not time out a probe that settles before the deadline', async () => {
+    vi.useFakeTimers();
+    const { app } = buildApp({
+      eprintProbe: () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve([]), 4000);
+        }),
+    });
+
+    const pending = app.request('/ready');
+    await vi.advanceTimersByTimeAsync(4000);
+    const res = await pending;
+    const body = await readBody(res);
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('healthy');
+    expect(body.checks?.postgresql?.status).toBe('pass');
+  });
+
+  it('records unconfigured services as passing without probing', async () => {
+    const { app } = buildApp({ services: {} });
+
+    const res = await app.request('/ready');
+    const body = await readBody(res);
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('healthy');
+    expect(body.checks?.postgresql).toMatchObject({
+      status: 'pass',
+      message: 'Service not configured',
+    });
+    expect(body.checks?.elasticsearch).toMatchObject({
+      status: 'pass',
+      message: 'Service not configured',
+    });
+    expect(body.checks?.neo4j).toMatchObject({
+      status: 'pass',
+      message: 'Service not configured',
+    });
+  });
+
+  it('falls back to the graph service when no node repository is injected', async () => {
+    const { app } = buildApp({
+      services: {
+        graph: {
+          getNode: () => Promise.reject(new Error('graph probe failed')),
+        },
+      } as unknown as Partial<ChiveServices>,
+    });
+
+    const res = await app.request('/ready');
+    const body = await readBody(res);
+
+    expect(res.status).toBe(503);
+    expect(body.checks?.neo4j).toMatchObject({
+      status: 'fail',
+      message: 'graph probe failed',
+    });
+  });
+});

--- a/tests/unit/api/handlers/rest/metrics-endpoint.test.ts
+++ b/tests/unit/api/handlers/rest/metrics-endpoint.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the Prometheus scrape endpoint.
+ *
+ * @remarks
+ * The service registered Prometheus metrics and exposed no way to scrape them:
+ * the only reader was an admin-authenticated XRPC method returning JSON, which
+ * Prometheus can neither authenticate against nor parse. Metrics existed and
+ * nothing could collect them.
+ *
+ * The endpoint is unauthenticated by default, which is the usual arrangement
+ * for a metrics port on a private network and is what lets an in-network
+ * scraper work without credentials. Since this deployment fronts the API with a
+ * public router, `METRICS_TOKEN` is enforced whenever it is set — both halves
+ * are pinned here, because the default-open half is only safe if the token half
+ * actually works.
+ */
+
+import { Hono } from 'hono';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { registerMetricsRoutes, METRICS_PATH } from '@/api/handlers/rest/metrics.js';
+import type { ChiveEnv } from '@/api/types/context.js';
+
+const ORIGINAL = { ...process.env };
+
+const appWithMetrics = (): Hono<ChiveEnv> => {
+  const app = new Hono<ChiveEnv>();
+  registerMetricsRoutes(app);
+  return app;
+};
+
+describe('metrics endpoint', () => {
+  beforeEach(() => {
+    delete process.env.METRICS_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+  });
+
+  it('serves metrics in the Prometheus text format', async () => {
+    const response = await appWithMetrics().request(METRICS_PATH);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toMatch(/text\/plain/);
+  });
+
+  // Prometheus parses the exposition format, not JSON; the previous admin XRPC
+  // method returned JSON, which is why it could not be scraped.
+  it('returns an exposition-format body rather than JSON', async () => {
+    const body = await (await appWithMetrics().request(METRICS_PATH)).text();
+    expect(body.startsWith('{')).toBe(false);
+    expect(body).toMatch(/^# HELP |^# TYPE /m);
+  });
+
+  it('is served on /metrics', () => {
+    expect(METRICS_PATH).toBe('/metrics');
+  });
+
+  describe('when METRICS_TOKEN is set', () => {
+    beforeEach(() => {
+      process.env.METRICS_TOKEN = 'scrape-secret';
+    });
+
+    it('rejects a request with no credentials', async () => {
+      const response = await appWithMetrics().request(METRICS_PATH);
+      expect(response.status).toBe(401);
+    });
+
+    it('rejects a request with the wrong token', async () => {
+      const response = await appWithMetrics().request(METRICS_PATH, {
+        headers: { authorization: 'Bearer wrong' },
+      });
+      expect(response.status).toBe(401);
+    });
+
+    it('accepts the configured token', async () => {
+      const response = await appWithMetrics().request(METRICS_PATH, {
+        headers: { authorization: 'Bearer scrape-secret' },
+      });
+      expect(response.status).toBe(200);
+    });
+
+    // A blank value is a misconfiguration, not a request to disable auth.
+    it('ignores a blank token and stays open', async () => {
+      process.env.METRICS_TOKEN = '   ';
+      const response = await appWithMetrics().request(METRICS_PATH);
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/tests/unit/api/handlers/rest/orcid-verification-persistence.test.ts
+++ b/tests/unit/api/handlers/rest/orcid-verification-persistence.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for the durability of ORCID verification.
+ *
+ * @remarks
+ * Verification wrote only `UPDATE authors_index ... WHERE did`. Two ways that
+ * lost the result:
+ *
+ * 1. An author who verified before being indexed matched no rows. The handler
+ *    logged that the value would "be picked up when they are indexed" and
+ *    discarded it — nothing persisted it, so there was nothing to pick up.
+ * 2. `authors_index` is rebuilt from the firehose, and both profile upserts
+ *    assigned `orcid = EXCLUDED.orcid`. The next profile update therefore
+ *    overwrote a verified ORCID with whatever the PDS record carried, which is
+ *    usually null.
+ *
+ * Verification records something Chive observed — a completed OAuth flow — so
+ * it cannot live only in a table reconstructed from someone else's data. These
+ * tests assert the write path and both upserts against that.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const read = (relative: string): string => readFileSync(join(process.cwd(), relative), 'utf8');
+
+const UPSERT_SITES = [
+  ['the firehose event processor', 'src/services/indexing/event-processor.ts'],
+  ['the PDS scanner', 'src/services/pds-discovery/pds-scanner.ts'],
+] as const;
+
+describe('ORCID verification is stored durably', () => {
+  const handler = read('src/api/handlers/rest/v1/orcid-auth.ts');
+
+  it('writes to a table that is not rebuilt from the firehose', () => {
+    expect(handler).toMatch(/INSERT INTO orcid_verifications/);
+  });
+
+  it('still updates the denormalized copy on the author index', () => {
+    expect(handler).toMatch(/UPDATE authors_index SET orcid = \$1, orcid_verified_at = NOW\(\)/);
+  });
+
+  it('no longer claims an unindexed author will be picked up later', () => {
+    expect(handler).not.toMatch(/it will be picked up when they are indexed/i);
+  });
+
+  // An ORCID iD identifies one researcher; a second DID claiming a verified one
+  // is a conflict to surface, not to store twice.
+  it('rejects an ORCID already verified by another account', () => {
+    expect(handler).toMatch(/orcid_verifications_orcid_unique/);
+    expect(handler).toMatch(/already linked to another account/);
+  });
+});
+
+describe('profile indexing preserves a verified ORCID', () => {
+  it.each(UPSERT_SITES)('%s does not overwrite it on conflict', (_label, path) => {
+    expect(read(path)).toMatch(
+      /orcid = CASE\s*\n\s*WHEN authors_index\.orcid_verified_at IS NOT NULL THEN authors_index\.orcid/
+    );
+  });
+
+  it.each(UPSERT_SITES)('%s no longer assigns it straight from the record', (_label, path) => {
+    expect(read(path)).not.toMatch(/^\s*orcid = EXCLUDED\.orcid,$/m);
+  });
+
+  // Covers the author who verified before ever being indexed: their first row
+  // has to pick the verification up rather than start blank.
+  it.each(UPSERT_SITES)('%s seeds a new row from the verification table', (_label, path) => {
+    expect(read(path)).toMatch(
+      /COALESCE\(\(SELECT orcid FROM orcid_verifications WHERE did = \$1\)/
+    );
+  });
+});

--- a/tests/unit/api/handlers/xrpc/admin-operation-cancellation.test.ts
+++ b/tests/unit/api/handlers/xrpc/admin-operation-cancellation.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for cancellation of long-running admin operations.
+ *
+ * @remarks
+ * `backfillManager.startOperation` returns `{ operation, signal }`. Every
+ * trigger handler destructured `{ operation }` alone and dropped the signal, so
+ * `admin.cancelBackfill` flipped the operation's state in Redis while the loop
+ * it was meant to stop ran to completion — a cancel that reported success and
+ * cancelled nothing. On a full reindex that is the difference between stopping
+ * a bad run and waiting out the entire index.
+ *
+ * These tests assert the source destructures the signal and guards its loops.
+ * The loops run inside a fire-and-forget async closure that the handler does
+ * not await, so observing the abort behaviourally from a unit test would race;
+ * pinning the wiring is what keeps the signal from being dropped again.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const HANDLER_DIR = 'src/api/handlers/xrpc/admin';
+
+const source = (handler: string): string =>
+  readFileSync(join(process.cwd(), HANDLER_DIR, `${handler}.ts`), 'utf8');
+
+/** Handlers that drive a loop locally and must therefore honour the signal. */
+const LOOPING_HANDLERS = [
+  'triggerFullReindex',
+  'triggerCitationExtraction',
+  'triggerPDSScan',
+  'triggerFreshnessScan',
+];
+
+/** Handlers that delegate the work to a service and have no local loop. */
+const DELEGATING_HANDLERS = ['triggerBackfill', 'triggerDIDSync', 'triggerGovernanceSync'];
+
+describe('admin operations honour cancellation', () => {
+  it.each(LOOPING_HANDLERS)('%s takes the abort signal from startOperation', (handler) => {
+    expect(source(handler)).toMatch(/const \{ operation, signal \} = await backfillManager/);
+  });
+
+  it.each(LOOPING_HANDLERS)('%s checks the signal inside its loop', (handler) => {
+    expect(source(handler)).toMatch(/if \(signal\.aborted\)/);
+  });
+
+  // Every loop needs its own guard: a reindex collects URIs in one loop and
+  // processes them in another, and cancelling during collection has to stop
+  // there rather than proceed to process everything collected so far.
+  it('guards both the collection and the processing loop of a full reindex', () => {
+    const contents = source('triggerFullReindex');
+    expect([...contents.matchAll(/if \(signal\.aborted\)/g)]).toHaveLength(2);
+  });
+
+  it('guards both loops of citation extraction', () => {
+    const contents = source('triggerCitationExtraction');
+    expect([...contents.matchAll(/if \(signal\.aborted\)/g)]).toHaveLength(2);
+  });
+
+  // Recorded so that adding a local loop to one of these is a deliberate act
+  // that has to update this list rather than silently reintroducing the bug.
+  it.each(DELEGATING_HANDLERS)('%s has no local loop to cancel', (handler) => {
+    const contents = source(handler);
+    expect(contents).not.toMatch(/^\s+(for|while) \(/m);
+  });
+});

--- a/tests/unit/api/handlers/xrpc/admin.test.ts
+++ b/tests/unit/api/handlers/xrpc/admin.test.ts
@@ -755,16 +755,22 @@ describe('XRPC Admin Handlers', () => {
       expect(result.body).toMatchObject({ success: true, did: 'did:plc:user1', role: 'moderator' });
     });
 
+    it('rejects governance roles with a pointer to the governance endpoint', async () => {
+      for (const role of ['graph-editor', 'trusted-editor', 'administrator']) {
+        await expect(
+          assignRole.handler({
+            params: undefined,
+            input: { did: 'did:plc:user1', role },
+            auth: null,
+            c: mockContext as never,
+          })
+        ).rejects.toThrow('pub.chive.governance.approveElevation');
+      }
+      expect(mockRedis.sadd).not.toHaveBeenCalled();
+    });
+
     it('accepts all valid roles', async () => {
-      const validRoles = [
-        'admin',
-        'moderator',
-        'graph-editor',
-        'author',
-        'reader',
-        'alpha-tester',
-        'premium',
-      ];
+      const validRoles = ['admin', 'moderator', 'author', 'reader', 'alpha-tester', 'premium'];
       for (const role of validRoles) {
         vi.clearAllMocks();
         mockContext = buildContext(adminUser);

--- a/tests/unit/api/handlers/xrpc/author/searchAuthors.test.ts
+++ b/tests/unit/api/handlers/xrpc/author/searchAuthors.test.ts
@@ -28,6 +28,7 @@ interface MockSearch {
 
 interface MockEprint {
   getEprint: ReturnType<typeof vi.fn>;
+  getEprints: ReturnType<typeof vi.fn>;
 }
 
 // =============================================================================
@@ -52,8 +53,22 @@ describe('searchAuthors', () => {
     mockSearch = {
       search: vi.fn().mockResolvedValue({ hits: [], total: 0 }),
     };
+    // The handler fetches the page in one call now. The batch mock resolves
+    // through `getEprint` so the per-test stubs below still describe what each
+    // case returns, rather than every case having to build a Map.
     mockEprint = {
       getEprint: vi.fn().mockResolvedValue(null),
+      getEprints: vi.fn(async (uris: readonly string[]) => {
+        const found = new Map<string, unknown>();
+        for (const uri of uris) {
+          const fetchOne = mockEprint.getEprint as (u: string) => Promise<unknown>;
+          const eprint: unknown = await fetchOne(uri);
+          if (eprint) {
+            found.set(uri, eprint);
+          }
+        }
+        return found;
+      }),
     };
     mockRedis = {
       get: vi.fn().mockResolvedValue(null),

--- a/tests/unit/api/handlers/xrpc/metrics/getTrending.test.ts
+++ b/tests/unit/api/handlers/xrpc/metrics/getTrending.test.ts
@@ -499,7 +499,9 @@ describe('getTrending', () => {
         c: mockContext as never,
       });
 
-      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20);
+      // The third argument is the paging offset, which the handler previously
+      // parsed but never passed on; see trending-paging.test.ts.
+      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20, 0);
     });
   });
 });

--- a/tests/unit/api/handlers/xrpc/sync-register-pds-auth.test.ts
+++ b/tests/unit/api/handlers/xrpc/sync-register-pds-auth.test.ts
@@ -17,6 +17,14 @@ import type { DID } from '@/types/atproto.js';
 import { AuthenticationError, ValidationError } from '@/types/errors.js';
 import type { ILogger } from '@/types/interfaces/logger.interface.js';
 
+// The registerPDS handler runs every candidate URL through the SSRF guard,
+// which resolves the hostname before any fetch. Test hostnames do not exist in
+// DNS, so resolution is stubbed to a public address; the guard's own rejection
+// paths are covered in tests/unit/utils/ssrf-guard.test.ts.
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn().mockResolvedValue([{ address: '93.184.216.34' }]),
+}));
+
 const createMockLogger = (): ILogger => ({
   debug: vi.fn(),
   info: vi.fn(),
@@ -126,6 +134,29 @@ describe('registerPDS authentication and ownership', () => {
         c: createContext(mockUser),
       })
     ).rejects.toThrow(ValidationError);
+
+    expect(mockPDSRegistry.registerPDS).not.toHaveBeenCalled();
+  });
+
+  // The registered host is stored and revisited by the scanner, so a URL
+  // pointing at cloud metadata or loopback would give the caller a persistent
+  // request generator aimed inside the deployment. An IP literal needs no DNS,
+  // so this reaches the guard regardless of how resolution is stubbed.
+  it.each([
+    ['cloud metadata', 'https://169.254.169.254/latest/meta-data/'],
+    ['loopback', 'https://127.0.0.1:5432'],
+    ['IPv6 loopback', 'https://[::1]/admin'],
+  ])('refuses to register a %s address', async (_label, pdsUrl) => {
+    global.fetch = mockFetchWithPlcEndpoint(null);
+
+    await expect(
+      registerPDS.handler({
+        params: undefined,
+        input: { pdsUrl },
+        auth: null,
+        c: createContext(mockUser),
+      })
+    ).rejects.toThrow(/non-public address/);
 
     expect(mockPDSRegistry.registerPDS).not.toHaveBeenCalled();
   });

--- a/tests/unit/api/handlers/xrpc/sync-register-pds-auth.test.ts
+++ b/tests/unit/api/handlers/xrpc/sync-register-pds-auth.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for authentication and PDS-ownership enforcement in registerPDS.
+ *
+ * @remarks
+ * Registering a PDS adds a host to the scan registry, which the scanner later
+ * enumerates. These tests pin the two guards that keep an anonymous or
+ * unrelated caller from seeding the registry with a host they do not control.
+ */
+
+import type { Context } from 'hono';
+import type { Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { registerPDS } from '@/api/handlers/xrpc/sync/registerPDS.js';
+import type { ChiveEnv } from '@/api/types/context.js';
+import type { DID } from '@/types/atproto.js';
+import { AuthenticationError, ValidationError } from '@/types/errors.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+const createMockLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+const mockUser = {
+  did: 'did:plc:user123' as DID,
+  handle: 'user.test',
+  isAdmin: false,
+};
+
+/** Builds a minimal Response stand-in for the fields the handler reads. */
+const stubResponse = (body: unknown, ok = true, status = 200): Response =>
+  ({ ok, status, json: () => Promise.resolve(body) }) as unknown as Response;
+
+/**
+ * Builds a fetch mock that answers PLC resolution with the given endpoint
+ * (or a non-ok response when null) and any other request with 200 OK.
+ */
+function mockFetchWithPlcEndpoint(
+  endpoint: string | null
+): Mock<(input: string | URL | Request) => Promise<Response>> {
+  return vi.fn((input: string | URL | Request): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes('plc.directory')) {
+      if (endpoint === null) {
+        return Promise.resolve(stubResponse({}, false, 404));
+      }
+      return Promise.resolve(
+        stubResponse({
+          service: [
+            {
+              id: '#atproto_pds',
+              type: 'AtprotoPersonalDataServer',
+              serviceEndpoint: endpoint,
+            },
+          ],
+        })
+      );
+    }
+    return Promise.resolve(stubResponse({}));
+  });
+}
+
+describe('registerPDS authentication and ownership', () => {
+  let mockLogger: ILogger;
+  let mockPDSRegistry: { registerPDS: ReturnType<typeof vi.fn>; getPDS: ReturnType<typeof vi.fn> };
+  let mockPDSScanner: { scanDID: ReturnType<typeof vi.fn> };
+
+  const createContext = (user: typeof mockUser | undefined): Context<ChiveEnv> =>
+    ({
+      get: vi.fn((key: string) => {
+        switch (key) {
+          case 'services':
+            return { pdsRegistry: mockPDSRegistry, pdsScanner: mockPDSScanner };
+          case 'logger':
+            return mockLogger;
+          case 'user':
+            return user;
+          default:
+            return undefined;
+        }
+      }),
+      set: vi.fn(),
+    }) as unknown as Context<ChiveEnv>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogger = createMockLogger();
+    mockPDSRegistry = {
+      registerPDS: vi.fn().mockResolvedValue(undefined),
+      getPDS: vi.fn().mockResolvedValue(null),
+    };
+    mockPDSScanner = { scanDID: vi.fn().mockResolvedValue(0) };
+  });
+
+  it('declares authentication as required', () => {
+    expect(registerPDS.auth).toBe(true);
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    global.fetch = mockFetchWithPlcEndpoint(null);
+
+    await expect(
+      registerPDS.handler({
+        params: undefined,
+        input: { pdsUrl: 'https://attacker-pds.example.com' },
+        auth: null,
+        c: createContext(undefined),
+      })
+    ).rejects.toThrow(AuthenticationError);
+
+    expect(mockPDSRegistry.registerPDS).not.toHaveBeenCalled();
+  });
+
+  it('rejects a host that is not the caller PDS', async () => {
+    global.fetch = mockFetchWithPlcEndpoint('https://user-pds.example.com');
+
+    await expect(
+      registerPDS.handler({
+        params: undefined,
+        input: { pdsUrl: 'https://attacker-pds.example.com' },
+        auth: null,
+        c: createContext(mockUser),
+      })
+    ).rejects.toThrow(ValidationError);
+
+    expect(mockPDSRegistry.registerPDS).not.toHaveBeenCalled();
+  });
+
+  it('registers the caller own PDS', async () => {
+    global.fetch = mockFetchWithPlcEndpoint('https://user-pds.example.com/');
+
+    const result = await registerPDS.handler({
+      params: undefined,
+      input: { pdsUrl: 'https://user-pds.example.com' },
+      auth: null,
+      c: createContext(mockUser),
+    });
+
+    expect(result.body.registered).toBe(true);
+    expect(mockPDSRegistry.registerPDS).toHaveBeenCalledWith(
+      'https://user-pds.example.com',
+      'user_registration'
+    );
+  });
+
+  it('registers when DID resolution is inconclusive', async () => {
+    // A directory outage must not block indexing for legitimate users.
+    global.fetch = mockFetchWithPlcEndpoint(null);
+
+    const result = await registerPDS.handler({
+      params: undefined,
+      input: { pdsUrl: 'https://custom-pds.example.com' },
+      auth: null,
+      c: createContext(mockUser),
+    });
+
+    expect(result.body.registered).toBe(true);
+    expect(mockPDSRegistry.registerPDS).toHaveBeenCalledWith(
+      'https://custom-pds.example.com',
+      'user_registration'
+    );
+  });
+
+  it('does not resolve the caller DID for an already registered PDS', async () => {
+    mockPDSRegistry.getPDS.mockResolvedValue({
+      pdsUrl: 'https://existing-pds.example.com',
+      status: 'active',
+    });
+    const fetchMock = mockFetchWithPlcEndpoint('https://user-pds.example.com');
+    global.fetch = fetchMock;
+
+    const result = await registerPDS.handler({
+      params: undefined,
+      input: { pdsUrl: 'https://existing-pds.example.com' },
+      auth: null,
+      c: createContext(mockUser),
+    });
+
+    expect(result.body.status).toBe('already_exists');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/handlers/xrpc/sync.test.ts
+++ b/tests/unit/api/handlers/xrpc/sync.test.ts
@@ -14,6 +14,14 @@ import type { ChiveEnv } from '@/api/types/context.js';
 import type { AtUri, DID } from '@/types/atproto.js';
 import type { ILogger } from '@/types/interfaces/logger.interface.js';
 
+// The registerPDS handler runs every candidate URL through the SSRF guard,
+// which resolves the hostname before any fetch. Test hostnames do not exist in
+// DNS, so resolution is stubbed to a public address; the guard's own rejection
+// paths are covered in tests/unit/utils/ssrf-guard.test.ts.
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn().mockResolvedValue([{ address: '93.184.216.34' }]),
+}));
+
 // =============================================================================
 // Mocks
 // =============================================================================

--- a/tests/unit/api/handlers/xrpc/trending-paging.test.ts
+++ b/tests/unit/api/handlers/xrpc/trending-paging.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for trending pagination.
+ *
+ * @remarks
+ * The cursor is an offset into the ranked list. It was parsed only at the end of
+ * the handler, to construct the *next* cursor, and never passed to either data
+ * source — so every request returned the same first `limit` entries while the
+ * cursor kept advancing. Paging appeared to work and never moved.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { getTrending } from '@/api/handlers/xrpc/metrics/getTrending.js';
+
+describe('trending pagination', () => {
+  const getTrendingMetrics = vi.fn();
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  const context = (): unknown => ({
+    get: (key: string) => {
+      if (key === 'logger') return logger;
+      if (key === 'services') {
+        return {
+          metrics: { getTrending: getTrendingMetrics },
+          eprint: { getEprint: vi.fn().mockResolvedValue(null) },
+          graph: undefined,
+          graphAlgorithmCache: undefined,
+        };
+      }
+      return undefined;
+    },
+  });
+
+  const call = async (cursor?: string, limit = 20): Promise<unknown> =>
+    getTrending.handler({
+      params: { window: '7d', limit, ...(cursor === undefined ? {} : { cursor }) },
+      input: undefined,
+      auth: null,
+      c: context(),
+    } as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTrendingMetrics.mockResolvedValue([]);
+  });
+
+  it('requests the first page when no cursor is supplied', async () => {
+    await call();
+    expect(getTrendingMetrics).toHaveBeenCalledWith('7d', 20, 0);
+  });
+
+  it('passes the cursor through as an offset', async () => {
+    await call('40');
+    expect(getTrendingMetrics).toHaveBeenCalledWith('7d', 20, 40);
+  });
+
+  // A malformed or negative cursor must not produce a negative slice bound.
+  it.each([['not-a-number'], ['-5'], ['']])('treats %s as the first page', async (cursor) => {
+    await call(cursor);
+    expect(getTrendingMetrics).toHaveBeenCalledWith('7d', 20, 0);
+  });
+});

--- a/tests/unit/api/middleware/auth-bypass-production.test.ts
+++ b/tests/unit/api/middleware/auth-bypass-production.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the production guard on the E2E authentication bypass.
+ *
+ * @remarks
+ * `ENABLE_E2E_AUTH_BYPASS` turns `X-E2E-Auth-Did` into an identity and
+ * `X-E2E-Auth-Admin: true` into full administrative access, and both header
+ * names are in the production CORS allowlist. Before this guard, an unset
+ * environment variable was the only thing separating a production deploy from
+ * an open admin door. Two independent protections are pinned here: the process
+ * refuses to boot when the flag is set in production, and the middleware
+ * ignores the flag there even if a boot check is bypassed.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { assertNoAuthBypassInProduction } from '@/api/middleware/auth.js';
+
+describe('assertNoAuthBypassInProduction', () => {
+  it('refuses to start a production process with the bypass enabled', () => {
+    expect(() =>
+      assertNoAuthBypassInProduction({
+        NODE_ENV: 'production',
+        ENABLE_E2E_AUTH_BYPASS: 'true',
+      })
+    ).toThrow(/ENABLE_E2E_AUTH_BYPASS is set in production/);
+  });
+
+  it('allows a production process with the bypass unset', () => {
+    expect(() => assertNoAuthBypassInProduction({ NODE_ENV: 'production' })).not.toThrow();
+  });
+
+  it('allows a production process with the bypass explicitly disabled', () => {
+    expect(() =>
+      assertNoAuthBypassInProduction({ NODE_ENV: 'production', ENABLE_E2E_AUTH_BYPASS: 'false' })
+    ).not.toThrow();
+  });
+
+  it.each([['development'], ['test'], [undefined]])(
+    'permits the bypass when NODE_ENV is %s',
+    (nodeEnv) => {
+      expect(() =>
+        assertNoAuthBypassInProduction({
+          ...(nodeEnv === undefined ? {} : { NODE_ENV: nodeEnv }),
+          ENABLE_E2E_AUTH_BYPASS: 'true',
+        })
+      ).not.toThrow();
+    }
+  );
+
+  // Only the exact string 'true' enables it, so a stray value cannot arm the
+  // bypass and equally must not block a boot.
+  it('ignores a non-boolean value for the flag', () => {
+    expect(() =>
+      assertNoAuthBypassInProduction({ NODE_ENV: 'production', ENABLE_E2E_AUTH_BYPASS: '1' })
+    ).not.toThrow();
+  });
+});

--- a/tests/unit/api/middleware/lxm-scoping.test.ts
+++ b/tests/unit/api/middleware/lxm-scoping.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for lexicon-method scoping of service auth tokens.
+ *
+ * @remarks
+ * A service auth JWT's `lxm` claim scopes it to a single lexicon method. The
+ * verifier has always been able to check it, but the middleware called
+ * `verify(token)` with no method, so the claim was decoded, copied into
+ * `user.scopes` — which nothing reads — and never enforced. A token minted for
+ * `pub.chive.metrics.recordView` was accepted at `pub.chive.admin.deleteContent`.
+ *
+ * The middleware now derives the method from the request path and passes it, so
+ * a scoped token is rejected everywhere except the method it names.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { lexiconMethodForPath } from '@/api/middleware/auth.js';
+
+describe('lexiconMethodForPath', () => {
+  it('extracts the NSID from an XRPC path', () => {
+    expect(lexiconMethodForPath('/xrpc/pub.chive.admin.deleteContent')).toBe(
+      'pub.chive.admin.deleteContent'
+    );
+  });
+
+  it('ignores a query string', () => {
+    expect(lexiconMethodForPath('/xrpc/pub.chive.eprint.searchSubmissions?q=syntax')).toBe(
+      'pub.chive.eprint.searchSubmissions'
+    );
+  });
+
+  it('ignores trailing path segments', () => {
+    expect(lexiconMethodForPath('/xrpc/pub.chive.actor.profile/extra')).toBe(
+      'pub.chive.actor.profile'
+    );
+  });
+
+  // REST routes carry no lexicon method; `lxm` does not scope them, so passing
+  // nothing leaves those tokens checked exactly as before.
+  it.each([
+    ['/v1/auth/orcid/callback'],
+    ['/health'],
+    ['/ready'],
+    ['/metrics'],
+    ['/.well-known/did.json'],
+  ])('returns nothing for the non-XRPC path %s', (path) => {
+    expect(lexiconMethodForPath(path)).toBeUndefined();
+  });
+
+  it('returns nothing for a bare xrpc prefix', () => {
+    expect(lexiconMethodForPath('/xrpc/')).toBeUndefined();
+  });
+
+  // The escalation this closes: two different methods must never resolve to the
+  // same scope string.
+  it('distinguishes the methods that were previously interchangeable', () => {
+    const low = lexiconMethodForPath('/xrpc/pub.chive.metrics.recordView');
+    const high = lexiconMethodForPath('/xrpc/pub.chive.admin.deleteContent');
+    expect(low).not.toBe(high);
+    expect(high).toBe('pub.chive.admin.deleteContent');
+  });
+});

--- a/tests/unit/api/rate-limit-paths.test.ts
+++ b/tests/unit/api/rate-limit-paths.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for the relaxed rate-limit path list.
+ *
+ * @remarks
+ * Autocomplete and search endpoints get a higher anonymous rate limit than
+ * everything else, selected by matching request paths against a hardcoded list
+ * of prefixes. One entry named `pub.chive.search.searchSubmissions`, which is
+ * not a method this service registers — the real NSID is
+ * `pub.chive.eprint.searchSubmissions` — so search never matched the relaxed
+ * tier and every anonymous search was billed against the low one.
+ *
+ * A stale NSID in a list of strings fails silently: nothing errors, the pattern
+ * simply never matches. Checking the list against the registered methods is the
+ * only way this stays true as endpoints are renamed.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { AUTOCOMPLETE_RATE_LIMIT_PATHS } from '@/api/rate-limit-paths.js';
+import { schemas } from '@/lexicons/generated/lexicons.js';
+
+const LEXICON_IDS = new Set(schemas.map((schema) => schema.id));
+
+const XRPC_PREFIX = '/xrpc/';
+
+const xrpcNsids = AUTOCOMPLETE_RATE_LIMIT_PATHS.filter((path) => path.startsWith(XRPC_PREFIX)).map(
+  (path) => path.slice(XRPC_PREFIX.length)
+);
+
+describe('relaxed rate-limit paths', () => {
+  it('lists at least one XRPC endpoint', () => {
+    expect(xrpcNsids.length).toBeGreaterThan(0);
+  });
+
+  // Checked against the lexicon set rather than the handler registry: importing
+  // the registry pulls every XRPC handler into this test's module graph, which
+  // drags several thousand untested lines into the coverage denominator for no
+  // extra assurance. A path naming an NSID that has no lexicon is the defect.
+  it.each(xrpcNsids)('%s names a real lexicon', (nsid) => {
+    expect(LEXICON_IDS).toContain(nsid);
+  });
+
+  // The specific regression: the search endpoint must be in the relaxed tier.
+  it('covers the eprint search endpoint under its real NSID', () => {
+    expect(AUTOCOMPLETE_RATE_LIMIT_PATHS).toContain('/xrpc/pub.chive.eprint.searchSubmissions');
+  });
+
+  it('no longer references the NSID that never existed', () => {
+    expect(AUTOCOMPLETE_RATE_LIMIT_PATHS).not.toContain('/xrpc/pub.chive.search.searchSubmissions');
+  });
+});

--- a/tests/unit/api/xrpc/method-type-registration.test.ts
+++ b/tests/unit/api/xrpc/method-type-registration.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for HTTP verb selection when registering XRPC methods.
+ *
+ * @remarks
+ * A registered lexicon decides whether a method is a query (GET) or a procedure
+ * (POST). When no lexicon is registered, the adapter fell through to `true` —
+ * query — and ignored the method's own `type`. A handler declared as a
+ * `procedure` was therefore mounted on GET, and every POST caller received a
+ * 404 while a GET reached a handler expecting a body.
+ */
+
+import { Lexicons } from '@atproto/lexicon';
+import { describe, it, expect, vi } from 'vitest';
+
+import { createXRPCRouter } from '@/api/xrpc/hono-adapter.js';
+import type { XRPCMethod } from '@/api/xrpc/types.js';
+
+const handler = vi.fn().mockResolvedValue({ encoding: 'application/json', body: { ok: true } });
+
+/** Registers one method on an empty lexicon set and returns the router. */
+const register = (nsid: string, config: Partial<XRPCMethod<unknown, unknown, unknown>>) => {
+  const xrpc = createXRPCRouter(new Lexicons());
+  xrpc.method(nsid, { handler, ...config } as XRPCMethod<unknown, unknown, unknown>);
+  return xrpc;
+};
+
+/** Reports the HTTP verbs Hono has routes registered for at a path. */
+const verbsFor = (xrpc: ReturnType<typeof register>, path: string): string[] =>
+  xrpc.router.routes.filter((r) => r.path === path).map((r) => r.method.toLowerCase());
+
+describe('XRPC method verb registration without a lexicon', () => {
+  it('registers a declared procedure on POST', () => {
+    const xrpc = register('pub.chive.test.doThing', { type: 'procedure' });
+    expect(verbsFor(xrpc, '/pub.chive.test.doThing')).toContain('post');
+  });
+
+  it('does not register a declared procedure on GET', () => {
+    const xrpc = register('pub.chive.test.doThing', { type: 'procedure' });
+    expect(verbsFor(xrpc, '/pub.chive.test.doThing')).not.toContain('get');
+  });
+
+  it('registers a declared query on GET', () => {
+    const xrpc = register('pub.chive.test.getThing', { type: 'query' });
+    expect(verbsFor(xrpc, '/pub.chive.test.getThing')).toContain('get');
+  });
+
+  // Query stays the default: most lexicon-less methods are reads, and changing
+  // that would move existing endpoints off the verb their callers use.
+  it('still defaults to GET when no type is declared', () => {
+    const xrpc = register('pub.chive.test.unspecified', {});
+    expect(verbsFor(xrpc, '/pub.chive.test.unspecified')).toContain('get');
+  });
+});

--- a/tests/unit/api/xrpc/method-type-registration.test.ts
+++ b/tests/unit/api/xrpc/method-type-registration.test.ts
@@ -18,7 +18,10 @@ import type { XRPCMethod } from '@/api/xrpc/types.js';
 const handler = vi.fn().mockResolvedValue({ encoding: 'application/json', body: { ok: true } });
 
 /** Registers one method on an empty lexicon set and returns the router. */
-const register = (nsid: string, config: Partial<XRPCMethod<unknown, unknown, unknown>>) => {
+const register = (
+  nsid: string,
+  config: Partial<XRPCMethod<unknown, unknown, unknown>>
+): ReturnType<typeof createXRPCRouter> => {
   const xrpc = createXRPCRouter(new Lexicons());
   xrpc.method(nsid, { handler, ...config } as XRPCMethod<unknown, unknown, unknown>);
   return xrpc;

--- a/tests/unit/auth/scopes/chive-scopes.test.ts
+++ b/tests/unit/auth/scopes/chive-scopes.test.ts
@@ -42,7 +42,12 @@ describe('chive-scopes', () => {
       expect(REPO_SCOPES.GRAPH_NODE).toBe('repo:pub.chive.graph.node');
       expect(REPO_SCOPES.GRAPH_EDGE).toBe('repo:pub.chive.graph.edge');
       expect(REPO_SCOPES.DISCOVERY_SETTINGS).toBe('repo:pub.chive.discovery.settings');
-      expect(REPO_SCOPES.GRAPH_FIELD_PROPOSAL).toBe('repo:pub.chive.graph.fieldProposal');
+    });
+
+    // The record type was renamed to node/edgeProposal and `fieldProposal` has
+    // no lexicon, so a scope for it could be granted but never used.
+    it('does not offer a scope for the renamed fieldProposal record', () => {
+      expect(Object.values(REPO_SCOPES)).not.toContain('repo:pub.chive.graph.fieldProposal');
     });
 
     it('prefixes all scopes with repo:', () => {
@@ -58,8 +63,10 @@ describe('chive-scopes', () => {
     });
 
     it('covers all pub.chive.* collections that the app writes to', () => {
-      // 19 original + actor.mute + collaboration.invite + collaboration.inviteAcceptance
-      expect(Object.keys(REPO_SCOPES)).toHaveLength(22);
+      // 19 original + actor.mute + collaboration.invite + collaboration.inviteAcceptance,
+      // less the fieldProposal scope, whose record type was renamed to
+      // node/edgeProposal and has no lexicon to grant against.
+      expect(Object.keys(REPO_SCOPES)).toHaveLength(21);
     });
   });
 

--- a/tests/unit/config/admin.test.ts
+++ b/tests/unit/config/admin.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for platform administrator resolution.
+ *
+ * @remarks
+ * The list was previously parsed in three places with two behaviours: the two
+ * seeding paths fell back to a hardcoded DID when `ADMIN_DIDS` was unset, while
+ * the governance role service did not. On a deployment that never sets the
+ * variable — the documented normal case — a platform admin existed while the
+ * governance layer recognised no administrator, leaving every privileged
+ * governance endpoint unreachable with no way to bootstrap one.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_ADMIN_DID, getAdminDids } from '@/config/admin.js';
+
+describe('getAdminDids', () => {
+  const original = process.env.ADMIN_DIDS;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.ADMIN_DIDS;
+    else process.env.ADMIN_DIDS = original;
+  });
+
+  it('should parse a comma-separated list', () => {
+    expect(getAdminDids('did:plc:abc,did:plc:def')).toEqual(['did:plc:abc', 'did:plc:def']);
+  });
+
+  it('should trim surrounding whitespace', () => {
+    expect(getAdminDids(' did:plc:abc , did:plc:def ')).toEqual(['did:plc:abc', 'did:plc:def']);
+  });
+
+  // `getAdminDids(undefined)` triggers the default parameter and therefore
+  // reads ADMIN_DIDS, so "unset" has to be established on the environment
+  // rather than by passing undefined — CI sets ADMIN_DIDS, and conflating the
+  // two made this pass locally and fail there.
+  it('should fall back when the environment has no ADMIN_DIDS', () => {
+    delete process.env.ADMIN_DIDS;
+    expect(getAdminDids()).toEqual([DEFAULT_ADMIN_DID]);
+  });
+
+  // An undefined deploy variable interpolates to an empty string rather than
+  // being absent, and treating that as "no administrators" is what silently
+  // disabled governance.
+  it.each([
+    ['empty string', ''],
+    ['whitespace only', '   '],
+    ['commas only', ',,,'],
+  ])('should fall back on %s', (_name, raw) => {
+    expect(getAdminDids(raw)).toEqual([DEFAULT_ADMIN_DID]);
+  });
+
+  it('should read the environment variable when no argument is given', () => {
+    process.env.ADMIN_DIDS = 'did:plc:fromenv';
+    expect(getAdminDids()).toEqual(['did:plc:fromenv']);
+  });
+
+  it('should fall back when the environment variable is blank', () => {
+    process.env.ADMIN_DIDS = '';
+    expect(getAdminDids()).toEqual([DEFAULT_ADMIN_DID]);
+  });
+});

--- a/tests/unit/config/coverage-enforcement.test.ts
+++ b/tests/unit/config/coverage-enforcement.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for coverage threshold enforcement.
+ *
+ * @remarks
+ * The coverage bar was unenforced end to end on the frontend: `web/vitest.config.ts`
+ * declared no thresholds, and CI ran the web suite without `--coverage`, so nothing
+ * ever evaluated one. The stated bar in the project documentation was 70%; the real
+ * figure had drifted to roughly 41% of lines without anything noticing.
+ *
+ * These tests pin that thresholds exist and that CI measures them. They deliberately
+ * do not assert the values match the documented bar — they do not, and closing that
+ * gap is test-writing work rather than a config change. Asserting the aspiration here
+ * would either be false or force every pull request to carry pre-existing debt.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const read = (relative: string): string => readFileSync(join(process.cwd(), relative), 'utf8');
+
+describe('coverage thresholds are declared', () => {
+  it.each([
+    ['backend', 'vitest.unit.config.ts'],
+    ['frontend', 'web/vitest.config.ts'],
+  ])('%s config declares thresholds', (_label, path) => {
+    expect(read(path)).toMatch(/thresholds:\s*\{/);
+  });
+
+  it.each([
+    ['backend', 'vitest.unit.config.ts'],
+    ['frontend', 'web/vitest.config.ts'],
+  ])('%s thresholds cover lines, statements, branches and functions', (_label, path) => {
+    const contents = read(path);
+    for (const metric of ['lines', 'statements', 'branches', 'functions']) {
+      expect(contents).toMatch(new RegExp(`${metric}:\\s*\\d+`));
+    }
+  });
+});
+
+describe('CI evaluates the thresholds', () => {
+  const workflow = read('.github/workflows/ci.yml');
+
+  it('runs the backend suite with coverage', () => {
+    expect(workflow).toMatch(/pnpm test:unit --coverage/);
+  });
+
+  // Without this flag the frontend thresholds are never evaluated, which is
+  // exactly how the bar came to be unenforced.
+  it('runs the frontend suite with coverage', () => {
+    expect(workflow).toMatch(/@chive\/web test -- --coverage/);
+  });
+});

--- a/tests/unit/config/governance-config.test.ts
+++ b/tests/unit/config/governance-config.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for governance configuration validation.
+ *
+ * @remarks
+ * `GRAPH_PDS_DID` was set to `did:plc:chive-governance` in every environment
+ * file — `.env.example`, the production example, and the Kubernetes configmap.
+ * That is not a PLC identifier: they are `did:plc:` followed by 24
+ * base32-sortable characters. The value overrode a correct code default, and
+ * nothing rejected it, so the governance sync resolved a DID that does not
+ * exist and imported an empty graph for as long as it was configured.
+ *
+ * A governance DID that cannot resolve is not a degraded mode, it is silence,
+ * so the configuration now refuses the value rather than carrying it.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import { isPlcDid } from '@/types/atproto-validators.js';
+
+const read = (relative: string): string => readFileSync(join(process.cwd(), relative), 'utf8');
+
+const CONFIG_FILES = [
+  '.env.example',
+  'docker/.env.production.example',
+  'k8s/base/appview/configmap.yaml',
+];
+
+describe('isPlcDid', () => {
+  it('accepts a real PLC identifier', () => {
+    expect(isPlcDid('did:plc:5wzpn4a4nbqtz3q45hyud6hd')).toBe(true);
+  });
+
+  it.each([
+    ['did:plc:chive-governance', 'the value that was configured everywhere'],
+    ['did:plc:short', 'too few characters'],
+    ['did:plc:5wzpn4a4nbqtz3q45hyud6hdx', 'too many characters'],
+    ['did:plc:5WZPN4A4NBQTZ3Q45HYUD6HD', 'uppercase is outside base32-sortable'],
+    ['did:plc:5wzpn4a4nbqtz3q45hyud6h1', '1 is outside base32-sortable'],
+    ['did:web:example.com', 'a different DID method'],
+    ['', 'empty'],
+  ])('rejects %s (%s)', (candidate) => {
+    expect(isPlcDid(candidate)).toBe(false);
+  });
+});
+
+describe('shipped governance configuration', () => {
+  it.each(CONFIG_FILES)('%s does not carry the invalid governance DID', (file) => {
+    expect(read(file)).not.toContain('did:plc:chive-governance');
+  });
+
+  it.each(CONFIG_FILES)('%s sets a well-formed PLC DID', (file) => {
+    const match = /GRAPH_PDS_DID[=:]\s*"?(did:plc:[a-z2-7]+)"?/.exec(read(file));
+    expect(match?.[1]).toBeDefined();
+    expect(isPlcDid(match?.[1] ?? '')).toBe(true);
+  });
+});

--- a/tests/unit/config/health-check-probes.test.ts
+++ b/tests/unit/config/health-check-probes.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for the scheduled health-check workflow's probes.
+ *
+ * @remarks
+ * The workflow probed `/api/health`, which is a static 200 that reports nothing
+ * about dependencies. `/ready` — the readiness path Kubernetes uses, and the
+ * only endpoint that actually checks PostgreSQL, Elasticsearch, Neo4j and Redis
+ * — was never probed by any workflow. A datastore outage was therefore
+ * invisible to monitoring: the API answered 200 from a pod that could not serve
+ * a single query.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const workflow = readFileSync(join(process.cwd(), '.github/workflows/health-check.yml'), 'utf8');
+
+describe('health-check workflow', () => {
+  it('probes the readiness endpoint', () => {
+    expect(workflow).toMatch(/\/api\/ready/);
+  });
+
+  it('still probes liveness', () => {
+    expect(workflow).toMatch(/\/api\/health/);
+  });
+
+  // Every probe is continue-on-error so that one failure does not hide the
+  // others, which means each outcome has to be folded into the summary
+  // explicitly or the job reports success regardless.
+  it('folds the readiness outcome into the failure list', () => {
+    expect(workflow).toMatch(/steps\.api_ready\.outcome/);
+    expect(workflow).toMatch(/failures="\$\{failures\}APIReadiness,"/);
+  });
+
+  it('reports readiness in the run summary', () => {
+    expect(workflow).toMatch(/API Readiness/);
+  });
+});

--- a/tests/unit/config/orcid-redirect-uri.test.ts
+++ b/tests/unit/config/orcid-redirect-uri.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the ORCID OAuth redirect URI.
+ *
+ * @remarks
+ * The callback is registered at `/v1/auth/orcid/callback`, since REST routes
+ * are mounted on the application root. The default redirect URI pointed at
+ * `/api/v1/auth/orcid/callback` instead, so the whole ORCID verification flow
+ * 404ed wherever a request reaches the application directly — local
+ * development, and the `api.DOMAIN` Traefik router, which does not strip a
+ * prefix. Only the `Host(DOMAIN) && PathPrefix(/api)` router strips one, and a
+ * deployment behind it can set `ORCID_REDIRECT_URI` explicitly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { getOrcidConfig } from '@/config/orcid.js';
+
+const ORIGINAL = { ...process.env };
+
+describe('ORCID redirect URI', () => {
+  beforeEach(() => {
+    process.env.ORCID_CLIENT_ID = 'test-client';
+    process.env.ORCID_CLIENT_SECRET = 'test-secret';
+    delete process.env.ORCID_REDIRECT_URI;
+    delete process.env.API_BASE_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+  });
+
+  it('defaults to the path the callback route is registered at', () => {
+    process.env.API_BASE_URL = 'https://api.chive.pub';
+    expect(getOrcidConfig().redirectUri).toBe('https://api.chive.pub/v1/auth/orcid/callback');
+  });
+
+  it('does not prepend an /api segment the application does not serve', () => {
+    process.env.API_BASE_URL = 'https://api.chive.pub';
+    expect(getOrcidConfig().redirectUri).not.toContain('/api/v1/');
+  });
+
+  // A deployment behind the path-prefixed router sets the URI explicitly.
+  it('honours an explicit override', () => {
+    process.env.ORCID_REDIRECT_URI = 'https://chive.pub/api/v1/auth/orcid/callback';
+    expect(getOrcidConfig().redirectUri).toBe('https://chive.pub/api/v1/auth/orcid/callback');
+  });
+
+  it('refuses to load without credentials', () => {
+    delete process.env.ORCID_CLIENT_ID;
+    expect(() => getOrcidConfig()).toThrow(/ORCID OAuth not configured/);
+  });
+});

--- a/tests/unit/config/root-test-script.test.ts
+++ b/tests/unit/config/root-test-script.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for the repository's root `test` script.
+ *
+ * @remarks
+ * The root package is not a pnpm workspace member — the workspace covers
+ * `packages/*`, `web` and `docs` — so `turbo test` fans out to `web` alone and
+ * never reaches the backend suite under `src/`. For a while the root script was
+ * exactly `turbo test`, which meant `pnpm test` exited zero having run no
+ * backend tests at all: the obvious command reported success while the thing it
+ * was meant to check went unrun. CI is unaffected, since it calls `test:unit`,
+ * `test:integration` and `test:compliance` explicitly, but anyone (or any agent)
+ * trusting `pnpm test` was reading a false green.
+ *
+ * This pins the invariant rather than the exact command: whatever the root
+ * script grows into, it has to reach the backend unit suite.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+interface PackageManifest {
+  readonly scripts?: Readonly<Record<string, string>>;
+}
+
+const manifest = JSON.parse(
+  readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+) as PackageManifest;
+
+describe('root test script', () => {
+  it('runs the backend unit suite and not only the workspace tasks', () => {
+    const script = manifest.scripts?.test;
+    expect(script).toBeDefined();
+    expect(script).toMatch(/test:unit|vitest\.unit\.config/);
+  });
+
+  it('still fans out to the workspace packages', () => {
+    expect(manifest.scripts?.test).toMatch(/turbo test/);
+  });
+
+  it('keeps the backend unit script pointed at the unit config', () => {
+    expect(manifest.scripts?.['test:unit']).toMatch(/vitest\.unit\.config/);
+  });
+});

--- a/tests/unit/config/security-scanning.test.ts
+++ b/tests/unit/config/security-scanning.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the presence of security scanning configuration.
+ *
+ * @remarks
+ * The repository ran no scanning of any kind — no SAST, no dependency audit, no
+ * container scan, no Dependabot — while the architecture overview described
+ * scanning as part of the pipeline. The gap survived precisely because nothing
+ * asserted it, so these tests pin the configuration's existence and the parts
+ * of its shape that matter.
+ *
+ * They deliberately do not assert that the dependency audit gates the build.
+ * It does not, and that is a recorded decision: the tree carries a large
+ * backlog of transitive advisories, and a gate switched on before that is
+ * worked down would block every pull request on pre-existing debt.
+ *
+ * Assertions are made against the file text rather than a parsed document,
+ * since the repository carries no YAML parser and adding one for a test is not
+ * worth the dependency.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const read = (relative: string): string => readFileSync(join(process.cwd(), relative), 'utf8');
+const exists = (relative: string): boolean => existsSync(join(process.cwd(), relative));
+
+describe('security scanning workflow', () => {
+  const path = '.github/workflows/security.yml';
+
+  it('exists', () => {
+    expect(exists(path)).toBe(true);
+  });
+
+  it.each([
+    ['SAST', /^ {2}codeql:$/m],
+    ['dependency audit', /^ {2}dependency-audit:$/m],
+    ['filesystem scan', /^ {2}filesystem-scan:$/m],
+  ])('defines a %s job', (_label, pattern) => {
+    expect(read(path)).toMatch(pattern);
+  });
+
+  // A tag that does not exist fails at "Set up job", before any step runs, so
+  // the workflow reports a red check with no scan output to explain it. The
+  // first version of this file pinned `aquasecurity/trivy-action@0.28.0`, which
+  // is neither a real release nor the right tag format — the action's releases
+  // are v-prefixed.
+  it('pins third-party actions to v-prefixed release tags', () => {
+    const contents = read(path);
+    const thirdParty = [...contents.matchAll(/uses:\s+(?!\.\/)([\w-]+\/[\w./-]+)@(\S+)/g)];
+    expect(thirdParty.length).toBeGreaterThan(0);
+    for (const [, action, ref] of thirdParty) {
+      expect(ref, `${action ?? ''} is pinned to ${ref ?? ''}`).toMatch(/^v\d+/);
+    }
+  });
+
+  it('grants the permission needed to publish findings', () => {
+    expect(read(path)).toMatch(/security-events:\s*write/);
+  });
+
+  // A scan that only runs on push misses advisories disclosed after the last
+  // commit, which is most of them.
+  it('runs on a schedule as well as on pull requests', () => {
+    const contents = read(path);
+    expect(contents).toMatch(/^\s{2}schedule:$/m);
+    expect(contents).toMatch(/^\s{2}pull_request:$/m);
+  });
+
+  it('analyses this repository languages with CodeQL', () => {
+    expect(read(path)).toMatch(/languages:\s*javascript-typescript/);
+  });
+});
+
+describe('dependabot configuration', () => {
+  const path = '.github/dependabot.yml';
+
+  it('exists', () => {
+    expect(exists(path)).toBe(true);
+  });
+
+  // Dependabot does not follow pnpm workspaces from the root manifest, so each
+  // workspace holding its own package.json needs its own entry or it is simply
+  // never updated.
+  it.each([['/'], ['/web'], ['/docs']])('covers the %s manifest', (directory) => {
+    const entries = [...read(path).matchAll(/directory:\s*(\S+)/g)].map((match) => match[1]);
+    expect(entries).toContain(directory);
+  });
+
+  it('keeps workflow actions updated too', () => {
+    expect(read(path)).toMatch(/package-ecosystem:\s*github-actions/);
+  });
+
+  // Grouping production separately keeps a runtime bump from being buried in a
+  // batch of tooling updates.
+  it('separates production from development updates', () => {
+    const contents = read(path);
+    expect(contents).toMatch(/dependency-type:\s*production/);
+    expect(contents).toMatch(/dependency-type:\s*development/);
+  });
+});

--- a/tests/unit/config/test-stack-isolation.test.ts
+++ b/tests/unit/config/test-stack-isolation.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the isolation of the developer test stack from production.
+ *
+ * @remarks
+ * The test stack in `docker/docker-compose.yml` originally named its containers
+ * `chive-postgres`, `chive-grobid` and so on, which are the same names the
+ * production compose file uses. Two problems followed. Running the test stack on
+ * a host that also runs production collided outright on `chive-grobid`, and the
+ * deploy workflows sweep leftovers with
+ * `docker ps -a --filter "name=chive-" | xargs docker rm -f`, which matched every
+ * test container and destroyed a running test stack mid-deploy.
+ *
+ * Prefixing alone does not fix the second problem — `chive-test-postgres` still
+ * matches a `name=chive-` filter — so the sweep has to exclude the prefix
+ * explicitly. Both halves are pinned here, since either one alone leaves the
+ * hazard in place.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const read = (relative: string): string => readFileSync(join(process.cwd(), relative), 'utf8');
+
+const DEPLOY_WORKFLOWS = [
+  '.github/workflows/deploy-app.yml',
+  '.github/workflows/deploy-staging.yml',
+];
+
+describe('test stack isolation', () => {
+  const compose = read('docker/docker-compose.yml');
+
+  it('prefixes every test stack container with chive-test-', () => {
+    const names = [...compose.matchAll(/container_name:\s*(\S+)/g)].map((m) => m[1]);
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(name).toMatch(/^chive-test-/);
+    }
+  });
+
+  it('points the test stack at the test database rather than the production name', () => {
+    expect(compose).toMatch(/POSTGRES_DB:\s*chive_test/);
+    expect(compose).not.toMatch(/POSTGRES_DB:\s*chive\s*$/m);
+  });
+
+  // The prefix shares `chive-`, so the deploy sweep must filter it out by name.
+  it.each(DEPLOY_WORKFLOWS)(
+    'excludes the test stack from the container sweep in %s',
+    (workflow) => {
+      const contents = read(workflow);
+      const sweeps = contents.split('\n').filter((line) => line.includes('--filter "name=chive-"'));
+      expect(sweeps.length).toBeGreaterThan(0);
+      expect(contents).toMatch(/grep -v '\^chive-test-'/);
+    }
+  );
+});

--- a/tests/unit/jobs/governance-sync-job.test.ts
+++ b/tests/unit/jobs/governance-sync-job.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for GovernanceSyncJob.
+ *
+ * @remarks
+ * Focuses on failure accounting: a cycle in which some records fail to index
+ * must report `partial` rather than `success`, so callers cannot mistake a
+ * lossy sync for a complete one. Also pins the clean-run reporting so the
+ * success path stays unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GovernanceSyncJob } from '@/jobs/governance-sync-job.js';
+import { jobMetrics } from '@/observability/prometheus-registry.js';
+import type { EdgeService } from '@/services/governance/edge-service.js';
+import type { NodeService } from '@/services/governance/node-service.js';
+import type { AtUri, DID } from '@/types/atproto.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+// Hoisted so the mock factories below can reach these spies without a TDZ error.
+const { endTimer, listRecords } = vi.hoisted(() => ({
+  endTimer: vi.fn(),
+  listRecords: vi.fn(),
+}));
+
+vi.mock('@/observability/tracer.js', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+  addSpanAttributes: vi.fn(),
+}));
+
+vi.mock('@/observability/prometheus-registry.js', () => ({
+  jobMetrics: {
+    executionsTotal: { inc: vi.fn() },
+    itemsProcessed: { inc: vi.fn() },
+    lastRunTimestamp: { set: vi.fn() },
+    duration: { startTimer: vi.fn(() => endTimer) },
+  },
+}));
+
+// A plain class, not vi.fn(), so vi.clearAllMocks() cannot strip the constructor.
+vi.mock('@atproto/api', () => ({
+  AtpAgent: class {
+    com = { atproto: { repo: { listRecords } } };
+  },
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const GOVERNANCE_DID = 'did:plc:governance' as DID;
+const INDEXED_URI = 'at://did:plc:governance/pub.chive.graph.node/indexed' as AtUri;
+
+const createMockLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+function nodeRecord(id: string): { uri: string; value: Record<string, unknown> } {
+  return {
+    uri: `at://${GOVERNANCE_DID}/pub.chive.graph.node/${id}`,
+    value: { id, kind: 'field', label: id, status: 'active' },
+  };
+}
+
+function edgeRecord(id: string): { uri: string; value: Record<string, unknown> } {
+  return {
+    uri: `at://${GOVERNANCE_DID}/pub.chive.graph.edge/${id}`,
+    value: {
+      id,
+      sourceUri: `at://${GOVERNANCE_DID}/pub.chive.graph.node/a`,
+      targetUri: `at://${GOVERNANCE_DID}/pub.chive.graph.node/b`,
+      relationSlug: 'broader',
+      status: 'active',
+    },
+  };
+}
+
+/**
+ * Stubs listRecords so the node collection returns `nodes` and the edge
+ * collection returns `edges`, each in a single page.
+ */
+function stubCollections(
+  nodes: ReturnType<typeof nodeRecord>[],
+  edges: ReturnType<typeof edgeRecord>[]
+): void {
+  listRecords.mockImplementation(({ collection }: { collection: string }) =>
+    Promise.resolve({
+      data: {
+        records: collection === 'pub.chive.graph.node' ? nodes : edges,
+        cursor: undefined,
+      },
+    })
+  );
+}
+
+function createJob(
+  nodeService: NodeService,
+  edgeService: EdgeService,
+  logger: ILogger
+): GovernanceSyncJob {
+  return new GovernanceSyncJob({
+    pdsUrl: 'https://governance.example',
+    graphPdsDid: GOVERNANCE_DID,
+    nodeService,
+    edgeService,
+    logger,
+  });
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('GovernanceSyncJob.run', () => {
+  let logger: ILogger;
+  let nodeService: NodeService;
+  let edgeService: EdgeService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = createMockLogger();
+    nodeService = { indexNode: vi.fn().mockResolvedValue(INDEXED_URI) } as unknown as NodeService;
+    edgeService = { indexEdge: vi.fn().mockResolvedValue(INDEXED_URI) } as unknown as EdgeService;
+  });
+
+  it('reports success and counts every record when nothing fails', async () => {
+    stubCollections([nodeRecord('n1'), nodeRecord('n2')], [edgeRecord('e1')]);
+
+    const result = await createJob(nodeService, edgeService, logger).run();
+
+    expect(result).toEqual({
+      nodesIndexed: 2,
+      edgesIndexed: 1,
+      failedCount: 0,
+      status: 'success',
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      'Governance sync completed',
+      expect.objectContaining({ nodesIndexed: 2, edgesIndexed: 1 })
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(jobMetrics.executionsTotal.inc).toHaveBeenCalledWith({
+      job: 'governance_sync',
+      status: 'success',
+    });
+    expect(jobMetrics.itemsProcessed.inc).toHaveBeenCalledTimes(1);
+    expect(jobMetrics.itemsProcessed.inc).toHaveBeenCalledWith(
+      { job: 'governance_sync', status: 'success' },
+      3
+    );
+    expect(endTimer).toHaveBeenCalledWith({ status: 'success' });
+  });
+
+  it('reports partial and counts failures when some records fail to index', async () => {
+    stubCollections([nodeRecord('n1'), nodeRecord('n2')], [edgeRecord('e1')]);
+    vi.mocked(nodeService.indexNode)
+      .mockResolvedValueOnce(INDEXED_URI)
+      .mockRejectedValueOnce(new Error('neo4j write failed'));
+    vi.mocked(edgeService.indexEdge).mockRejectedValueOnce(new Error('neo4j write failed'));
+
+    const result = await createJob(nodeService, edgeService, logger).run();
+
+    expect(result).toEqual({
+      nodesIndexed: 1,
+      edgesIndexed: 0,
+      failedCount: 2,
+      status: 'partial',
+    });
+    expect(logger.info).not.toHaveBeenCalledWith('Governance sync completed', expect.anything());
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Governance sync completed with failures',
+      expect.objectContaining({ nodesFailed: 1, edgesFailed: 1 })
+    );
+    expect(jobMetrics.executionsTotal.inc).toHaveBeenCalledWith({
+      job: 'governance_sync',
+      status: 'partial',
+    });
+    expect(jobMetrics.itemsProcessed.inc).toHaveBeenCalledWith(
+      { job: 'governance_sync', status: 'error' },
+      2
+    );
+    expect(endTimer).toHaveBeenCalledWith({ status: 'partial' });
+  });
+
+  it('does not fail the cycle when one record poisons the batch', async () => {
+    stubCollections([nodeRecord('n1'), nodeRecord('n2'), nodeRecord('n3')], []);
+    vi.mocked(nodeService.indexNode).mockRejectedValueOnce(new Error('boom'));
+
+    const result = await createJob(nodeService, edgeService, logger).run();
+
+    expect(nodeService.indexNode).toHaveBeenCalledTimes(3);
+    expect(result.nodesIndexed).toBe(2);
+    expect(result.failedCount).toBe(1);
+  });
+
+  it('reports success for a skipped cycle since no records were read', async () => {
+    stubCollections([nodeRecord('n1')], []);
+    const job = createJob(nodeService, edgeService, logger);
+
+    const [first, second] = await Promise.all([job.run(), job.run()]);
+
+    expect(first.nodesIndexed + second.nodesIndexed).toBe(1);
+    expect([first.status, second.status]).toEqual(['success', 'success']);
+  });
+});

--- a/tests/unit/observability/telemetry-startup.test.ts
+++ b/tests/unit/observability/telemetry-startup.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for telemetry startup wiring.
+ *
+ * @remarks
+ * `initTelemetry` was never called from either entry point. The OpenTelemetry
+ * SDK therefore never started, every `withSpan` in the codebase executed its
+ * callback without recording anything, and no OTLP export ever happened — the
+ * tracing existed as decoration. Nothing failed, which is why it survived.
+ *
+ * Both processes need their own call: the API and the firehose indexer run
+ * separately, and instrumenting one leaves the other dark.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const source = (relative: string): string => readFileSync(join(process.cwd(), relative), 'utf8');
+
+const ENTRY_POINTS = [
+  ['the API', 'src/index.ts', 'chive-appview'],
+  ['the indexer', 'src/indexer.ts', 'chive-indexer'],
+] as const;
+
+describe('telemetry startup', () => {
+  it.each(ENTRY_POINTS)('%s imports initTelemetry', (_label, path) => {
+    expect(source(path)).toMatch(/import \{ initTelemetry \} from/);
+  });
+
+  it.each(ENTRY_POINTS)('%s calls it with its own service name', (_label, path, serviceName) => {
+    expect(source(path)).toMatch(
+      new RegExp(`initTelemetry\\(\\{[^}]*serviceName: '${serviceName}'`)
+    );
+  });
+
+  // Without a configured endpoint outside production the exporter would retry a
+  // collector that is not there, so local runs skip initialization instead.
+  it.each(ENTRY_POINTS)('%s only initializes when there is somewhere to export', (_label, path) => {
+    const contents = source(path);
+    expect(contents).toMatch(/OTEL_EXPORTER_OTLP_ENDPOINT \|\| config\.nodeEnv === 'production'/);
+  });
+
+  it.each(ENTRY_POINTS)('%s honours the standard disable flag', (_label, path) => {
+    expect(source(path)).toMatch(/OTEL_SDK_DISABLED === 'true'/);
+  });
+});

--- a/tests/unit/plugins/builtin/backlink-collection-nsids.test.ts
+++ b/tests/unit/plugins/builtin/backlink-collection-nsids.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for the collections the backlink plugins track.
+ *
+ * @remarks
+ * These plugins subscribe to foreign lexicons, and a wrong NSID fails silently:
+ * the plugin loads, subscribes to a collection nothing publishes, and indexes
+ * nothing. There is no error to notice.
+ *
+ * The WhiteWind plugin tracked `com.whitewind.blog.entry`. WhiteWind's actual
+ * lexicon is `com.whtwnd.blog.entry` — the abbreviated spelling — so the plugin
+ * could never have matched a real blog post.
+ *
+ * The Leaflet plugin tracks `xyz.leaflet.list`, which does not exist at all;
+ * Leaflet publishes `pub.leaflet.document` and `pub.leaflet.comment`. That one
+ * is deliberately left as it is: the plugin's record interface was invented to
+ * match the fictional NSID, so repointing it at a real collection without
+ * rewriting the parser would read real records against a schema they do not
+ * have — wrong backlinks rather than none. This test records the state rather
+ * than blessing it, so the next reader does not have to re-derive it.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const source = (name: string): string =>
+  readFileSync(join(process.cwd(), 'src/plugins/builtin', `${name}.ts`), 'utf8');
+
+describe('WhiteWind backlink plugin', () => {
+  const contents = source('whitewind-backlinks');
+
+  it("tracks WhiteWind's real blog entry collection", () => {
+    expect(contents).toMatch(/trackedCollection = 'com\.whtwnd\.blog\.entry'/);
+  });
+
+  it('no longer references the misspelled authority', () => {
+    expect(contents).not.toMatch(/com\.whitewind/);
+  });
+});
+
+describe('Leaflet backlink plugin', () => {
+  const contents = source('leaflet-backlinks');
+
+  // Kept pointing at the fictional NSID on purpose; see the file header.
+  it('still tracks the fictional collection', () => {
+    expect(contents).toMatch(/trackedCollection = 'xyz\.leaflet\.list'/);
+  });
+
+  it('says plainly that the collection does not exist', () => {
+    expect(contents).toMatch(/does not exist/);
+    expect(contents).toMatch(/pub\.leaflet\.document/);
+  });
+});

--- a/tests/unit/plugins/builtin/whitewind-backlinks.test.ts
+++ b/tests/unit/plugins/builtin/whitewind-backlinks.test.ts
@@ -80,7 +80,7 @@ const createMockEventBus = (): IPluginEventBus & {
 const createMockBacklinkService = (): IBacklinkService => ({
   createBacklink: vi.fn().mockResolvedValue({
     id: 1,
-    sourceUri: 'at://did:plc:test/com.whitewind.blog.entry/rkey',
+    sourceUri: 'at://did:plc:test/com.whtwnd.blog.entry/rkey',
     sourceType: 'whitewind.blog',
     targetUri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
     indexedAt: new Date(),
@@ -150,7 +150,7 @@ const createWhiteWindEntry = (
     tags: string[];
   }> = {}
 ): Record<string, unknown> => ({
-  $type: 'com.whitewind.blog.entry' as const,
+  $type: 'com.whtwnd.blog.entry' as const,
   title: 'Test Blog Post',
   content: 'Test content',
   contentFormat: 'markdown' as const,
@@ -185,7 +185,7 @@ describe('WhiteWindBacklinksPlugin', () => {
     });
 
     it('should have correct tracked collection', () => {
-      expect(plugin.trackedCollection).toBe('com.whitewind.blog.entry');
+      expect(plugin.trackedCollection).toBe('com.whtwnd.blog.entry');
     });
 
     it('should have correct source type', () => {
@@ -222,7 +222,7 @@ describe('WhiteWindBacklinksPlugin', () => {
 
     it('should have correct permissions', () => {
       expect(plugin.manifest.permissions).toEqual({
-        hooks: ['firehose.com.whitewind.blog.entry'],
+        hooks: ['firehose.com.whtwnd.blog.entry'],
         storage: {
           maxSize: 10 * 1024 * 1024, // 10MB
         },
@@ -239,13 +239,13 @@ describe('WhiteWindBacklinksPlugin', () => {
       await plugin.initialize(context);
 
       expect(context.eventBus.on).toHaveBeenCalledWith(
-        'firehose.com.whitewind.blog.entry',
+        'firehose.com.whtwnd.blog.entry',
         expect.any(Function)
       );
       expect(context.logger.info).toHaveBeenCalledWith(
         'Backlink tracking initialized',
         expect.objectContaining({
-          collection: 'com.whitewind.blog.entry',
+          collection: 'com.whtwnd.blog.entry',
           sourceType: 'whitewind.blog',
         })
       );
@@ -263,7 +263,7 @@ describe('WhiteWindBacklinksPlugin', () => {
     it('should extract eprint URI from embed', () => {
       const entry = createWhiteWindEntry({
         embed: {
-          $type: 'com.whitewind.blog.embed#record',
+          $type: 'com.whtwnd.blog.embed#record',
           uri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
         },
       });
@@ -276,7 +276,7 @@ describe('WhiteWindBacklinksPlugin', () => {
     it('should not extract non-eprint URI from embed', () => {
       const entry = createWhiteWindEntry({
         embed: {
-          $type: 'com.whitewind.blog.embed#record',
+          $type: 'com.whtwnd.blog.embed#record',
           uri: 'at://did:plc:someone/app.bsky.feed.post/xyz',
         },
       });
@@ -401,7 +401,7 @@ describe('WhiteWindBacklinksPlugin', () => {
     it('should extract from both embed and content', () => {
       const entry = createWhiteWindEntry({
         embed: {
-          $type: 'com.whitewind.blog.embed#record',
+          $type: 'com.whtwnd.blog.embed#record',
           uri: 'at://did:plc:author1/pub.chive.eprint.submission/paper1',
         },
         content: 'Also see: at://did:plc:author2/pub.chive.eprint.submission/paper2',
@@ -421,7 +421,7 @@ describe('WhiteWindBacklinksPlugin', () => {
       const uri = 'at://did:plc:author/pub.chive.eprint.submission/paper1';
       const entry = createWhiteWindEntry({
         embed: {
-          $type: 'com.whitewind.blog.embed#record',
+          $type: 'com.whtwnd.blog.embed#record',
           uri,
         },
         content: `This paper: ${uri} is great!`,
@@ -509,14 +509,14 @@ describe('WhiteWindBacklinksPlugin', () => {
 
     it('should create backlink from public entry with embed', async () => {
       const record: FirehoseRecord = {
-        uri: 'at://did:plc:blogger/com.whitewind.blog.entry/post123',
-        collection: 'com.whitewind.blog.entry',
+        uri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post123',
+        collection: 'com.whtwnd.blog.entry',
         did: 'did:plc:blogger',
         rkey: 'post123',
         record: createWhiteWindEntry({
           title: 'Great Paper Review',
           embed: {
-            $type: 'com.whitewind.blog.embed#record',
+            $type: 'com.whtwnd.blog.embed#record',
             uri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
           },
         }),
@@ -524,11 +524,11 @@ describe('WhiteWindBacklinksPlugin', () => {
         timestamp: new Date(),
       };
 
-      await context.eventBus.trigger('firehose.com.whitewind.blog.entry', record);
+      await context.eventBus.trigger('firehose.com.whtwnd.blog.entry', record);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(backlinkService.createBacklink).toHaveBeenCalledWith({
-        sourceUri: 'at://did:plc:blogger/com.whitewind.blog.entry/post123',
+        sourceUri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post123',
         sourceType: 'whitewind.blog',
         targetUri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
         context: 'Great Paper Review',
@@ -537,8 +537,8 @@ describe('WhiteWindBacklinksPlugin', () => {
 
     it('should create backlinks from markdown content', async () => {
       const record: FirehoseRecord = {
-        uri: 'at://did:plc:blogger/com.whitewind.blog.entry/post456',
-        collection: 'com.whitewind.blog.entry',
+        uri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post456',
+        collection: 'com.whtwnd.blog.entry',
         did: 'did:plc:blogger',
         rkey: 'post456',
         record: createWhiteWindEntry({
@@ -553,18 +553,18 @@ describe('WhiteWindBacklinksPlugin', () => {
         timestamp: new Date(),
       };
 
-      await context.eventBus.trigger('firehose.com.whitewind.blog.entry', record);
+      await context.eventBus.trigger('firehose.com.whtwnd.blog.entry', record);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(backlinkService.createBacklink).toHaveBeenCalledTimes(2);
       expect(backlinkService.createBacklink).toHaveBeenCalledWith({
-        sourceUri: 'at://did:plc:blogger/com.whitewind.blog.entry/post456',
+        sourceUri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post456',
         sourceType: 'whitewind.blog',
         targetUri: 'at://did:plc:author1/pub.chive.eprint.submission/paper1',
         context: 'Reading List',
       });
       expect(backlinkService.createBacklink).toHaveBeenCalledWith({
-        sourceUri: 'at://did:plc:blogger/com.whitewind.blog.entry/post456',
+        sourceUri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post456',
         sourceType: 'whitewind.blog',
         targetUri: 'at://did:plc:author2/pub.chive.eprint.submission/paper2',
         context: 'Reading List',
@@ -573,14 +573,14 @@ describe('WhiteWindBacklinksPlugin', () => {
 
     it('should not create backlink for unlisted entry', async () => {
       const record: FirehoseRecord = {
-        uri: 'at://did:plc:blogger/com.whitewind.blog.entry/post789',
-        collection: 'com.whitewind.blog.entry',
+        uri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post789',
+        collection: 'com.whtwnd.blog.entry',
         did: 'did:plc:blogger',
         rkey: 'post789',
         record: createWhiteWindEntry({
           visibility: 'unlisted',
           embed: {
-            $type: 'com.whitewind.blog.embed#record',
+            $type: 'com.whtwnd.blog.embed#record',
             uri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
           },
         }),
@@ -588,7 +588,7 @@ describe('WhiteWindBacklinksPlugin', () => {
         timestamp: new Date(),
       };
 
-      await context.eventBus.trigger('firehose.com.whitewind.blog.entry', record);
+      await context.eventBus.trigger('firehose.com.whtwnd.blog.entry', record);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(backlinkService.createBacklink).not.toHaveBeenCalled();
@@ -596,14 +596,14 @@ describe('WhiteWindBacklinksPlugin', () => {
 
     it('should not create backlink for private entry', async () => {
       const record: FirehoseRecord = {
-        uri: 'at://did:plc:blogger/com.whitewind.blog.entry/post000',
-        collection: 'com.whitewind.blog.entry',
+        uri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post000',
+        collection: 'com.whtwnd.blog.entry',
         did: 'did:plc:blogger',
         rkey: 'post000',
         record: createWhiteWindEntry({
           visibility: 'private',
           embed: {
-            $type: 'com.whitewind.blog.embed#record',
+            $type: 'com.whtwnd.blog.embed#record',
             uri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
           },
         }),
@@ -611,7 +611,7 @@ describe('WhiteWindBacklinksPlugin', () => {
         timestamp: new Date(),
       };
 
-      await context.eventBus.trigger('firehose.com.whitewind.blog.entry', record);
+      await context.eventBus.trigger('firehose.com.whtwnd.blog.entry', record);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(backlinkService.createBacklink).not.toHaveBeenCalled();
@@ -619,8 +619,8 @@ describe('WhiteWindBacklinksPlugin', () => {
 
     it('should not create backlink for entry without eprint refs', async () => {
       const record: FirehoseRecord = {
-        uri: 'at://did:plc:blogger/com.whitewind.blog.entry/post111',
-        collection: 'com.whitewind.blog.entry',
+        uri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post111',
+        collection: 'com.whtwnd.blog.entry',
         did: 'did:plc:blogger',
         rkey: 'post111',
         record: createWhiteWindEntry({
@@ -631,7 +631,7 @@ describe('WhiteWindBacklinksPlugin', () => {
         timestamp: new Date(),
       };
 
-      await context.eventBus.trigger('firehose.com.whitewind.blog.entry', record);
+      await context.eventBus.trigger('firehose.com.whtwnd.blog.entry', record);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(backlinkService.createBacklink).not.toHaveBeenCalled();
@@ -639,8 +639,8 @@ describe('WhiteWindBacklinksPlugin', () => {
 
     it('should handle deletion events', async () => {
       const record: FirehoseRecord = {
-        uri: 'at://did:plc:blogger/com.whitewind.blog.entry/post222',
-        collection: 'com.whitewind.blog.entry',
+        uri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post222',
+        collection: 'com.whtwnd.blog.entry',
         did: 'did:plc:blogger',
         rkey: 'post222',
         record: null,
@@ -648,27 +648,27 @@ describe('WhiteWindBacklinksPlugin', () => {
         timestamp: new Date(),
       };
 
-      await context.eventBus.trigger('firehose.com.whitewind.blog.entry', record);
+      await context.eventBus.trigger('firehose.com.whtwnd.blog.entry', record);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(backlinkService.deleteBacklink).toHaveBeenCalledWith(
-        'at://did:plc:blogger/com.whitewind.blog.entry/post222'
+        'at://did:plc:blogger/com.whtwnd.blog.entry/post222'
       );
       expect(context.eventBus.emit).toHaveBeenCalledWith('backlink.deleted', {
-        sourceUri: 'at://did:plc:blogger/com.whitewind.blog.entry/post222',
+        sourceUri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post222',
         sourceType: 'whitewind.blog',
       });
     });
 
     it('should emit backlink.created events', async () => {
       const record: FirehoseRecord = {
-        uri: 'at://did:plc:blogger/com.whitewind.blog.entry/post333',
-        collection: 'com.whitewind.blog.entry',
+        uri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post333',
+        collection: 'com.whtwnd.blog.entry',
         did: 'did:plc:blogger',
         rkey: 'post333',
         record: createWhiteWindEntry({
           embed: {
-            $type: 'com.whitewind.blog.embed#record',
+            $type: 'com.whtwnd.blog.embed#record',
             uri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
           },
         }),
@@ -676,11 +676,11 @@ describe('WhiteWindBacklinksPlugin', () => {
         timestamp: new Date(),
       };
 
-      await context.eventBus.trigger('firehose.com.whitewind.blog.entry', record);
+      await context.eventBus.trigger('firehose.com.whtwnd.blog.entry', record);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(context.eventBus.emit).toHaveBeenCalledWith('backlink.created', {
-        sourceUri: 'at://did:plc:blogger/com.whitewind.blog.entry/post333',
+        sourceUri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post333',
         sourceType: 'whitewind.blog',
         targetUri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
       });
@@ -688,13 +688,13 @@ describe('WhiteWindBacklinksPlugin', () => {
 
     it('should record metrics for created backlinks', async () => {
       const record: FirehoseRecord = {
-        uri: 'at://did:plc:blogger/com.whitewind.blog.entry/post444',
-        collection: 'com.whitewind.blog.entry',
+        uri: 'at://did:plc:blogger/com.whtwnd.blog.entry/post444',
+        collection: 'com.whtwnd.blog.entry',
         did: 'did:plc:blogger',
         rkey: 'post444',
         record: createWhiteWindEntry({
           embed: {
-            $type: 'com.whitewind.blog.embed#record',
+            $type: 'com.whtwnd.blog.embed#record',
             uri: 'at://did:plc:author/pub.chive.eprint.submission/xyz',
           },
         }),
@@ -702,7 +702,7 @@ describe('WhiteWindBacklinksPlugin', () => {
         timestamp: new Date(),
       };
 
-      await context.eventBus.trigger('firehose.com.whitewind.blog.entry', record);
+      await context.eventBus.trigger('firehose.com.whtwnd.blog.entry', record);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(context.metrics.incrementCounter).toHaveBeenCalledWith(
@@ -727,7 +727,7 @@ describe('WhiteWindBacklinksPlugin', () => {
 
     it('should handle entry with null-like values gracefully', () => {
       const entry = {
-        $type: 'com.whitewind.blog.entry' as const,
+        $type: 'com.whtwnd.blog.entry' as const,
         title: 'Test',
         content: '',
         contentFormat: 'markdown' as const,
@@ -743,7 +743,7 @@ describe('WhiteWindBacklinksPlugin', () => {
     it('should handle malformed embed gracefully', () => {
       const entry = createWhiteWindEntry({
         embed: {
-          $type: 'com.whitewind.blog.embed#record',
+          $type: 'com.whtwnd.blog.embed#record',
           uri: '',
         },
       });

--- a/tests/unit/services/eprint/eprint-service-delete-cleanup.test.ts
+++ b/tests/unit/services/eprint/eprint-service-delete-cleanup.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for EprintService deletion cleanup paths.
+ *
+ * @remarks
+ * Covers two regressions: citation and related-work tombstones were routed to
+ * index tables that no migration creates, and eprint deletion left the Neo4j
+ * eprint node (and every edge hanging off it) behind.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { EprintService } from '@/services/eprint/eprint-service.js';
+import type { TagManager } from '@/storage/neo4j/tag-manager.js';
+import type { AtUri } from '@/types/atproto.js';
+import type { IGraphDatabase } from '@/types/interfaces/graph.interface.js';
+import type { IIdentityResolver } from '@/types/interfaces/identity.interface.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+import type { IRepository } from '@/types/interfaces/repository.interface.js';
+import type { ISearchEngine } from '@/types/interfaces/search.interface.js';
+import type { IStorageBackend } from '@/types/interfaces/storage.interface.js';
+
+const EPRINT_URI = 'at://did:plc:author123/pub.chive.eprint.submission/abc123' as AtUri;
+
+const createMockLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const createMockStorage = () => ({
+  deleteEprint: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+  deleteByUri: vi.fn().mockResolvedValue(undefined),
+  deleteCitation: vi.fn().mockResolvedValue(undefined),
+  deleteRelatedWork: vi.fn().mockResolvedValue(undefined),
+});
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const createMockSearch = () => ({
+  deleteDocument: vi.fn().mockResolvedValue(undefined),
+});
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const createMockGraph = () => ({
+  deleteNode: vi.fn().mockResolvedValue(undefined),
+});
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const createMockTagManager = () => ({
+  removeAllTagsForRecord: vi.fn().mockResolvedValue(0),
+});
+
+describe('EprintService deletion cleanup', () => {
+  let storage: ReturnType<typeof createMockStorage>;
+  let search: ReturnType<typeof createMockSearch>;
+  let graph: ReturnType<typeof createMockGraph>;
+  let tagManager: ReturnType<typeof createMockTagManager>;
+  let logger: ILogger;
+  let service: EprintService;
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  const build = (options?: { withGraph?: boolean }) =>
+    new EprintService({
+      storage: storage as unknown as IStorageBackend,
+      search: search as unknown as ISearchEngine,
+      repository: {} as unknown as IRepository,
+      identity: {} as unknown as IIdentityResolver,
+      logger,
+      tagManager: tagManager as unknown as TagManager,
+      graph: (options?.withGraph ?? true) ? (graph as unknown as IGraphDatabase) : undefined,
+    });
+
+  beforeEach(() => {
+    storage = createMockStorage();
+    search = createMockSearch();
+    graph = createMockGraph();
+    tagManager = createMockTagManager();
+    logger = createMockLogger();
+    service = build();
+  });
+
+  describe('deleteFromIndex', () => {
+    it('routes citation tombstones to deleteCitation', async () => {
+      const uri = 'at://did:plc:author123/pub.chive.eprint.citation/c1' as AtUri;
+
+      await service.deleteFromIndex(uri, 'pub.chive.eprint.citation');
+
+      expect(storage.deleteCitation).toHaveBeenCalledWith(uri);
+      // extracted_citations is keyed by user_record_uri, so deleteByUri cannot serve it
+      expect(storage.deleteByUri).not.toHaveBeenCalled();
+    });
+
+    it('routes related-work tombstones to deleteRelatedWork', async () => {
+      const uri = 'at://did:plc:author123/pub.chive.eprint.relatedWork/r1' as AtUri;
+
+      await service.deleteFromIndex(uri, 'pub.chive.eprint.relatedWork');
+
+      expect(storage.deleteRelatedWork).toHaveBeenCalledWith(uri);
+      expect(storage.deleteByUri).not.toHaveBeenCalled();
+    });
+
+    it('never passes a table name that no migration creates', async () => {
+      const collections = [
+        'pub.chive.eprint.userTag',
+        'pub.chive.review.comment',
+        'pub.chive.review.endorsement',
+        'pub.chive.eprint.citation',
+        'pub.chive.eprint.relatedWork',
+      ];
+
+      for (const collection of collections) {
+        await service.deleteFromIndex(EPRINT_URI, collection);
+      }
+
+      const tables = storage.deleteByUri.mock.calls.map((call) => call[0] as string);
+      expect(tables).toEqual(['user_tags_index', 'reviews_index', 'endorsements_index']);
+    });
+  });
+
+  describe('indexEprintDelete', () => {
+    it('removes the eprint node from Neo4j', async () => {
+      const result = await service.indexEprintDelete(EPRINT_URI);
+
+      expect(result.ok).toBe(true);
+      expect(graph.deleteNode).toHaveBeenCalledWith(EPRINT_URI);
+    });
+
+    it('succeeds without a graph configured', async () => {
+      const serviceWithoutGraph = build({ withGraph: false });
+
+      const result = await serviceWithoutGraph.indexEprintDelete(EPRINT_URI);
+
+      expect(result.ok).toBe(true);
+      expect(graph.deleteNode).not.toHaveBeenCalled();
+    });
+
+    it('continues when the graph cleanup fails', async () => {
+      graph.deleteNode.mockRejectedValue(new Error('Neo4j unavailable'));
+
+      const result = await service.indexEprintDelete(EPRINT_URI);
+
+      expect(result.ok).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Neo4j node cleanup failed, PostgreSQL is source of truth',
+        { uri: EPRINT_URI, error: 'Neo4j unavailable' }
+      );
+      expect(logger.info).toHaveBeenCalledWith('Deleted eprint from indexes', { uri: EPRINT_URI });
+    });
+
+    it('cleans up the graph even when tag removal fails', async () => {
+      tagManager.removeAllTagsForRecord.mockRejectedValue(new Error('Neo4j tag failure'));
+
+      const result = await service.indexEprintDelete(EPRINT_URI);
+
+      expect(result.ok).toBe(true);
+      expect(graph.deleteNode).toHaveBeenCalledWith(EPRINT_URI);
+    });
+  });
+});

--- a/tests/unit/services/governance/trusted-editor-service.test.ts
+++ b/tests/unit/services/governance/trusted-editor-service.test.ts
@@ -7,7 +7,10 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { TrustedEditorService } from '@/services/governance/trusted-editor-service.js';
+import {
+  ROLE_VOTE_WEIGHTS,
+  TrustedEditorService,
+} from '@/services/governance/trusted-editor-service.js';
 import type { DID } from '@/types/atproto.js';
 import type { ILogger } from '@/types/interfaces/logger.interface.js';
 
@@ -496,6 +499,135 @@ describe('TrustedEditorService', () => {
       if (!result.ok) {
         expect(result.error.code).toBe('DATABASE_ERROR');
       }
+    });
+  });
+
+  describe('getEditorStatus', () => {
+    const userDid = makeDID('did:plc:editor');
+
+    /**
+     * Queue the five queries getEditorStatus issues after the role lookup:
+     * delegations, then the four reputation queries.
+     */
+    const mockRemainingQueries = (role: string): void => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [] }) // delegations
+        .mockResolvedValueOnce({ rows: [{ created_at: null, role }] }) // account
+        .mockResolvedValueOnce({ rows: [] }) // eprints
+        .mockResolvedValueOnce({ rows: [] }) // proposals and votes
+        .mockResolvedValueOnce({ rows: [] }); // warnings and violations
+    };
+
+    it('resolves the role from governance_roles when the profile is not indexed', async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            display_name: null,
+            role: 'trusted-editor',
+            role_granted_at: new Date(),
+            role_granted_by: 'did:plc:admin',
+            created_at: null,
+          },
+        ],
+      });
+      mockRemainingQueries('trusted-editor');
+
+      const result = await service.getEditorStatus(userDid);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.role).toBe('trusted-editor');
+        expect(result.value.displayName).toBeUndefined();
+      }
+
+      // The role must not depend on authors_index having a row
+      const roleQuery = mockPool.query.mock.calls[0]?.[0] as string;
+      expect(roleQuery).toContain('LEFT JOIN governance_roles');
+      expect(roleQuery).toContain('LEFT JOIN authors_index');
+    });
+
+    it('treats a configured platform admin as an administrator', async () => {
+      service = new TrustedEditorService({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: mockPool as any,
+        logger: mockLogger,
+        platformAdminDids: [userDid],
+      });
+
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            display_name: 'Editor',
+            role: 'community-member',
+            role_granted_at: null,
+            role_granted_by: null,
+            created_at: new Date(),
+          },
+        ],
+      });
+      mockRemainingQueries('community-member');
+
+      const result = await service.getEditorStatus(userDid);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.role).toBe('administrator');
+        expect(result.value.metrics.role).toBe('administrator');
+      }
+    });
+
+    it('reads platform admins from ADMIN_DIDS when none are injected', async () => {
+      vi.stubEnv('ADMIN_DIDS', ` did:plc:other , ${userDid} `);
+      service = new TrustedEditorService({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: mockPool as any,
+        logger: mockLogger,
+      });
+      vi.unstubAllEnvs();
+
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+      mockRemainingQueries('community-member');
+
+      const result = await service.getEditorStatus(userDid);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.role).toBe('administrator');
+      }
+    });
+
+    it('leaves non-admins on their stored role', async () => {
+      service = new TrustedEditorService({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: mockPool as any,
+        logger: mockLogger,
+        platformAdminDids: [makeDID('did:plc:someone-else')],
+      });
+
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+      mockRemainingQueries('community-member');
+
+      const result = await service.getEditorStatus(userDid);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.role).toBe('community-member');
+      }
+    });
+  });
+
+  describe('getVoteWeight', () => {
+    it('gives a platform admin the administrator weight', async () => {
+      const adminDid = makeDID('did:plc:platform-admin');
+      service = new TrustedEditorService({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: mockPool as any,
+        logger: mockLogger,
+        platformAdminDids: [adminDid],
+      });
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      await expect(service.getVoteWeight(adminDid)).resolves.toBe(ROLE_VOTE_WEIGHTS.administrator);
     });
   });
 });

--- a/tests/unit/services/indexing/event-processor-collections.test.ts
+++ b/tests/unit/services/indexing/event-processor-collections.test.ts
@@ -1,0 +1,820 @@
+/**
+ * Unit tests for the per-collection dispatch in the firehose event processor.
+ *
+ * @remarks
+ * The processor fans every firehose commit out to a collection-specific branch,
+ * and each branch has to do two things correctly: apply the create/update path,
+ * and remove the record from the index on a delete. A branch that silently
+ * swallows a datastore failure leaves the cursor advanced past an event that was
+ * never indexed, so the failure paths are pinned here alongside the happy ones.
+ * Non-critical failures are expected to reach the DLQ; eprint failures are
+ * critical and must also throw so the indexer halts rather than losing the
+ * record.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { DeadLetterQueue } from '@/services/indexing/dlq-handler.js';
+import {
+  createEventProcessor,
+  type EventProcessorOptions,
+} from '@/services/indexing/event-processor.js';
+import type { ProcessedEvent } from '@/services/indexing/indexing-service.js';
+
+const REPO = 'did:plc:testrepo';
+
+/**
+ * Builds a firehose commit event for an arbitrary collection.
+ */
+const event = (
+  collection: string,
+  action: 'create' | 'update' | 'delete',
+  record?: unknown
+): ProcessedEvent =>
+  ({
+    $type: 'commit',
+    seq: 11,
+    repo: REPO,
+    time: '2026-08-25T00:00:00.000Z',
+    action,
+    collection,
+    rkey: '3kxyz',
+    cid: 'bafyreiabc',
+    record,
+  }) as ProcessedEvent;
+
+/**
+ * A minimal eprint submission record that survives PDS-record transformation.
+ */
+const submissionRecord = (): Record<string, unknown> => ({
+  $type: 'pub.chive.eprint.submission',
+  title: 'A Study in Indexing',
+  document: {
+    $type: 'blob',
+    ref: { $link: 'bafkreiabc123def456' },
+    mimeType: 'application/pdf',
+    size: 1234,
+  },
+  authors: [{ name: 'Alice Researcher', order: 1, did: 'did:plc:author123' }],
+  createdAt: '2026-01-18T12:00:00.000Z',
+  submittedBy: 'did:plc:submitter456',
+  abstract: 'An abstract.',
+  documentFormat: 'pdf',
+});
+
+describe('event processor collection dispatch', () => {
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const query = vi.fn();
+  const dlqAdd = vi.fn();
+
+  const ok = { ok: true, value: undefined };
+  const err = (message: string): { ok: false; error: Error } => ({
+    ok: false,
+    error: new Error(message),
+  });
+
+  const eprintService = {
+    indexEprint: vi.fn(),
+    indexEprintUpdate: vi.fn(),
+    indexEprintDelete: vi.fn(),
+  };
+  const reviewService = { indexReview: vi.fn(), indexEndorsement: vi.fn() };
+  const annotationService = { indexAnnotation: vi.fn(), indexEntityLink: vi.fn() };
+
+  /**
+   * Builds a processor over the shared mocks.
+   */
+  const processor = (extra: Record<string, unknown> = {}): ((e: ProcessedEvent) => Promise<void>) =>
+    createEventProcessor({
+      pool: { query },
+      activity: { correlateWithFirehose: vi.fn().mockResolvedValue({ ok: true, value: null }) },
+      eprintService,
+      reviewService,
+      annotationService,
+      graphService: {},
+      identity: { getPDSEndpoint: vi.fn().mockResolvedValue('https://pds.example.com') },
+      logger,
+      dlq: { add: dlqAdd } as unknown as DeadLetterQueue,
+      ...extra,
+    } as unknown as EventProcessorOptions);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    query.mockResolvedValue({ rows: [], rowCount: 0 });
+    dlqAdd.mockResolvedValue(1);
+    eprintService.indexEprint.mockResolvedValue(ok);
+    eprintService.indexEprintUpdate.mockResolvedValue(ok);
+    eprintService.indexEprintDelete.mockResolvedValue(ok);
+    reviewService.indexReview.mockResolvedValue(ok);
+    reviewService.indexEndorsement.mockResolvedValue(ok);
+    annotationService.indexAnnotation.mockResolvedValue(ok);
+    annotationService.indexEntityLink.mockResolvedValue(ok);
+  });
+
+  describe('eprint submissions', () => {
+    it('indexes a newly created submission', async () => {
+      await processor()(event('pub.chive.eprint.submission', 'create', submissionRecord()));
+      expect(eprintService.indexEprint).toHaveBeenCalledTimes(1);
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('routes an update through the update path rather than a fresh insert', async () => {
+      await processor()(event('pub.chive.eprint.submission', 'update', submissionRecord()));
+      expect(eprintService.indexEprintUpdate).toHaveBeenCalledTimes(1);
+      expect(eprintService.indexEprint).not.toHaveBeenCalled();
+    });
+
+    it('removes a submission deleted from its source PDS', async () => {
+      await processor()(event('pub.chive.eprint.submission', 'delete'));
+      expect(eprintService.indexEprintDelete).toHaveBeenCalledTimes(1);
+    });
+
+    // Eprint failures are critical: the processor both DLQs and rethrows, so a
+    // lost submission halts the indexer instead of advancing the cursor past it.
+    it('throws and DLQs when the delete fails', async () => {
+      eprintService.indexEprintDelete.mockResolvedValue(err('delete exploded'));
+      await expect(processor()(event('pub.chive.eprint.submission', 'delete'))).rejects.toThrow(
+        /Failed to delete eprint/
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws and DLQs when indexing fails', async () => {
+      eprintService.indexEprint.mockResolvedValue(err('index exploded'));
+      await expect(
+        processor()(event('pub.chive.eprint.submission', 'create', submissionRecord()))
+      ).rejects.toThrow(/Failed to create eprint/);
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('changelogs', () => {
+    const changelog = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      version: { major: 1, minor: 1, patch: 0 },
+      sections: [{ category: 'added', items: [{ description: 'A new section.' }] }],
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+
+    it('inserts a changelog into the index', async () => {
+      await processor()(event('pub.chive.eprint.changelog', 'create', changelog));
+      expect(query).toHaveBeenCalledTimes(1);
+      expect(query.mock.calls[0]?.[0]).toMatch(/INSERT INTO changelogs_index/);
+    });
+
+    it('deletes a changelog by URI', async () => {
+      await processor()(event('pub.chive.eprint.changelog', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM changelogs_index/);
+    });
+
+    it('sends a failed changelog insert to the DLQ without throwing', async () => {
+      query.mockRejectedValue(new Error('insert failed'));
+      await expect(
+        processor()(event('pub.chive.eprint.changelog', 'create', changelog))
+      ).resolves.toBeUndefined();
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed changelog delete to the DLQ', async () => {
+      query.mockRejectedValue(new Error('delete failed'));
+      await processor()(event('pub.chive.eprint.changelog', 'delete'));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('eprint versions', () => {
+    const version = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      versionNumber: 2,
+      changes: 'Revised the analysis.',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+
+    it('inserts a version into the index', async () => {
+      await processor()(event('pub.chive.eprint.version', 'create', version));
+      expect(query.mock.calls[0]?.[0]).toMatch(/INSERT INTO eprint_versions_index/);
+    });
+
+    it('deletes a version by URI', async () => {
+      await processor()(event('pub.chive.eprint.version', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM eprint_versions_index/);
+    });
+
+    it('sends a failed version insert to the DLQ', async () => {
+      query.mockRejectedValue(new Error('insert failed'));
+      await processor()(event('pub.chive.eprint.version', 'create', version));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reviews and endorsements', () => {
+    it('indexes a review comment', async () => {
+      await processor()(event('pub.chive.review.comment', 'create', { body: 'A comment.' }));
+      expect(reviewService.indexReview).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a review comment by URI', async () => {
+      await processor()(event('pub.chive.review.comment', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM reviews_index/);
+    });
+
+    it('sends a failed review index to the DLQ', async () => {
+      reviewService.indexReview.mockResolvedValue(err('review failed'));
+      await processor()(event('pub.chive.review.comment', 'create', { body: 'A comment.' }));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('indexes an endorsement', async () => {
+      await processor()(event('pub.chive.review.endorsement', 'create', { rating: 5 }));
+      expect(reviewService.indexEndorsement).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes an endorsement by URI', async () => {
+      await processor()(event('pub.chive.review.endorsement', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM endorsements_index/);
+    });
+
+    it('sends a failed endorsement index to the DLQ', async () => {
+      reviewService.indexEndorsement.mockResolvedValue(err('endorsement failed'));
+      await processor()(event('pub.chive.review.endorsement', 'create', { rating: 5 }));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('annotations', () => {
+    it('indexes an annotation comment', async () => {
+      await processor()(event('pub.chive.annotation.comment', 'create', { body: 'Note.' }));
+      expect(annotationService.indexAnnotation).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes an annotation by URI', async () => {
+      await processor()(event('pub.chive.annotation.comment', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM annotations_index/);
+    });
+
+    it('indexes an entity link', async () => {
+      await processor()(event('pub.chive.annotation.entityLink', 'create', { target: 'x' }));
+      expect(annotationService.indexEntityLink).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes an entity link by URI', async () => {
+      await processor()(event('pub.chive.annotation.entityLink', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM entity_links_index/);
+    });
+
+    it('sends a failed annotation index to the DLQ', async () => {
+      annotationService.indexAnnotation.mockResolvedValue(err('annotation failed'));
+      await processor()(event('pub.chive.annotation.comment', 'create', { body: 'Note.' }));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('user tags', () => {
+    const tag = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      tag: 'Syntax',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+
+    it('inserts a tag into the index', async () => {
+      await processor()(event('pub.chive.eprint.userTag', 'create', tag));
+      expect(query.mock.calls[0]?.[0]).toMatch(/INSERT INTO user_tags_index/);
+    });
+
+    it('mirrors a new tag into the tag graph', async () => {
+      const addTag = vi.fn().mockResolvedValue(undefined);
+      await processor({ tagManager: { addTag, normalizeTag: (t: string) => t } })(
+        event('pub.chive.eprint.userTag', 'create', tag)
+      );
+      expect(addTag).toHaveBeenCalledTimes(1);
+    });
+
+    // The tag graph is a derived index, so a Neo4j failure must not fail the
+    // Postgres insert that the firehose cursor has already advanced past.
+    it('keeps the row indexed when the tag graph rejects the tag', async () => {
+      const addTag = vi.fn().mockRejectedValue(new Error('neo4j down'));
+      await processor({ tagManager: { addTag, normalizeTag: (t: string) => t } })(
+        event('pub.chive.eprint.userTag', 'create', tag)
+      );
+      expect(dlqAdd).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('removes the tag from the graph when the record is deleted', async () => {
+      const removeTag = vi.fn().mockResolvedValue(undefined);
+      query.mockResolvedValue({
+        rows: [{ eprint_uri: tag.eprintUri, tag: 'Syntax' }],
+        rowCount: 1,
+      });
+      await processor({ tagManager: { removeTag, normalizeTag: (t: string) => t } })(
+        event('pub.chive.eprint.userTag', 'delete')
+      );
+      expect(removeTag).toHaveBeenCalledWith(tag.eprintUri, 'Syntax');
+    });
+
+    it('sends a failed tag insert to the DLQ', async () => {
+      query.mockRejectedValue(new Error('insert failed'));
+      await processor()(event('pub.chive.eprint.userTag', 'create', tag));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('citations', () => {
+    const citation = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      citedWork: { title: 'A Cited Work', doi: '10.1000/xyz' },
+      citationType: 'supports',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+    const storage = (): Record<string, unknown> => ({
+      indexCitation: vi.fn().mockResolvedValue(undefined),
+      deleteCitation: vi.fn().mockResolvedValue(undefined),
+      indexRelatedWork: vi.fn().mockResolvedValue(undefined),
+      deleteRelatedWork: vi.fn().mockResolvedValue(undefined),
+    });
+
+    it('indexes a citation through the storage backend', async () => {
+      const s = storage();
+      await processor({ storage: s })(event('pub.chive.eprint.citation', 'create', citation));
+      expect(s.indexCitation).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a citation through the storage backend', async () => {
+      const s = storage();
+      await processor({ storage: s })(event('pub.chive.eprint.citation', 'delete'));
+      expect(s.deleteCitation).toHaveBeenCalledWith(expect.stringContaining('at://'));
+    });
+
+    // Without a storage backend the branch is a no-op rather than a crash.
+    it('ignores a citation when no storage backend is configured', async () => {
+      await processor()(event('pub.chive.eprint.citation', 'create', citation));
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('adds a CITES edge when the cited work lives in Chive', async () => {
+      const upsertCitationsBatch = vi.fn().mockResolvedValue(undefined);
+      await processor({
+        storage: storage(),
+        citationGraph: { upsertCitationsBatch },
+      })(
+        event('pub.chive.eprint.citation', 'create', {
+          ...citation,
+          citedWork: {
+            ...citation.citedWork,
+            chiveUri: `at://${REPO}/pub.chive.eprint.submission/z`,
+          },
+        })
+      );
+      expect(upsertCitationsBatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the citation indexed when the CITES upsert fails', async () => {
+      const upsertCitationsBatch = vi.fn().mockRejectedValue(new Error('graph down'));
+      await processor({
+        storage: storage(),
+        citationGraph: { upsertCitationsBatch },
+      })(
+        event('pub.chive.eprint.citation', 'create', {
+          ...citation,
+          citedWork: {
+            ...citation.citedWork,
+            chiveUri: `at://${REPO}/pub.chive.eprint.submission/z`,
+          },
+        })
+      );
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('sends a failed citation index to the DLQ', async () => {
+      const s = storage();
+      (s.indexCitation as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('insert failed'));
+      await processor({ storage: s })(event('pub.chive.eprint.citation', 'create', citation));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed citation delete to the DLQ', async () => {
+      const s = storage();
+      (s.deleteCitation as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('delete failed'));
+      await processor({ storage: s })(event('pub.chive.eprint.citation', 'delete'));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('related works', () => {
+    const relatedWork = {
+      eprintUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      relatedUri: `at://${REPO}/pub.chive.eprint.submission/def`,
+      relationType: 'extends',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+    const storage = (): Record<string, unknown> => ({
+      indexRelatedWork: vi.fn().mockResolvedValue(undefined),
+      deleteRelatedWork: vi.fn().mockResolvedValue(undefined),
+    });
+
+    it('indexes a related work through the storage backend', async () => {
+      const s = storage();
+      await processor({ storage: s })(event('pub.chive.eprint.relatedWork', 'create', relatedWork));
+      expect(s.indexRelatedWork).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a related work through the storage backend', async () => {
+      const s = storage();
+      await processor({ storage: s })(event('pub.chive.eprint.relatedWork', 'delete'));
+      expect(s.deleteRelatedWork).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed related-work index to the DLQ', async () => {
+      const s = storage();
+      (s.indexRelatedWork as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+      await processor({ storage: s })(event('pub.chive.eprint.relatedWork', 'create', relatedWork));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('personal graph nodes', () => {
+    // A node authored in a user's own repo (rather than the Governance PDS) is a
+    // personal node, and takes the personalGraphService path.
+    const node = {
+      id: 'n1',
+      kind: 'concept',
+      label: 'Ergativity',
+      status: 'active',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+    const okResult = { ok: true, value: undefined };
+    const errResult = { ok: false, error: new Error('graph rejected it') };
+
+    const services = (): {
+      personalGraphService: Record<string, unknown>;
+      collectionService: Record<string, unknown>;
+    } => ({
+      personalGraphService: {
+        indexNode: vi.fn().mockResolvedValue(okResult),
+        updateNode: vi.fn().mockResolvedValue(okResult),
+        deleteNode: vi.fn().mockResolvedValue(okResult),
+      },
+      collectionService: {
+        indexCollection: vi.fn().mockResolvedValue(okResult),
+        updateCollection: vi.fn().mockResolvedValue(okResult),
+        deleteCollection: vi.fn().mockResolvedValue(okResult),
+      },
+    });
+
+    it('indexes a personal node', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.node', 'create', node));
+      expect(s.personalGraphService.indexNode).toHaveBeenCalledTimes(1);
+      expect(s.collectionService.indexCollection).not.toHaveBeenCalled();
+    });
+
+    it('routes an update to the update path', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.node', 'update', node));
+      expect(s.personalGraphService.updateNode).toHaveBeenCalledTimes(1);
+    });
+
+    // A node whose subkind is 'collection' is indexed twice: once as a
+    // collection, once as an ordinary personal node.
+    it('indexes a collection node through both services', async () => {
+      const s = services();
+      await processor(s)(
+        event('pub.chive.graph.node', 'create', { ...node, subkind: 'collection' })
+      );
+      expect(s.collectionService.indexCollection).toHaveBeenCalledTimes(1);
+      expect(s.personalGraphService.indexNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates a collection node through the collection update path', async () => {
+      const s = services();
+      await processor(s)(
+        event('pub.chive.graph.node', 'update', { ...node, subkind: 'collection' })
+      );
+      expect(s.collectionService.updateCollection).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a personal node from both indexes', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.node', 'delete'));
+      expect(s.collectionService.deleteCollection).toHaveBeenCalledTimes(1);
+      expect(s.personalGraphService.deleteNode).toHaveBeenCalledTimes(1);
+    });
+
+    // A URI that was never a collection makes deleteCollection fail, which is
+    // expected and must not stop the personal-graph delete from running.
+    it('still deletes the node when the collection delete reports a miss', async () => {
+      const s = services();
+      (s.collectionService.deleteCollection as ReturnType<typeof vi.fn>).mockResolvedValue(
+        errResult
+      );
+      await processor(s)(event('pub.chive.graph.node', 'delete'));
+      expect(s.personalGraphService.deleteNode).toHaveBeenCalledTimes(1);
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('tolerates a collection delete that throws', async () => {
+      const s = services();
+      (s.collectionService.deleteCollection as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('boom')
+      );
+      await processor(s)(event('pub.chive.graph.node', 'delete'));
+      expect(s.personalGraphService.deleteNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed personal node delete to the DLQ', async () => {
+      const s = services();
+      (s.personalGraphService.deleteNode as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor(s)(event('pub.chive.graph.node', 'delete'));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed personal node index to the DLQ', async () => {
+      const s = services();
+      (s.personalGraphService.indexNode as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor(s)(event('pub.chive.graph.node', 'create', node));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed collection index to the DLQ without indexing the node', async () => {
+      const s = services();
+      (s.collectionService.indexCollection as ReturnType<typeof vi.fn>).mockResolvedValue(
+        errResult
+      );
+      await processor(s)(
+        event('pub.chive.graph.node', 'create', { ...node, subkind: 'collection' })
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+      expect(s.personalGraphService.indexNode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('personal graph edges', () => {
+    const okResult = { ok: true, value: undefined };
+    const errResult = { ok: false, error: new Error('edge rejected') };
+    const OWNED = `at://${REPO}/pub.chive.graph.node/collection1`;
+    const FOREIGN = 'at://did:plc:someoneelse/pub.chive.graph.node/collection1';
+
+    const edge = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+      id: 'e1',
+      sourceUri: `at://${REPO}/pub.chive.eprint.submission/abc`,
+      targetUri: OWNED,
+      relationSlug: 'relates-to',
+      createdAt: '2026-08-25T00:00:00.000Z',
+      ...overrides,
+    });
+
+    const services = (): {
+      personalGraphService: Record<string, unknown>;
+      collectionService: Record<string, unknown>;
+      collaborationService: Record<string, unknown>;
+    } => ({
+      personalGraphService: {
+        indexEdge: vi.fn().mockResolvedValue(okResult),
+        updateEdge: vi.fn().mockResolvedValue(okResult),
+        deleteEdge: vi.fn().mockResolvedValue(okResult),
+      },
+      collectionService: {
+        indexCollectionEdge: vi.fn().mockResolvedValue(okResult),
+        deleteCollectionEdge: vi.fn().mockResolvedValue(okResult),
+      },
+      collaborationService: {
+        isCollaborator: vi.fn().mockResolvedValue(true),
+        parkPendingCollectionEdge: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    it('indexes an ordinary personal edge', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.edge', 'create', edge()));
+      expect(s.personalGraphService.indexEdge).toHaveBeenCalledTimes(1);
+      expect(s.collectionService.indexCollectionEdge).not.toHaveBeenCalled();
+    });
+
+    it('routes an edge update to the update path', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.edge', 'update', edge()));
+      expect(s.personalGraphService.updateEdge).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes a personal edge', async () => {
+      const s = services();
+      await processor(s)(event('pub.chive.graph.edge', 'delete', edge()));
+      expect(s.personalGraphService.deleteEdge).toHaveBeenCalledTimes(1);
+    });
+
+    // 'contains' marks the edge as a collection relation, which takes the
+    // collection path in addition to the personal graph.
+    it('deletes a collection edge through the collection service', async () => {
+      const s = services();
+      await processor(s)(
+        event('pub.chive.graph.edge', 'delete', edge({ relationSlug: 'contains' }))
+      );
+      expect(s.collectionService.deleteCollectionEdge).toHaveBeenCalledTimes(1);
+    });
+
+    it('indexes a collection edge when the author owns the collection', async () => {
+      const s = services();
+      await processor(s)(
+        event('pub.chive.graph.edge', 'create', edge({ relationSlug: 'contains' }))
+      );
+      expect(s.collectionService.indexCollectionEdge).toHaveBeenCalledTimes(1);
+      expect(s.collaborationService.isCollaborator).not.toHaveBeenCalled();
+    });
+
+    it('indexes a foreign collection edge when the author is an active collaborator', async () => {
+      const s = services();
+      await processor(s)(
+        event(
+          'pub.chive.graph.edge',
+          'create',
+          edge({ relationSlug: 'contains', targetUri: FOREIGN })
+        )
+      );
+      expect(s.collaborationService.isCollaborator).toHaveBeenCalledTimes(1);
+      expect(s.collectionService.indexCollectionEdge).toHaveBeenCalledTimes(1);
+    });
+
+    // An unauthorized author must not have their edge indexed into someone
+    // else's collection; it is parked until the collaboration turns active.
+    it('parks a foreign collection edge from a non-collaborator', async () => {
+      const s = services();
+      (s.collaborationService.isCollaborator as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+      await processor(s)(
+        event(
+          'pub.chive.graph.edge',
+          'create',
+          edge({ relationSlug: 'contains', targetUri: FOREIGN })
+        )
+      );
+      expect(s.collaborationService.parkPendingCollectionEdge).toHaveBeenCalledTimes(1);
+      expect(s.collectionService.indexCollectionEdge).not.toHaveBeenCalled();
+    });
+
+    it('sends a failed personal edge delete to the DLQ', async () => {
+      const s = services();
+      (s.personalGraphService.deleteEdge as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor(s)(event('pub.chive.graph.edge', 'delete', edge()));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed personal edge index to the DLQ', async () => {
+      const s = services();
+      (s.personalGraphService.indexEdge as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor(s)(event('pub.chive.graph.edge', 'create', edge()));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('actor profiles', () => {
+    const profile = { displayName: 'Alice Researcher', bio: 'Linguist.' };
+
+    it('upserts a profile into the authors index', async () => {
+      await processor()(event('pub.chive.actor.profile', 'create', profile));
+      expect(query).toHaveBeenCalled();
+    });
+
+    it('deletes a profile by repo DID', async () => {
+      await processor()(event('pub.chive.actor.profile', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM authors_index/);
+      expect(query.mock.calls[0]?.[1]).toEqual([REPO]);
+    });
+
+    it('sends a failed profile upsert to the DLQ', async () => {
+      query.mockRejectedValue(new Error('upsert failed'));
+      await processor()(event('pub.chive.actor.profile', 'create', profile));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed profile delete to the DLQ', async () => {
+      query.mockRejectedValue(new Error('delete failed'));
+      await processor()(event('pub.chive.actor.profile', 'delete'));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('upserts a profile config keyed on the repo DID', async () => {
+      await processor()(event('pub.chive.actor.profileConfig', 'create', { theme: 'dark' }));
+      expect(query).toHaveBeenCalled();
+    });
+
+    it('deletes a profile config by repo DID', async () => {
+      await processor()(event('pub.chive.actor.profileConfig', 'delete'));
+      expect(query.mock.calls[0]?.[0]).toMatch(/DELETE FROM profile_config/);
+    });
+
+    it('sends a failed profile config write to the DLQ', async () => {
+      query.mockRejectedValue(new Error('config failed'));
+      await processor()(event('pub.chive.actor.profileConfig', 'create', { theme: 'dark' }));
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('collaboration invites', () => {
+    const okResult = { ok: true, value: undefined };
+    const errResult = { ok: false, error: new Error('invite rejected') };
+    const invite = {
+      subject: { uri: `at://${REPO}/pub.chive.graph.node/collection1` },
+      invitee: 'did:plc:invitee',
+      createdAt: '2026-08-25T00:00:00.000Z',
+    };
+
+    const collaborationService = (): Record<string, unknown> => ({
+      indexInvite: vi.fn().mockResolvedValue(okResult),
+      deleteInvite: vi.fn().mockResolvedValue(okResult),
+      indexAcceptance: vi.fn().mockResolvedValue(okResult),
+      deleteAcceptance: vi.fn().mockResolvedValue(okResult),
+    });
+
+    // Collaboration is optional, so a deployment without the service must skip
+    // the record rather than fail the event.
+    it('ignores an invite when collaboration is not configured', async () => {
+      await processor()(event('pub.chive.collaboration.invite', 'create', invite));
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('indexes an invite', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'create', invite)
+      );
+      expect(c.indexInvite).toHaveBeenCalledTimes(1);
+    });
+
+    // A record missing a lexicon-required field is skipped rather than indexed
+    // half-formed.
+    it('skips an invite missing its subject', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'create', {
+          invitee: 'did:plc:x',
+          createdAt: 'now',
+        })
+      );
+      expect(c.indexInvite).not.toHaveBeenCalled();
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('skips an invite missing its invitee', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'create', {
+          subject: invite.subject,
+          createdAt: 'now',
+        })
+      );
+      expect(c.indexInvite).not.toHaveBeenCalled();
+    });
+
+    it('deletes an invite', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'delete')
+      );
+      expect(c.deleteInvite).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed invite index to the DLQ', async () => {
+      const c = collaborationService();
+      (c.indexInvite as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'create', invite)
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed invite delete to the DLQ', async () => {
+      const c = collaborationService();
+      (c.deleteInvite as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.invite', 'delete')
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes an invite acceptance', async () => {
+      const c = collaborationService();
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.inviteAcceptance', 'delete')
+      );
+      expect(c.deleteAcceptance).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a failed acceptance delete to the DLQ', async () => {
+      const c = collaborationService();
+      (c.deleteAcceptance as ReturnType<typeof vi.fn>).mockResolvedValue(errResult);
+      await processor({ collaborationService: c })(
+        event('pub.chive.collaboration.inviteAcceptance', 'delete')
+      );
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unhandled collections', () => {
+    // A foreign lexicon is not an error: the processor should ignore it quietly
+    // rather than filling the DLQ with records Chive never claimed to index.
+    it('ignores a collection outside the pub.chive namespace', async () => {
+      await processor()(event('app.bsky.feed.post', 'create', { text: 'hello' }));
+      expect(dlqAdd).not.toHaveBeenCalled();
+      expect(query).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/services/indexing/event-processor-governance.test.ts
+++ b/tests/unit/services/indexing/event-processor-governance.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for governance record handling in the firehose event processor.
+ *
+ * @remarks
+ * Two failure modes are pinned here. First, a proposal or vote retracted from
+ * its source PDS must be removed from the index rather than ignored, so that a
+ * withdrawn ballot stops counting. Second, a governance record missing a
+ * lexicon-required field must reach the DLQ instead of being recorded as
+ * indexed, since the cursor advances whether or not the record was stored.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { DeadLetterQueue } from '@/services/indexing/dlq-handler.js';
+import {
+  createEventProcessor,
+  EventProcessingError,
+  type EventProcessorOptions,
+} from '@/services/indexing/event-processor.js';
+import type { ProcessedEvent } from '@/services/indexing/indexing-service.js';
+
+const REPO = 'did:plc:testrepo';
+const PROPOSAL_URI = `at://${REPO}/pub.chive.graph.nodeProposal/xyz`;
+
+/**
+ * Builds a firehose event for a governance collection.
+ */
+const event = (
+  collection: string,
+  action: 'create' | 'update' | 'delete',
+  record?: unknown
+): ProcessedEvent =>
+  ({
+    $type: 'commit',
+    seq: 7,
+    repo: REPO,
+    time: '2026-08-24T00:00:00.000Z',
+    action,
+    collection,
+    rkey: '3kabc',
+    cid: 'bafyreiabc',
+    record,
+  }) as ProcessedEvent;
+
+describe('event processor governance records', () => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const indexNodeProposal = vi.fn();
+  const indexEdgeProposal = vi.fn();
+  const indexVote = vi.fn();
+  const deleteNodeProposal = vi.fn();
+  const deleteEdgeProposal = vi.fn();
+  const deleteVote = vi.fn();
+  const dlqAdd = vi.fn();
+
+  const buildOptions = (graphService: Record<string, unknown>): EventProcessorOptions =>
+    ({
+      pool: { query: vi.fn() },
+      activity: { correlateWithFirehose: vi.fn().mockResolvedValue({ ok: true, value: null }) },
+      eprintService: {},
+      reviewService: {},
+      graphService,
+      identity: { getPDSEndpoint: vi.fn().mockResolvedValue('https://pds.example.com') },
+      logger,
+      dlq: { add: dlqAdd } as unknown as DeadLetterQueue,
+    }) as unknown as EventProcessorOptions;
+
+  const fullGraphService = (): Record<string, unknown> => ({
+    indexNodeProposal,
+    indexEdgeProposal,
+    indexVote,
+    deleteNodeProposal,
+    deleteEdgeProposal,
+    deleteVote,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const ok = { ok: true, value: undefined };
+    indexNodeProposal.mockResolvedValue(ok);
+    indexEdgeProposal.mockResolvedValue(ok);
+    indexVote.mockResolvedValue(ok);
+    deleteNodeProposal.mockResolvedValue(ok);
+    deleteEdgeProposal.mockResolvedValue(ok);
+    deleteVote.mockResolvedValue(ok);
+    dlqAdd.mockResolvedValue(1);
+  });
+
+  describe('deletions from the source PDS', () => {
+    it('removes a retracted vote from the index', async () => {
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(event('pub.chive.graph.vote', 'delete'));
+
+      expect(deleteVote).toHaveBeenCalledWith(`at://${REPO}/pub.chive.graph.vote/3kabc`);
+      expect(indexVote).not.toHaveBeenCalled();
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('removes a retracted node proposal from the index', async () => {
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(event('pub.chive.graph.nodeProposal', 'delete'));
+
+      expect(deleteNodeProposal).toHaveBeenCalledWith(
+        `at://${REPO}/pub.chive.graph.nodeProposal/3kabc`
+      );
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('removes a retracted edge proposal from the index', async () => {
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(event('pub.chive.graph.edgeProposal', 'delete'));
+
+      expect(deleteEdgeProposal).toHaveBeenCalledWith(
+        `at://${REPO}/pub.chive.graph.edgeProposal/3kabc`
+      );
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('sends the deletion to the DLQ when the graph service rejects it', async () => {
+      deleteVote.mockResolvedValue({ ok: false, error: new Error('neo4j unavailable') });
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(event('pub.chive.graph.vote', 'delete'));
+
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+      const [, error] = dlqAdd.mock.calls[0] as [ProcessedEvent, EventProcessingError, number];
+      expect(error).toBeInstanceOf(EventProcessingError);
+      expect(error.critical).toBe(false);
+      expect(error.message).toContain('Failed to delete vote');
+    });
+
+    it('sends the deletion to the DLQ when the graph service cannot apply it yet', async () => {
+      // deleteVote is absent from the service, as it is today.
+      const processor = createEventProcessor(
+        buildOptions({ indexNodeProposal, indexEdgeProposal, indexVote })
+      );
+
+      await processor(event('pub.chive.graph.vote', 'delete'));
+
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+      const [, error] = dlqAdd.mock.calls[0] as [ProcessedEvent, EventProcessingError, number];
+      expect(error.cause).toBeDefined();
+      expect(error.cause?.message).toContain('deleteVote');
+    });
+
+    it('sends the deletion to the DLQ when the graph service throws', async () => {
+      deleteVote.mockRejectedValue(new Error('bolt connection reset'));
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(event('pub.chive.graph.vote', 'delete'));
+
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+      const [, error] = dlqAdd.mock.calls[0] as [ProcessedEvent, EventProcessingError, number];
+      expect(error.cause?.message).toContain('bolt connection reset');
+    });
+  });
+
+  describe('malformed records', () => {
+    it('routes a vote missing its choice to the DLQ without indexing it', async () => {
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(event('pub.chive.graph.vote', 'create', { proposalUri: PROPOSAL_URI }));
+
+      expect(indexVote).not.toHaveBeenCalled();
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+      const [, error] = dlqAdd.mock.calls[0] as [ProcessedEvent, EventProcessingError, number];
+      expect(error.message).toContain('Malformed vote');
+      expect(error.cause?.message).toContain('vote');
+    });
+
+    it('routes a node proposal missing its rationale to the DLQ', async () => {
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(
+        event('pub.chive.graph.nodeProposal', 'create', { proposalType: 'create', kind: 'type' })
+      );
+
+      expect(indexNodeProposal).not.toHaveBeenCalled();
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+      const [, error] = dlqAdd.mock.calls[0] as [ProcessedEvent, EventProcessingError, number];
+      expect(error.cause?.message).toContain('rationale');
+    });
+
+    it('routes an edge proposal missing its rationale to the DLQ', async () => {
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(event('pub.chive.graph.edgeProposal', 'update', { proposalType: 'update' }));
+
+      expect(indexEdgeProposal).not.toHaveBeenCalled();
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes a create carrying no decoded record to the DLQ', async () => {
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(event('pub.chive.graph.vote', 'create', undefined));
+
+      expect(indexVote).not.toHaveBeenCalled();
+      expect(dlqAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('well-formed records', () => {
+    it('indexes a valid vote and leaves the DLQ untouched', async () => {
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(
+        event('pub.chive.graph.vote', 'create', { proposalUri: PROPOSAL_URI, vote: 'approve' })
+      );
+
+      expect(indexVote).toHaveBeenCalledTimes(1);
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+
+    it('indexes a valid node proposal and leaves the DLQ untouched', async () => {
+      const processor = createEventProcessor(buildOptions(fullGraphService()));
+
+      await processor(
+        event('pub.chive.graph.nodeProposal', 'create', {
+          proposalType: 'create',
+          kind: 'type',
+          rationale: 'This field is missing from the taxonomy.',
+        })
+      );
+
+      expect(indexNodeProposal).toHaveBeenCalledTimes(1);
+      expect(dlqAdd).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/services/indexing/event-processor.test.ts
+++ b/tests/unit/services/indexing/event-processor.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the firehose event processor's failure handling.
+ *
+ * @remarks
+ * The cursor advances when an event is queued, not when it is processed, so a
+ * handler failure that neither reaches the DLQ nor rethrows loses the record
+ * permanently. These tests pin the two halves of that contract: a configured
+ * DLQ receives non-critical failures, and an absent one is reported loudly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { DeadLetterQueue } from '@/services/indexing/dlq-handler.js';
+import {
+  createEventProcessor,
+  EventProcessingError,
+  type EventProcessorOptions,
+} from '@/services/indexing/event-processor.js';
+import type { ProcessedEvent } from '@/services/indexing/indexing-service.js';
+
+const REPO = 'did:plc:testrepo';
+
+/**
+ * A vote event whose handler fails non-critically when graphService rejects it.
+ */
+const voteEvent: ProcessedEvent = {
+  $type: 'commit',
+  seq: 42,
+  repo: REPO,
+  time: '2026-08-24T00:00:00.000Z',
+  action: 'create',
+  collection: 'pub.chive.graph.vote',
+  rkey: '3kabc',
+  cid: 'bafyreiabc',
+  record: { proposalUri: `at://${REPO}/pub.chive.graph.nodeProposal/xyz`, vote: 'support' },
+};
+
+describe('createEventProcessor', () => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const indexVote = vi.fn();
+  const dlqAdd = vi.fn();
+
+  const buildOptions = (dlq?: DeadLetterQueue): EventProcessorOptions =>
+    ({
+      pool: { query: vi.fn() },
+      activity: { correlateWithFirehose: vi.fn().mockResolvedValue({ ok: true, value: null }) },
+      eprintService: {},
+      reviewService: {},
+      graphService: { indexVote },
+      identity: { getPDSEndpoint: vi.fn().mockResolvedValue('https://pds.example.com') },
+      logger,
+      dlq,
+    }) as unknown as EventProcessorOptions;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    indexVote.mockResolvedValue({ ok: false, error: new Error('neo4j unavailable') });
+    dlqAdd.mockResolvedValue(1);
+  });
+
+  it('sends non-critical handler failures to the DLQ', async () => {
+    const dlq = { add: dlqAdd } as unknown as DeadLetterQueue;
+    const processor = createEventProcessor(buildOptions(dlq));
+
+    await processor(voteEvent);
+
+    expect(dlqAdd).toHaveBeenCalledTimes(1);
+    const [event, error, retryCount] = dlqAdd.mock.calls[0] as [
+      ProcessedEvent,
+      EventProcessingError,
+      number,
+    ];
+    expect(event.seq).toBe(42);
+    expect(event.collection).toBe('pub.chive.graph.vote');
+    expect(error).toBeInstanceOf(EventProcessingError);
+    expect(error.critical).toBe(false);
+    expect(error.uri).toBe(`at://${REPO}/pub.chive.graph.vote/3kabc`);
+    expect(retryCount).toBe(0);
+  });
+
+  it('does not rethrow when the DLQ accepts the failure', async () => {
+    const dlq = { add: dlqAdd } as unknown as DeadLetterQueue;
+    const processor = createEventProcessor(buildOptions(dlq));
+
+    await expect(processor(voteEvent)).resolves.toBeUndefined();
+  });
+
+  it('warns that the record is dropped when no DLQ is configured', async () => {
+    const processor = createEventProcessor(buildOptions(undefined));
+
+    await processor(voteEvent);
+
+    expect(dlqAdd).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('no DLQ configured'),
+      expect.objectContaining({ collection: 'pub.chive.graph.vote' })
+    );
+  });
+
+  it('still processes the event when the DLQ write itself fails', async () => {
+    dlqAdd.mockRejectedValue(new Error('postgres down'));
+    const dlq = { add: dlqAdd } as unknown as DeadLetterQueue;
+    const processor = createEventProcessor(buildOptions(dlq));
+
+    await expect(processor(voteEvent)).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to send event to DLQ',
+      expect.any(Error),
+      expect.objectContaining({ collection: 'pub.chive.graph.vote' })
+    );
+  });
+});

--- a/tests/unit/services/indexing/indexed-collections.test.ts
+++ b/tests/unit/services/indexing/indexed-collections.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests keeping the indexed-collection lists from drifting apart again.
+ *
+ * @remarks
+ * "The collections we index" was stated in three places that disagreed: the
+ * firehose event processor's dispatch, `sync.indexRecord`'s manual reindex
+ * list, and the PDS scanner's backfill filter. A collection in one and not
+ * another means the index depends on how a record arrived — the live firehose
+ * indexes it, a manual reindex rejects it as unsupported, and a backfill skips
+ * it without saying so.
+ *
+ * `sync.indexRecord` accepted 13 while the event processor handled 20, so seven
+ * were unreachable by manual reindex — including `pub.chive.graph.edgeProposal`,
+ * which meant an edge proposal the firehose missed could not be recovered at
+ * all.
+ *
+ * The event processor is the authoritative definition, because it is the live
+ * path. This test reads the `case` labels straight out of its dispatch, so a
+ * new branch added there without a matching entry in the shared list fails here
+ * rather than quietly recreating the divergence.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  INDEXED_COLLECTIONS,
+  isIndexedCollection,
+} from '@/services/indexing/indexed-collections.js';
+
+/** Collections the firehose event processor actually dispatches on. */
+const dispatchedCollections = (): string[] => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/services/indexing/event-processor.ts'),
+    'utf8'
+  );
+  const matches = [...source.matchAll(/case '(pub\.chive\.[a-zA-Z.]+)':/g)];
+  return [...new Set(matches.map((match) => match[1]!))].sort();
+};
+
+describe('INDEXED_COLLECTIONS', () => {
+  it('matches what the event processor dispatches on', () => {
+    expect([...INDEXED_COLLECTIONS].sort()).toEqual(dispatchedCollections());
+  });
+
+  it('is not empty', () => {
+    expect(INDEXED_COLLECTIONS.length).toBeGreaterThan(0);
+  });
+
+  it('contains no duplicates', () => {
+    expect(new Set(INDEXED_COLLECTIONS).size).toBe(INDEXED_COLLECTIONS.length);
+  });
+
+  // The specific gap the divergence left: an edge proposal missed by the
+  // firehose was unrecoverable, because manual reindex refused the collection.
+  it('includes the edge proposal collection that manual reindex rejected', () => {
+    expect(isIndexedCollection('pub.chive.graph.edgeProposal')).toBe(true);
+  });
+
+  it.each([
+    'pub.chive.actor.profile',
+    'pub.chive.collaboration.invite',
+    'pub.chive.collaboration.inviteAcceptance',
+    'pub.chive.eprint.changelog',
+    'pub.chive.eprint.version',
+    'pub.chive.eprint.tag',
+  ])('includes %s, previously unreachable by manual reindex', (collection) => {
+    expect(isIndexedCollection(collection)).toBe(true);
+  });
+
+  it('rejects a collection outside the namespace', () => {
+    expect(isIndexedCollection('app.bsky.feed.post')).toBe(false);
+  });
+});
+
+describe('sync.indexRecord uses the shared list', () => {
+  it('no longer keeps its own copy', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/api/handlers/xrpc/sync/indexRecord.ts'),
+      'utf8'
+    );
+    expect(source).toMatch(/isIndexedCollection\(collection\)/);
+    expect(source).not.toMatch(/const supportedCollections = \[/);
+  });
+});

--- a/tests/unit/services/knowledge-graph/governance-record-timestamps.test.ts
+++ b/tests/unit/services/knowledge-graph/governance-record-timestamps.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for governance record timestamp provenance.
+ *
+ * @remarks
+ * Proposals and votes were indexed with the AppView's ingest time rather than
+ * the `createdAt` the record carries. Both values are sort keys — proposals
+ * list `ORDER BY p.createdAt DESC`, ballots `ORDER BY v.createdAt` — so a
+ * rebuild of the index from the firehose reordered governance history, which
+ * the rebuildability rule forbids. Ingest time survives only as the fallback
+ * for a record carrying no usable timestamp of its own.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import type { RecordMetadata } from '@/services/eprint/eprint-service.js';
+import { KnowledgeGraphService } from '@/services/knowledge-graph/graph-service.js';
+import type { AtUri, CID } from '@/types/atproto.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+const DID = 'did:plc:izttpdp3l6vss5crelt5kcux';
+const RECORD_CREATED_AT = '2026-05-07T14:48:40.171Z';
+const INDEXED_AT = new Date('2026-08-24T09:00:00.000Z');
+
+const metadataFor = (collection: string): RecordMetadata => ({
+  uri: `at://${DID}/${collection}/3mlbhk6h2ne2k` as AtUri,
+  cid: 'bafyreiabc123' as CID,
+  pdsUrl: 'https://pds.example.com',
+  indexedAt: INDEXED_AT,
+});
+
+const createLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+describe('KnowledgeGraphService governance record timestamps', () => {
+  let graph: { createProposal: ReturnType<typeof vi.fn>; createVote: ReturnType<typeof vi.fn> };
+  let service: KnowledgeGraphService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    graph = {
+      createProposal: vi.fn().mockResolvedValue(undefined),
+      createVote: vi.fn().mockResolvedValue(undefined),
+    };
+    service = new KnowledgeGraphService({
+      graph: graph as never,
+      storage: {} as never,
+      logger: createLogger(),
+    });
+  });
+
+  describe('indexNodeProposal', () => {
+    const nodeProposal = (createdAt?: string): Record<string, unknown> => ({
+      proposalType: 'create',
+      kind: 'type',
+      subkind: 'field',
+      proposedNode: { label: 'Semantics' },
+      rationale: 'because',
+      ...(createdAt === undefined ? {} : { createdAt }),
+    });
+
+    it("should store the record's own createdAt rather than ingest time", async () => {
+      const result = await service.indexNodeProposal(
+        nodeProposal(RECORD_CREATED_AT),
+        metadataFor('pub.chive.graph.nodeProposal')
+      );
+
+      expect(result.ok).toBe(true);
+      expect(graph.createProposal).toHaveBeenCalledWith(
+        expect.objectContaining({ createdAt: new Date(RECORD_CREATED_AT) })
+      );
+    });
+
+    it('should fall back to ingest time when the record carries no timestamp', async () => {
+      await service.indexNodeProposal(nodeProposal(), metadataFor('pub.chive.graph.nodeProposal'));
+
+      expect(graph.createProposal).toHaveBeenCalledWith(
+        expect.objectContaining({ createdAt: INDEXED_AT })
+      );
+    });
+
+    it('should fall back to ingest time when the timestamp does not parse', async () => {
+      await service.indexNodeProposal(
+        nodeProposal('not-a-timestamp'),
+        metadataFor('pub.chive.graph.nodeProposal')
+      );
+
+      expect(graph.createProposal).toHaveBeenCalledWith(
+        expect.objectContaining({ createdAt: INDEXED_AT })
+      );
+    });
+  });
+
+  describe('indexEdgeProposal', () => {
+    const edgeProposal = (createdAt?: string): Record<string, unknown> => ({
+      proposalType: 'create',
+      proposedEdge: { sourceUri: `at://${DID}/pub.chive.graph.node/a`, relationSlug: 'broader' },
+      rationale: 'because',
+      ...(createdAt === undefined ? {} : { createdAt }),
+    });
+
+    it("should store the record's own createdAt rather than ingest time", async () => {
+      const result = await service.indexEdgeProposal(
+        edgeProposal(RECORD_CREATED_AT),
+        metadataFor('pub.chive.graph.edgeProposal')
+      );
+
+      expect(result.ok).toBe(true);
+      expect(graph.createProposal).toHaveBeenCalledWith(
+        expect.objectContaining({ createdAt: new Date(RECORD_CREATED_AT) })
+      );
+    });
+
+    it('should fall back to ingest time when the record carries no timestamp', async () => {
+      await service.indexEdgeProposal(edgeProposal(), metadataFor('pub.chive.graph.edgeProposal'));
+
+      expect(graph.createProposal).toHaveBeenCalledWith(
+        expect.objectContaining({ createdAt: INDEXED_AT })
+      );
+    });
+  });
+
+  describe('indexVote', () => {
+    const vote = (createdAt?: string): Record<string, unknown> => ({
+      proposalUri: `at://${DID}/pub.chive.graph.nodeProposal/3mlbhk6h2ne2k`,
+      vote: 'approve',
+      ...(createdAt === undefined ? {} : { createdAt }),
+    });
+
+    it("should store the ballot's own createdAt rather than ingest time", async () => {
+      const result = await service.indexVote(
+        vote(RECORD_CREATED_AT),
+        metadataFor('pub.chive.graph.vote')
+      );
+
+      expect(result.ok).toBe(true);
+      expect(graph.createVote).toHaveBeenCalledWith(
+        expect.objectContaining({ createdAt: new Date(RECORD_CREATED_AT) })
+      );
+    });
+
+    it('should fall back to ingest time when the ballot carries no timestamp', async () => {
+      await service.indexVote(vote(), metadataFor('pub.chive.graph.vote'));
+
+      expect(graph.createVote).toHaveBeenCalledWith(
+        expect.objectContaining({ createdAt: INDEXED_AT })
+      );
+    });
+  });
+});

--- a/tests/unit/services/knowledge-graph/proposal-error-propagation.test.ts
+++ b/tests/unit/services/knowledge-graph/proposal-error-propagation.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for proposal read-failure propagation.
+ *
+ * @remarks
+ * `listProposals` used to swallow every error and return an empty page, which
+ * the UI renders as "no proposals found" with HTTP 200 and which the moderation
+ * badge reads as a zero backlog; `getProposalById` used to return null, which
+ * handlers turn into a 404. Both now surface a typed error so callers can
+ * answer 5xx, while a genuinely absent proposal still reads as null.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { KnowledgeGraphService } from '@/services/knowledge-graph/graph-service.js';
+import { DatabaseError } from '@/types/errors.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+const RKEY = '3mlbhk6h2ne2k';
+const URI = `at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.graph.nodeProposal/${RKEY}`;
+
+const createLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+describe('KnowledgeGraphService proposal read failures', () => {
+  let graph: {
+    listProposals: ReturnType<typeof vi.fn>;
+    getProposal: ReturnType<typeof vi.fn>;
+    getProposalByRkey: ReturnType<typeof vi.fn>;
+  };
+  let logger: ILogger;
+  let service: KnowledgeGraphService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    graph = {
+      listProposals: vi.fn(),
+      getProposal: vi.fn().mockResolvedValue(null),
+      getProposalByRkey: vi.fn().mockResolvedValue(null),
+    };
+    logger = createLogger();
+    service = new KnowledgeGraphService({ graph: graph as never, logger } as never);
+  });
+
+  describe('listProposals', () => {
+    it('should propagate a graph outage as a DatabaseError', async () => {
+      graph.listProposals.mockRejectedValue(new Error('Neo4j unavailable'));
+
+      await expect(service.listProposals({})).rejects.toBeInstanceOf(DatabaseError);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('should preserve a typed error raised by the adapter', async () => {
+      const adapterError = new DatabaseError('QUERY', 'connection pool exhausted');
+      graph.listProposals.mockRejectedValue(adapterError);
+
+      await expect(service.listProposals({})).rejects.toBe(adapterError);
+    });
+
+    it('should still return an empty page when the graph holds no proposals', async () => {
+      graph.listProposals.mockResolvedValue({ proposals: [], total: 0, hasMore: false, offset: 0 });
+
+      const result = await service.listProposals({});
+
+      expect(result).toEqual({
+        proposals: [],
+        cursor: undefined,
+        hasMore: false,
+        total: 0,
+      });
+    });
+  });
+
+  describe('getProposalById', () => {
+    it('should propagate a read failure rather than reporting the proposal as missing', async () => {
+      graph.getProposalByRkey.mockRejectedValue(new Error('Neo4j unavailable'));
+
+      await expect(service.getProposalById(RKEY)).rejects.toBeInstanceOf(DatabaseError);
+    });
+
+    it('should propagate a read failure for the AT-URI lookup too', async () => {
+      graph.getProposal.mockRejectedValue(new Error('Neo4j unavailable'));
+
+      await expect(service.getProposalById(URI)).rejects.toBeInstanceOf(DatabaseError);
+    });
+
+    it('should still return null when the proposal genuinely does not exist', async () => {
+      expect(await service.getProposalById(RKEY)).toBeNull();
+    });
+  });
+});

--- a/tests/unit/storage/neo4j/facet-depth-traversal.test.ts
+++ b/tests/unit/storage/neo4j/facet-depth-traversal.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for facet hierarchy traversal.
+ *
+ * @remarks
+ * `getChildFacets` asked Cypher for `*1..$maxDepth`. Neo4j does not accept a
+ * parameter as a variable-length bound, so the query was a syntax error and the
+ * method threw on every call — the child-facet hierarchy never resolved at all.
+ * The bound must therefore live in the query text, which means it cannot be
+ * parameterized and has to be proven to be a bounded integer first.
+ *
+ * The pattern also carried a duplicated `:Node:Node:Facet` label.
+ */
+
+import 'reflect-metadata';
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+import type { Neo4jConnection } from '@/storage/neo4j/connection.js';
+import { FacetManager } from '@/storage/neo4j/facet-manager.js';
+import type { AtUri } from '@/types/atproto.js';
+
+const PARENT = 'at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.graph.node/facet1' as AtUri;
+
+describe('FacetManager.getChildFacets', () => {
+  let executeQuery: Mock;
+  let manager: FacetManager;
+
+  beforeEach(() => {
+    executeQuery = vi.fn().mockResolvedValue({ records: [] });
+    manager = new FacetManager({ executeQuery } as unknown as Neo4jConnection);
+  });
+
+  it('writes the depth into the query rather than passing it as a parameter', async () => {
+    await manager.getChildFacets(PARENT, 3);
+    const [cypher, params] = executeQuery.mock.calls[0] as [string, Record<string, unknown>];
+    expect(cypher).toContain('*1..3');
+    expect(cypher).not.toContain('$maxDepth');
+    expect(params).not.toHaveProperty('maxDepth');
+    expect(params).toHaveProperty('parentUri', PARENT);
+  });
+
+  it('defaults to a depth of one', async () => {
+    await manager.getChildFacets(PARENT);
+    expect(executeQuery.mock.calls[0]?.[0]).toContain('*1..1');
+  });
+
+  it('does not repeat the Node label in the pattern', async () => {
+    await manager.getChildFacets(PARENT);
+    expect(executeQuery.mock.calls[0]?.[0]).not.toContain(':Node:Node');
+  });
+
+  // The bound is interpolated, so anything that is not a plain bounded integer
+  // has to be refused before it reaches the query text.
+  it.each([[0], [-1], [1.5], [Number.NaN], [Infinity], [11]])(
+    'rejects a depth of %s without querying',
+    async (depth) => {
+      await expect(manager.getChildFacets(PARENT, depth)).rejects.toThrow(RangeError);
+      expect(executeQuery).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects a non-numeric depth smuggled in as a string', async () => {
+    await expect(
+      manager.getChildFacets(PARENT, '2 UNION MATCH (n) DETACH DELETE n' as unknown as number)
+    ).rejects.toThrow(RangeError);
+    expect(executeQuery).not.toHaveBeenCalled();
+  });
+
+  it('accepts the maximum permitted depth', async () => {
+    await manager.getChildFacets(PARENT, 10);
+    expect(executeQuery.mock.calls[0]?.[0]).toContain('*1..10');
+  });
+});

--- a/tests/unit/storage/neo4j/governance-write-queries.test.ts
+++ b/tests/unit/storage/neo4j/governance-write-queries.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the governance write queries in the Neo4j adapter.
+ *
+ * @remarks
+ * Two defects are covered here. First, `createVote` stamped ballots with
+ * `datetime()` and dropped the timestamp it was handed, so ballot order was a
+ * function of ingest time and changed on every rebuild from the firehose.
+ * Second, `createProposal`'s `ON MATCH SET` copied only `proposedNode` and
+ * `rationale`, so a proposal edited in its PDS kept a stale `proposalType`,
+ * `kind`, `subkind` and `targetUri` after re-index.
+ */
+
+import 'reflect-metadata';
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+import { Neo4jAdapter } from '@/storage/neo4j/adapter.js';
+import type { Neo4jConnection } from '@/storage/neo4j/connection.js';
+import type { Vote } from '@/storage/neo4j/types.js';
+import type { AtUri, DID } from '@/types/atproto.js';
+
+const PROPOSER = 'did:plc:izttpdp3l6vss5crelt5kcux' as DID;
+const PROPOSAL_URI = `at://${PROPOSER}/pub.chive.graph.nodeProposal/3mlbhk6h2ne2k` as AtUri;
+const VOTE_URI = `at://${PROPOSER}/pub.chive.graph.vote/3mlbhk6h2ne2v` as AtUri;
+const CREATED_AT = new Date('2026-05-07T14:48:40.171Z');
+
+describe('Neo4jAdapter governance write queries', () => {
+  let executeQuery: Mock;
+  let adapter: Neo4jAdapter;
+
+  beforeEach(() => {
+    executeQuery = vi.fn().mockResolvedValue({ records: [] });
+    adapter = new Neo4jAdapter({ executeQuery } as unknown as Neo4jConnection);
+  });
+
+  describe('createVote', () => {
+    const vote: Vote = {
+      id: '3mlbhk6h2ne2v',
+      uri: VOTE_URI,
+      proposalUri: PROPOSAL_URI,
+      voterDid: PROPOSER,
+      voterRole: 'community-member',
+      vote: 'approve',
+      createdAt: CREATED_AT,
+    };
+
+    it('should stamp the ballot with the record timestamp it was handed', async () => {
+      await adapter.createVote(vote);
+
+      const [query, params] = executeQuery.mock.calls[0] as [string, Record<string, unknown>];
+
+      expect(query).toContain('v.createdAt = datetime($createdAt)');
+      expect(params.createdAt).toBe(CREATED_AT.toISOString());
+    });
+
+    it('should not fall back to wall-clock time for createdAt', async () => {
+      await adapter.createVote(vote);
+
+      const [query] = executeQuery.mock.calls[0] as [string];
+
+      expect(query).not.toContain('v.createdAt = datetime()');
+    });
+  });
+
+  describe('createProposal', () => {
+    const proposal = {
+      uri: PROPOSAL_URI,
+      proposalType: 'update' as const,
+      kind: 'object' as const,
+      subkind: 'field',
+      targetUri: `at://${PROPOSER}/pub.chive.graph.node/target` as AtUri,
+      proposedNode: { label: 'Semantics' },
+      rationale: 'because',
+      proposerDid: PROPOSER,
+      createdAt: CREATED_AT,
+    };
+
+    const onMatchBlock = (query: string): string => query.slice(query.indexOf('ON MATCH SET'));
+
+    it('should mirror every record-carried field when the proposal already exists', async () => {
+      await adapter.createProposal(proposal);
+
+      const [query] = executeQuery.mock.calls[0] as [string];
+      const onMatch = onMatchBlock(query);
+
+      for (const assignment of [
+        'p.proposalType = $proposalType',
+        'p.kind = $kind',
+        'p.subkind = $subkind',
+        'p.targetUri = $targetUri',
+        'p.proposedNode = $proposedNode',
+        'p.rationale = $rationale',
+        'p.createdAt = datetime($createdAt)',
+      ]) {
+        expect(onMatch).toContain(assignment);
+      }
+    });
+
+    it('should leave status, id and proposer untouched on re-index', async () => {
+      await adapter.createProposal(proposal);
+
+      const [query] = executeQuery.mock.calls[0] as [string];
+      const onMatch = onMatchBlock(query);
+
+      expect(onMatch).not.toContain('p.status');
+      expect(onMatch).not.toContain('p.id =');
+      expect(onMatch).not.toContain('p.proposerDid');
+    });
+
+    it("should pass the record's own createdAt as an ISO parameter", async () => {
+      await adapter.createProposal(proposal);
+
+      const [, params] = executeQuery.mock.calls[0] as [string, Record<string, unknown>];
+
+      expect(params.createdAt).toBe(CREATED_AT.toISOString());
+    });
+  });
+});

--- a/tests/unit/storage/neo4j/label-alignment.test.ts
+++ b/tests/unit/storage/neo4j/label-alignment.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests aligning read-side Cypher with the labels the write side creates.
+ *
+ * @remarks
+ * Cypher does not error on a label that matches nothing — it returns no rows.
+ * Several recommendation and collaboration queries matched labels and property
+ * shapes that no writer in this codebase ever produces, so those features
+ * returned empty results indefinitely and looked like "no data yet".
+ *
+ * Two mismatches existed. Fields are created as `(:Node:Field {uri})` and were
+ * read as `(:FieldNode)`. Authors are created as `(:Node:Object:Person)` with
+ * `subkind = 'author'` and the DID under `metadata.did` — that is what
+ * `AuthorRepository.createCoauthorship` writes `COAUTHORED_WITH` between — and
+ * were read as `(:Author {did})`, so collaboration strength was null for every
+ * pair of authors who had in fact collaborated.
+ *
+ * These are asserted against the source because they are query text: there is
+ * no behaviour to observe without a live Neo4j, and a live Neo4j would not
+ * catch the mismatch either — it would happily return nothing.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const source = (name: string): string =>
+  readFileSync(join(process.cwd(), 'src/storage/neo4j', `${name}.ts`), 'utf8');
+
+/**
+ * The file with block comments stripped.
+ *
+ * @remarks
+ * The explanatory notes in these files name the old labels in order to explain
+ * them, so an assertion that a label is absent has to look at the code rather
+ * than at prose describing the code.
+ */
+const queryText = (name: string): string => source(name).replace(/\/\*[\s\S]*?\*\//g, '');
+
+const READ_SIDE = ['recommendations', 'graph-algorithms', 'collaboration-graph'] as const;
+
+describe('read queries use labels the write side creates', () => {
+  it.each(READ_SIDE)('%s does not match the non-existent :FieldNode label', (name) => {
+    expect(queryText(name)).not.toMatch(/:FieldNode/);
+  });
+
+  it.each(['recommendations', 'graph-algorithms'] as const)(
+    '%s matches fields as :Node:Field',
+    (name) => {
+      expect(source(name)).toMatch(/:Node:Field/);
+    }
+  );
+
+  it('matches authors the way createCoauthorship writes them', () => {
+    const contents = source('collaboration-graph');
+    expect(contents).toMatch(/:Node:Object:Person/);
+    expect(contents).toMatch(/metadata\.did = \$did1/);
+  });
+
+  it('no longer matches the non-existent (:Author {did}) shape', () => {
+    expect(queryText('collaboration-graph')).not.toMatch(/:Author \{did:/);
+  });
+});
+
+describe('the missing INTERESTED_IN writer is recorded', () => {
+  // Relabelling cannot fix this half: nothing creates the relationship at all,
+  // so the queries that depend on it alone stay empty by construction.
+  it.each(['recommendations', 'graph-algorithms'] as const)(
+    '%s says the relationship has no writer',
+    (name) => {
+      expect(source(name)).toMatch(/NOTE ON `INTERESTED_IN`/);
+    }
+  );
+
+  it('has no writer anywhere in the read-side files themselves', () => {
+    for (const name of ['recommendations', 'graph-algorithms'] as const) {
+      expect(queryText(name)).not.toMatch(/MERGE \([^)]*\)-\[:INTERESTED_IN\]/);
+      expect(queryText(name)).not.toMatch(/CREATE \([^)]*\)-\[:INTERESTED_IN\]/);
+    }
+  });
+});

--- a/tests/unit/storage/neo4j/proposal-mapping.test.ts
+++ b/tests/unit/storage/neo4j/proposal-mapping.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for proposal row mapping in the Neo4j adapter.
+ *
+ * @remarks
+ * A proposal row whose `proposerDid` does not parse used to abort the enclosing
+ * query, so one malformed row emptied the whole governance list. The row is now
+ * skipped for list queries and reported as a read failure for single-record
+ * lookups, where a null would otherwise be rendered as a 404.
+ */
+
+import 'reflect-metadata';
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+import { Neo4jAdapter } from '@/storage/neo4j/adapter.js';
+import type { Neo4jConnection } from '@/storage/neo4j/connection.js';
+import type { AtUri } from '@/types/atproto.js';
+import { DatabaseError } from '@/types/errors.js';
+
+interface MockRecord {
+  get: (key: string) => unknown;
+}
+
+const createProposalRecord = (overrides: Record<string, unknown> = {}): MockRecord => {
+  const properties = {
+    id: 'rkey-good',
+    uri: 'at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.graph.nodeProposal/rkey-good',
+    proposalType: 'create',
+    kind: 'type',
+    subkind: 'field',
+    rationale: 'because',
+    status: 'pending',
+    proposerDid: 'did:plc:izttpdp3l6vss5crelt5kcux',
+    createdAt: '2026-05-07T14:48:40.171Z',
+    ...overrides,
+  };
+
+  return { get: (key: string): unknown => (key === 'p' ? { properties } : undefined) };
+};
+
+const countRecord = (total: number): MockRecord => ({ get: (): unknown => total });
+
+describe('Neo4jAdapter proposal mapping', () => {
+  let executeQuery: Mock;
+  let adapter: Neo4jAdapter;
+
+  beforeEach(() => {
+    executeQuery = vi.fn();
+    adapter = new Neo4jAdapter({ executeQuery } as unknown as Neo4jConnection);
+  });
+
+  describe('listProposals', () => {
+    it('should skip an unmappable row instead of emptying the page', async () => {
+      executeQuery
+        .mockResolvedValueOnce({
+          records: [
+            createProposalRecord({ proposerDid: 'not-a-did' }),
+            createProposalRecord({ id: 'rkey-good' }),
+          ],
+        })
+        .mockResolvedValueOnce({ records: [countRecord(2)] });
+
+      const result = await adapter.listProposals({ limit: 50 });
+
+      expect(result.proposals).toHaveLength(1);
+      expect(result.proposals[0]?.id).toBe('rkey-good');
+      expect(result.total).toBe(2);
+    });
+
+    it('should decide pagination on raw rows so a skipped row does not end it early', async () => {
+      // The query asks for limit + 1 rows; the extra row is the next-page probe.
+      executeQuery
+        .mockResolvedValueOnce({
+          records: [
+            createProposalRecord({ id: 'rkey-a' }),
+            createProposalRecord({ id: 'rkey-b', proposerDid: 'not-a-did' }),
+            createProposalRecord({ id: 'rkey-c' }),
+          ],
+        })
+        .mockResolvedValueOnce({ records: [countRecord(9)] });
+
+      const result = await adapter.listProposals({ limit: 2 });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.proposals.map((p) => p.id)).toEqual(['rkey-a']);
+    });
+  });
+
+  describe('getProposal', () => {
+    it('should report an unmappable row as a read failure, not as absent', async () => {
+      executeQuery.mockResolvedValueOnce({
+        records: [createProposalRecord({ proposerDid: 'not-a-did' })],
+      });
+
+      await expect(adapter.getProposal('at://did:plc:x/c/rkey' as AtUri)).rejects.toBeInstanceOf(
+        DatabaseError
+      );
+    });
+
+    it('should still return null when no row matches', async () => {
+      executeQuery.mockResolvedValueOnce({ records: [] });
+
+      expect(await adapter.getProposal('at://did:plc:x/c/rkey' as AtUri)).toBeNull();
+    });
+  });
+
+  describe('getProposalByRkey', () => {
+    it('should report an unmappable row as a read failure, not as absent', async () => {
+      executeQuery.mockResolvedValueOnce({
+        records: [createProposalRecord({ proposerDid: 'not-a-did' })],
+      });
+
+      await expect(adapter.getProposalByRkey('rkey-good')).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
+  describe('getProposalsForNode', () => {
+    it('should drop an unmappable row and keep the rest', async () => {
+      executeQuery.mockResolvedValueOnce({
+        records: [
+          createProposalRecord({ id: 'rkey-a' }),
+          createProposalRecord({ id: 'rkey-b', proposerDid: '' }),
+        ],
+      });
+
+      const proposals = await adapter.getProposalsForNode('at://did:plc:x/c/node' as AtUri);
+
+      expect(proposals.map((p) => p.id)).toEqual(['rkey-a']);
+    });
+  });
+});

--- a/tests/unit/storage/postgresql/adapter-delete-by-uri.test.ts
+++ b/tests/unit/storage/postgresql/adapter-delete-by-uri.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for the PostgreSQLAdapter.deleteByUri table allowlist.
+ *
+ * @remarks
+ * The allowlist previously named `citations_index` and `related_works_index`,
+ * neither of which any migration creates, so every firehose tombstone for those
+ * record types raised an undefined_table error. These tests pin the allowlist to
+ * table names that exist and are keyed by a `uri` column.
+ */
+
+import type { Pool } from 'pg';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { PostgreSQLAdapter } from '@/storage/postgresql/adapter.js';
+import type { AtUri } from '@/types/atproto.js';
+
+const TEST_URI = 'at://did:plc:abc123/pub.chive.eprint.relatedWork/xyz789' as AtUri;
+
+function createMockPool(): Pool {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  } as unknown as Pool;
+}
+
+describe('PostgreSQLAdapter.deleteByUri', () => {
+  let adapter: PostgreSQLAdapter;
+  let mockPool: Pool;
+
+  beforeEach(() => {
+    mockPool = createMockPool();
+    adapter = new PostgreSQLAdapter(mockPool);
+  });
+
+  it.each(['user_tags_index', 'reviews_index', 'endorsements_index', 'user_related_works_index'])(
+    'deletes from %s',
+    async (table) => {
+      await adapter.deleteByUri(table, TEST_URI);
+
+      expect(mockPool.query).toHaveBeenCalledWith(`DELETE FROM ${table} WHERE uri = $1`, [
+        TEST_URI,
+      ]);
+    }
+  );
+
+  it.each(['citations_index', 'related_works_index'])(
+    'rejects %s, which no migration creates',
+    async (table) => {
+      await expect(adapter.deleteByUri(table, TEST_URI)).rejects.toThrow(
+        `Invalid table name: ${table}`
+      );
+      expect(mockPool.query).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects extracted_citations, which is keyed by user_record_uri', async () => {
+    await expect(adapter.deleteByUri('extracted_citations', TEST_URI)).rejects.toThrow(
+      'Invalid table name: extracted_citations'
+    );
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects an injection attempt', async () => {
+    await expect(adapter.deleteByUri('reviews_index; DROP TABLE users', TEST_URI)).rejects.toThrow(
+      'Invalid table name'
+    );
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/storage/postgresql/batch-eprint-fetch.test.ts
+++ b/tests/unit/storage/postgresql/batch-eprint-fetch.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for batched eprint fetching.
+ *
+ * @remarks
+ * Callers needing many eprints fetched them one at a time. Author autocomplete
+ * did this on every keystroke over `limit * 3` search hits — up to 75 sequential
+ * database round trips per character typed, each waiting on the one before it.
+ * A single `uri = ANY($1)` replaces them.
+ *
+ * The soft-delete filter is included here for the same reason it was added to
+ * the other read paths: a deleted eprint must not reappear through a batch
+ * fetch that skipped the check.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+import { EprintsRepository } from '@/storage/postgresql/eprints-repository.js';
+import type { AtUri } from '@/types/atproto.js';
+
+const URI_A = 'at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.eprint.submission/a' as AtUri;
+const URI_B = 'at://did:plc:izttpdp3l6vss5crelt5kcux/pub.chive.eprint.submission/b' as AtUri;
+
+describe('EprintsRepository.findByUris', () => {
+  let query: Mock;
+  let repository: EprintsRepository;
+
+  beforeEach(() => {
+    query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    repository = new EprintsRepository({ query } as never);
+  });
+
+  it('issues a single query for many URIs', async () => {
+    await repository.findByUris([URI_A, URI_B]);
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the URIs as one array parameter', async () => {
+    await repository.findByUris([URI_A, URI_B]);
+    expect(query.mock.calls[0]?.[1]).toEqual([[URI_A, URI_B]]);
+    expect(query.mock.calls[0]?.[0]).toMatch(/uri = ANY\(\$1::text\[\]\)/);
+  });
+
+  // A batch fetch that skipped the check would resurrect deleted eprints in any
+  // caller that used it.
+  it('excludes soft-deleted rows', async () => {
+    await repository.findByUris([URI_A]);
+    expect(query.mock.calls[0]?.[0]).toMatch(/deleted_at IS NULL/);
+  });
+
+  it('does not query at all for an empty list', async () => {
+    const result = await repository.findByUris([]);
+    expect(query).not.toHaveBeenCalled();
+    expect(result.size).toBe(0);
+  });
+
+  it('deduplicates repeated URIs', async () => {
+    await repository.findByUris([URI_A, URI_A, URI_B]);
+    expect(query.mock.calls[0]?.[1]).toEqual([[URI_A, URI_B]]);
+  });
+
+  // The index can legitimately lag a search result, so a URI with no row is
+  // absent from the map rather than an error.
+  it('omits URIs that have no row', async () => {
+    const result = await repository.findByUris([URI_A, URI_B]);
+    expect(result.has(URI_A)).toBe(false);
+    expect(result.size).toBe(0);
+  });
+});

--- a/tests/unit/storage/postgresql/soft-delete-filtering.test.ts
+++ b/tests/unit/storage/postgresql/soft-delete-filtering.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for soft-delete filtering in eprint read paths.
+ *
+ * @remarks
+ * Deleting an eprint sets `deleted_at` rather than removing the row — the
+ * migration that added the column also added the `idx_eprints_active` partial
+ * index precisely for `deleted_at IS NULL` lookups. The author, field and
+ * keyword read paths never used it, so a withdrawn eprint kept appearing in
+ * profiles, in the counts beside them, and in tag and keyword browse.
+ *
+ * The tag lookup needs a join rather than a predicate: `user_tags_index` rows
+ * carry only `eprint_uri`, so without joining `eprints_index` a community tag
+ * keeps a deleted eprint reachable.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+import { PostgreSQLAdapter } from '@/storage/postgresql/adapter.js';
+import { EprintsRepository } from '@/storage/postgresql/eprints-repository.js';
+import type { DID } from '@/types/atproto.js';
+
+const AUTHOR = 'did:plc:izttpdp3l6vss5crelt5kcux' as DID;
+
+/** Collapses whitespace so assertions do not depend on SQL formatting. */
+const flat = (sql: string): string => sql.replace(/\s+/g, ' ');
+
+describe('eprint read paths exclude soft-deleted rows', () => {
+  let query: Mock;
+  let repository: EprintsRepository;
+
+  beforeEach(() => {
+    query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    repository = new EprintsRepository({ query } as never);
+  });
+
+  it('filters deleted eprints out of an author listing', async () => {
+    await repository.findByAuthor(AUTHOR);
+    expect(flat(query.mock.calls[0]?.[0] as string)).toMatch(/deleted_at IS NULL/);
+  });
+
+  // The count sits next to the listing in a profile; if it counts deleted rows
+  // the two disagree.
+  it('filters deleted eprints out of the author count', async () => {
+    query.mockResolvedValue({ rows: [{ count: 0 }], rowCount: 1 });
+    await repository.countByAuthor(AUTHOR);
+    expect(flat(query.mock.calls[0]?.[0] as string)).toMatch(/deleted_at IS NULL/);
+  });
+
+  it('filters deleted eprints out of a field listing', async () => {
+    await repository.listUrisByFieldUri(['at://did:plc:x/pub.chive.graph.node/f1']);
+    expect(flat(query.mock.calls[0]?.[0] as string)).toMatch(/deleted_at IS NULL/);
+  });
+
+  // With several field URIs the predicates are OR-ed, so the delete filter has
+  // to bind outside that group or it only applies to the last one.
+  it('keeps the field predicates grouped so the filter applies to all of them', async () => {
+    await repository.listUrisByFieldUri([
+      'at://did:plc:x/pub.chive.graph.node/f1',
+      'at://did:plc:x/pub.chive.graph.node/f2',
+    ]);
+    const sql = flat(query.mock.calls[0]?.[0] as string);
+    expect(sql).toMatch(/WHERE \(.*OR.*\) AND deleted_at IS NULL/);
+  });
+});
+
+describe('tag and keyword browse excludes soft-deleted eprints', () => {
+  let query: Mock;
+  let adapter: PostgreSQLAdapter;
+
+  beforeEach(() => {
+    query = vi.fn().mockResolvedValue({ rows: [{ count: '0' }], rowCount: 1 });
+    adapter = new PostgreSQLAdapter({ query } as never);
+  });
+
+  it('filters the keyword half of the lookup', async () => {
+    await adapter.getEprintUrisForTerm('syntax', 10, 0);
+    for (const call of query.mock.calls) {
+      const sql = flat(call[0] as string);
+      expect(sql).toMatch(/unnest\(keywords\) AS k WHERE .* AND deleted_at IS NULL/);
+    }
+  });
+
+  // A tag row only carries eprint_uri, so the deleted eprint has to be excluded
+  // by joining the eprint table rather than by a predicate on the tag table.
+  it('joins the eprint table to filter the tag half of the lookup', async () => {
+    await adapter.getEprintUrisForTerm('syntax', 10, 0);
+    for (const call of query.mock.calls) {
+      const sql = flat(call[0] as string);
+      expect(sql).toMatch(/user_tags_index t JOIN eprints_index te ON te\.uri = t\.eprint_uri/);
+      expect(sql).toMatch(/te\.deleted_at IS NULL/);
+    }
+  });
+
+  it('applies the filter to the count query as well as the page query', async () => {
+    await adapter.getEprintUrisForTerm('syntax', 10, 0);
+    expect(query.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/unit/utils/ssrf-guard.test.ts
+++ b/tests/unit/utils/ssrf-guard.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the SSRF guard.
+ *
+ * @remarks
+ * The guard stands between a caller-supplied URL and a server-side `fetch`.
+ * The cases that matter are the ones an attacker reaches for: the cloud
+ * metadata endpoint, loopback, RFC 1918 space, and a hostname that resolves
+ * into any of them. Hostname resolution is stubbed so the tests do not depend
+ * on DNS.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { assertFetchableUrl, isPrivateAddress, SsrfBlockedError } from '@/utils/ssrf-guard.js';
+
+const lookupMock = vi.hoisted(() => vi.fn());
+vi.mock('node:dns/promises', () => ({ lookup: lookupMock }));
+
+describe('isPrivateAddress', () => {
+  it.each([
+    ['169.254.169.254', 'cloud metadata'],
+    ['127.0.0.1', 'loopback'],
+    ['10.1.2.3', 'RFC 1918 /8'],
+    ['172.16.0.1', 'RFC 1918 /12'],
+    ['172.31.255.255', 'RFC 1918 /12 upper bound'],
+    ['192.168.1.1', 'RFC 1918 /16'],
+    ['100.64.0.1', 'carrier-grade NAT'],
+    ['0.0.0.0', 'this network'],
+    ['224.0.0.1', 'multicast'],
+    ['::1', 'IPv6 loopback'],
+    ['fd00::1', 'IPv6 unique-local'],
+    ['fe80::1', 'IPv6 link-local'],
+    ['::ffff:169.254.169.254', 'IPv4-mapped metadata'],
+  ])('treats %s as private (%s)', (address) => {
+    expect(isPrivateAddress(address)).toBe(true);
+  });
+
+  it.each([['8.8.8.8'], ['1.1.1.1'], ['2606:4700:4700::1111']])(
+    'treats %s as public',
+    (address) => {
+      expect(isPrivateAddress(address)).toBe(false);
+    }
+  );
+
+  // 172.15 and 172.32 sit just outside the /12 and must not be swept up.
+  it.each([['172.15.0.1'], ['172.32.0.1']])('does not over-block %s', (address) => {
+    expect(isPrivateAddress(address)).toBe(false);
+  });
+});
+
+describe('assertFetchableUrl', () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+    lookupMock.mockResolvedValue([{ address: '93.184.216.34' }]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('accepts a public https URL', async () => {
+    await expect(assertFetchableUrl('https://pds.example.com/xrpc/x')).resolves.toBeInstanceOf(URL);
+  });
+
+  it('rejects plain http by default', async () => {
+    await expect(assertFetchableUrl('http://pds.example.com')).rejects.toThrow(SsrfBlockedError);
+  });
+
+  it('permits plain http when explicitly allowed', async () => {
+    await expect(
+      assertFetchableUrl('http://pds.example.com', { allowHttp: true })
+    ).resolves.toBeInstanceOf(URL);
+  });
+
+  it.each([['file:///etc/passwd'], ['gopher://example.com'], ['ftp://example.com']])(
+    'rejects the %s scheme',
+    async (url) => {
+      await expect(assertFetchableUrl(url)).rejects.toThrow(SsrfBlockedError);
+    }
+  );
+
+  it('rejects a URL carrying embedded credentials', async () => {
+    await expect(assertFetchableUrl('https://user:pw@pds.example.com')).rejects.toThrow(
+      /embedded credentials/
+    );
+  });
+
+  it('rejects an unparseable URL', async () => {
+    await expect(assertFetchableUrl('not a url')).rejects.toThrow(/not parseable/);
+  });
+
+  // Literals are checked directly, without a DNS round trip.
+  it('rejects the cloud metadata address given as a literal', async () => {
+    await expect(assertFetchableUrl('https://169.254.169.254/latest/meta-data/')).rejects.toThrow(
+      /non-public address/
+    );
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects localhost by name', async () => {
+    await expect(assertFetchableUrl('https://localhost/admin')).rejects.toThrow(/non-public/);
+  });
+
+  it('rejects an IPv6 loopback literal', async () => {
+    await expect(assertFetchableUrl('https://[::1]/admin')).rejects.toThrow(/non-public/);
+  });
+
+  // The interesting case: a name the attacker controls that points inward.
+  it('rejects a public hostname that resolves to a private address', async () => {
+    lookupMock.mockResolvedValue([{ address: '169.254.169.254' }]);
+    await expect(assertFetchableUrl('https://evil.example.com')).rejects.toThrow(
+      /non-public address \(169\.254\.169\.254\)/
+    );
+  });
+
+  // A split-horizon answer must not be rescued by one public address.
+  it('rejects when any resolved address is private', async () => {
+    lookupMock.mockResolvedValue([{ address: '93.184.216.34' }, { address: '10.0.0.5' }]);
+    await expect(assertFetchableUrl('https://evil.example.com')).rejects.toThrow(/10\.0\.0\.5/);
+  });
+
+  it('rejects a host that does not resolve', async () => {
+    lookupMock.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(assertFetchableUrl('https://nope.example.com')).rejects.toThrow(
+      /Could not resolve/
+    );
+  });
+
+  it('rejects a host that resolves to nothing', async () => {
+    lookupMock.mockResolvedValue([]);
+    await expect(assertFetchableUrl('https://empty.example.com')).rejects.toThrow(
+      /Could not resolve/
+    );
+  });
+});

--- a/tests/unit/workers/freshness-deletion.test.ts
+++ b/tests/unit/workers/freshness-deletion.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for deletion handling in the freshness worker.
+ *
+ * @remarks
+ * When a freshness check found a record gone from its PDS, the worker emitted
+ * `record.deletion_detected` and returned `deleted: true`. No subscriber to
+ * that event was ever written, so the record stayed in the index indefinitely:
+ * the scan reported a successful deletion detection and deleted nothing. The
+ * source comment admitted the handler was still to be written.
+ *
+ * `PDSSyncService.markAsDeleted` was on this worker's own dependencies the
+ * whole time. The event is still emitted, for plugins that want to observe it,
+ * but it is no longer what performs the deletion.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'src/workers/freshness-worker.ts'), 'utf8');
+
+describe('freshness worker deletion', () => {
+  it('marks the record deleted through the sync service', () => {
+    expect(source).toMatch(/await this\.syncService\.markAsDeleted\(uri, source\)/);
+  });
+
+  it('awaits the deletion before reporting the job result', () => {
+    expect(source).toMatch(/await this\.markAsDeleted\(uri, 'pds_404'\)/);
+  });
+
+  it('logs when the deletion itself fails', () => {
+    expect(source).toMatch(/Failed to mark record as deleted/);
+  });
+
+  // Kept so plugins can observe deletions; it is no longer load-bearing.
+  it('still emits the detection event', () => {
+    expect(source).toMatch(/record\.deletion_detected/);
+  });
+
+  // The comment that described the missing handler should not outlive it.
+  it('no longer claims a handler will do the work', () => {
+    expect(source).not.toMatch(/For now, emit event for handler to process/);
+  });
+});

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -34,8 +34,15 @@ export default defineConfig({
         '**/lexicons/**',
       ],
       thresholds: {
-        // Lowered thresholds to match current coverage levels
-        // TODO: Increase thresholds as coverage improves
+        // These sit below the 80% line / 100%-critical-path bar stated in
+        // CLAUDE.md. They were lowered to match what the suite actually
+        // achieved and the gap was never recorded anywhere but this TODO, so
+        // the stated bar and the enforced one have disagreed since.
+        //
+        // Treat these as a ratchet, not as the target: raise them as coverage
+        // improves rather than lowering them to accommodate a new gap. The
+        // frontend equivalent lives in web/vitest.config.ts and is further
+        // behind still.
         lines: 70,
         functions: 70,
         branches: 58,

--- a/web/lib/atproto/record-creator.test.ts
+++ b/web/lib/atproto/record-creator.test.ts
@@ -342,6 +342,36 @@ describe('createVoteRecord', () => {
       })
     );
   });
+
+  // VoteRecord carries an index signature, so a misnamed wire field typechecks
+  // silently; only an assertion on the emitted record catches the regression.
+  it('writes the rationale to the lexicon comment field', async () => {
+    const agent = createMockAgent();
+
+    await createVoteRecord(agent, {
+      proposalUri: 'at://did:plc:user/pub.chive.graph.fieldProposal/123',
+      vote: 'approve',
+      rationale: 'This is a well-defined field.',
+    });
+
+    const createRecordCall = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(createRecordCall.record.comment).toBe('This is a well-defined field.');
+    expect(createRecordCall.record.rationale).toBeUndefined();
+  });
+
+  it('omits the comment field when no rationale is given', async () => {
+    const agent = createMockAgent();
+
+    await createVoteRecord(agent, {
+      proposalUri: 'at://did:plc:user/pub.chive.graph.fieldProposal/123',
+      vote: 'reject',
+    });
+
+    const createRecordCall = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(createRecordCall.record).not.toHaveProperty('comment');
+  });
 });
 
 describe('deleteRecord', () => {

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -212,13 +212,19 @@ export interface FieldProposalRecord {
 
 /**
  * Vote record as stored in ATProto.
+ *
+ * @remarks
+ * The free-text justification is named `comment` on the wire because that is
+ * what the `pub.chive.graph.vote` lexicon defines and what the indexer reads.
+ * The UI and form schemas call it `rationale`; {@link createVoteRecord} maps
+ * between the two so the naming divergence stops at this boundary.
  */
 export interface VoteRecord {
   [key: string]: unknown;
   $type: 'pub.chive.graph.vote';
   proposalUri: string;
   vote: 'approve' | 'reject' | 'abstain' | 'request-changes';
-  rationale?: string;
+  comment?: string;
   createdAt: string;
 }
 
@@ -702,6 +708,10 @@ export async function createFieldProposalRecord(
  * Records a vote on a governance proposal.
  * The vote is stored in the voter's PDS and indexed by Chive for tallying.
  *
+ * The caller supplies `rationale`, matching the form and UI vocabulary; it is
+ * written to the lexicon's `comment` field, which is the only one the indexer
+ * reads.
+ *
  * @param agent - Authenticated ATProto Agent
  * @param data - Vote data
  * @returns Created record result
@@ -735,7 +745,7 @@ export async function createVoteRecord(
   };
 
   if (data.rationale) {
-    record.rationale = data.rationale;
+    record.comment = data.rationale;
   }
 
   const response = await agent.com.atproto.repo.createRecord({

--- a/web/lib/auth/paper-oauth-popup.test.ts
+++ b/web/lib/auth/paper-oauth-popup.test.ts
@@ -59,6 +59,64 @@ describe('paper-oauth-popup', () => {
     vi.unstubAllGlobals();
   });
 
+  // A completed or cancelled attempt must take its timers with it. They used to
+  // live only in the promise closure, so the success path could not clear them:
+  // the 500ms poll ran forever, and the five-minute timeout stayed armed
+  // against whatever attempt was pending when it eventually fired. A second
+  // authentication started inside that window had its popup closed and its
+  // promise left unsettled — a spinner that never stopped.
+  describe('timer cleanup', () => {
+    it('clears both timers when the attempt is cancelled', async () => {
+      const clearInterval = vi.spyOn(globalThis, 'clearInterval');
+      const clearTimeout = vi.spyOn(globalThis, 'clearTimeout');
+
+      void authenticatePaperInPopup('paper.example.com').catch(() => undefined);
+      await Promise.resolve();
+      cancelPaperAuthentication();
+
+      expect(clearInterval).toHaveBeenCalled();
+      expect(clearTimeout).toHaveBeenCalled();
+
+      clearInterval.mockRestore();
+      clearTimeout.mockRestore();
+    });
+
+    it('leaves no attempt pending after cancellation', async () => {
+      void authenticatePaperInPopup('paper.example.com').catch(() => undefined);
+      await Promise.resolve();
+      cancelPaperAuthentication();
+
+      expect(isPaperAuthInProgress()).toBe(false);
+    });
+
+    // The stranded-spinner case. The two attempts start four minutes apart, so
+    // when the first attempt's five-minute deadline passes the second is still
+    // well inside its own. A stale timer belonging to the first must not settle
+    // or close the second.
+    it('does not disturb a second attempt started after the first ended', async () => {
+      vi.useFakeTimers();
+      try {
+        void authenticatePaperInPopup('first.example.com').catch(() => undefined);
+        await vi.advanceTimersByTimeAsync(0);
+        cancelPaperAuthentication();
+
+        await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+
+        void authenticatePaperInPopup('second.example.com').catch(() => undefined);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(isPaperAuthInProgress()).toBe(true);
+
+        // Cross the first attempt's original deadline. The second attempt's own
+        // deadline is still three minutes away.
+        await vi.advanceTimersByTimeAsync(90 * 1000);
+
+        expect(isPaperAuthInProgress()).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('isPaperAuthInProgress', () => {
     it('returns false initially', () => {
       expect(isPaperAuthInProgress()).toBe(false);

--- a/web/lib/auth/paper-oauth-popup.ts
+++ b/web/lib/auth/paper-oauth-popup.ts
@@ -50,6 +50,38 @@ interface PopupState {
   reject: (error: Error) => void;
   popup: Window | null;
   handle: string;
+  /**
+   * Timers belonging to this attempt.
+   *
+   * @remarks
+   * These used to live only in the promise closure, so the success path could
+   * not clear them. The poll interval then ran forever, and the five-minute
+   * timeout stayed armed against whatever attempt was pending when it finally
+   * fired — a second authentication started within five minutes had its popup
+   * closed and its promise left unsettled, which the UI showed as a spinner
+   * that never stopped.
+   */
+  checkClosedTimer: ReturnType<typeof setInterval> | null;
+  timeoutTimer: ReturnType<typeof setTimeout> | null;
+}
+
+/**
+ * Clears the pending attempt and both of its timers.
+ *
+ * @returns The state that was pending, or null if there was none
+ */
+function takePendingPopup(): PopupState | null {
+  const state = pendingPopup;
+  pendingPopup = null;
+
+  if (state?.checkClosedTimer) {
+    clearInterval(state.checkClosedTimer);
+  }
+  if (state?.timeoutTimer) {
+    clearTimeout(state.timeoutTimer);
+  }
+
+  return state;
 }
 
 /**
@@ -96,7 +128,7 @@ function handlePaperOAuthMessage(event: MessageEvent): void {
   }
 
   const { resolve, reject, popup } = pendingPopup;
-  pendingPopup = null;
+  takePendingPopup();
 
   // Close the popup if still open
   if (popup && !popup.closed) {
@@ -188,23 +220,23 @@ export async function authenticatePaperInPopup(paperHandle: string): Promise<Pap
       reject,
       popup,
       handle: paperHandle,
+      checkClosedTimer: null,
+      timeoutTimer: null,
     };
 
     // Check if popup was closed without completing auth
     const checkClosed = setInterval(() => {
       if (popup.closed && pendingPopup) {
-        clearInterval(checkClosed);
-        pendingPopup = null;
+        takePendingPopup();
         reject(new Error('Popup was closed before authentication completed'));
       }
     }, 500);
 
     // Timeout after 5 minutes
-    setTimeout(
+    const timeoutTimer = setTimeout(
       () => {
         if (pendingPopup) {
-          clearInterval(checkClosed);
-          pendingPopup = null;
+          takePendingPopup();
           if (!popup.closed) {
             popup.close();
           }
@@ -213,6 +245,11 @@ export async function authenticatePaperInPopup(paperHandle: string): Promise<Pap
       },
       5 * 60 * 1000
     );
+
+    if (pendingPopup) {
+      pendingPopup.checkClosedTimer = checkClosed;
+      pendingPopup.timeoutTimer = timeoutTimer;
+    }
   });
 }
 
@@ -227,7 +264,7 @@ export async function authenticatePaperInPopup(paperHandle: string): Promise<Pap
 export function cancelPaperAuthentication(): void {
   if (pendingPopup) {
     const { popup, reject } = pendingPopup;
-    pendingPopup = null;
+    takePendingPopup();
 
     if (popup && !popup.closed) {
       popup.close();

--- a/web/lib/hooks/use-governance.test.ts
+++ b/web/lib/hooks/use-governance.test.ts
@@ -15,6 +15,7 @@ import {
   governanceKeys,
   useMyEditorStatus,
   useEditorStatus,
+  useMyVote,
   useTrustedEditors,
   useRequestElevation,
   useGrantDelegation,
@@ -26,6 +27,7 @@ import {
 // Mock functions using vi.hoisted for proper hoisting
 const {
   mockGetEditorStatus,
+  mockGetUserVote,
   mockAuthGetEditorStatus,
   mockListTrustedEditors,
   mockRequestElevation,
@@ -34,6 +36,7 @@ const {
   mockRevokeRole,
 } = vi.hoisted(() => ({
   mockGetEditorStatus: vi.fn(),
+  mockGetUserVote: vi.fn(),
   mockAuthGetEditorStatus: vi.fn(),
   mockListTrustedEditors: vi.fn(),
   mockRequestElevation: vi.fn(),
@@ -48,9 +51,7 @@ vi.mock('@/lib/api/client', () => ({
       chive: {
         governance: {
           getEditorStatus: mockGetEditorStatus,
-          requestElevation: mockRequestElevation,
-          grantDelegation: mockGrantDelegation,
-          revokeDelegation: mockRevokeDelegation,
+          getUserVote: mockGetUserVote,
         },
       },
     },
@@ -61,6 +62,9 @@ vi.mock('@/lib/api/client', () => ({
         governance: {
           getEditorStatus: mockAuthGetEditorStatus,
           listTrustedEditors: mockListTrustedEditors,
+          requestElevation: mockRequestElevation,
+          grantDelegation: mockGrantDelegation,
+          revokeDelegation: mockRevokeDelegation,
           revokeRole: mockRevokeRole,
         },
       },
@@ -104,6 +108,15 @@ const createMockTrustedEditorsResponse = (editors = [createMockEditorStatus()]) 
 describe('governanceKeys', () => {
   it('generates all key', () => {
     expect(governanceKeys.all).toEqual(['governance']);
+  });
+
+  it('generates proposals key as a prefix of every proposals list key', () => {
+    // Invalidation after a vote relies on this prefix relationship: proposalsList()
+    // with no params carries a trailing `undefined` that partial-matches nothing.
+    const params = { status: 'open' as const };
+    expect(governanceKeys.proposals()).toEqual(['governance', 'proposals']);
+    expect(governanceKeys.proposalsList(params).slice(0, 2)).toEqual(governanceKeys.proposals());
+    expect(governanceKeys.proposalsList()).toEqual(['governance', 'proposals', 'list', undefined]);
   });
 
   it('generates trustedEditors key', () => {
@@ -243,6 +256,64 @@ describe('useEditorStatus', () => {
 
     expect(result.current.fetchStatus).toBe('idle');
     expect(mockGetEditorStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('useMyVote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null for the #noVote sentinel', async () => {
+    mockGetUserVote.mockResolvedValueOnce({
+      data: { vote: { $type: 'pub.chive.governance.getUserVote#noVote' } },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useMyVote('proposal-1', 'did:plc:user123'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it('returns the vote for the #voteView member', async () => {
+    mockGetUserVote.mockResolvedValueOnce({
+      data: {
+        vote: {
+          $type: 'pub.chive.governance.getUserVote#voteView',
+          id: 'vote-1',
+          uri: 'at://did:plc:user123/pub.chive.graph.vote/vote-1',
+          cid: 'bafyvote',
+          proposalUri: 'at://did:plc:author/pub.chive.graph.nodeProposal/proposal-1',
+          voterDid: 'did:plc:user123',
+          voterRole: 'community-member',
+          vote: 'approve',
+          weight: 1,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useMyVote('proposal-1', 'did:plc:user123'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.id).toBe('vote-1');
+    expect(result.current.data?.vote).toBe('approve');
+    expect(mockGetUserVote).toHaveBeenCalledWith({
+      proposalId: 'proposal-1',
+      userDid: 'did:plc:user123',
+    });
   });
 });
 

--- a/web/lib/hooks/use-governance.ts
+++ b/web/lib/hooks/use-governance.ts
@@ -34,6 +34,7 @@ import { APIError } from '@/lib/errors';
 import { api, authApi } from '@/lib/api/client';
 import { getCurrentAgent } from '@/lib/auth/oauth-client';
 import { createVoteRecord, createNodeProposalRecord } from '@/lib/atproto/record-creator';
+import type { VoteView as UserVoteView } from '@/lib/api/generated/types/pub/chive/governance/getUserVote';
 import type {
   Vote as RecordCreatorVote,
   NodeProposal as RecordCreatorNodeProposal,
@@ -381,9 +382,20 @@ export function useMyVote(proposalId: string, userDid: string, options: UseGover
     queryFn: async (): Promise<Vote | null> => {
       try {
         const response = await api.pub.chive.governance.getUserVote({ proposalId, userDid });
-        // The API returns a VoteView with a different $type discriminator than listVotes.
-        // Cast to Vote since they share the same structural shape.
-        return (response.data?.vote as Vote) ?? null;
+        const vote = response.data?.vote;
+        // The handler answers "this user has not voted" with a `#noVote` sentinel
+        // rather than omitting the field, so the union must be narrowed on its
+        // discriminator. Accepting the sentinel as a cast vote would hide the
+        // voting UI from every user who has yet to vote.
+        if (vote?.$type !== 'pub.chive.governance.getUserVote#voteView') {
+          return null;
+        }
+        // getUserVote#voteView and listVotes#voteView (exported as Vote) are the
+        // same shape under different discriminators, so re-tag rather than reshape.
+        return {
+          ...(vote as UserVoteView),
+          $type: 'pub.chive.governance.listVotes#voteView',
+        };
       } catch (error) {
         if (error instanceof APIError && error.statusCode === 404) {
           return null;
@@ -636,8 +648,10 @@ export function useCreateVote() {
         queryClient.invalidateQueries({
           queryKey: governanceKeys.votes(proposalId),
         });
+        // Invalidate the whole proposals subtree: proposalsList() with no params
+        // yields a trailing `undefined` element that matches no cached list query.
         queryClient.invalidateQueries({
-          queryKey: governanceKeys.proposalsList(),
+          queryKey: governanceKeys.proposals(),
         });
       }, 1000);
     },
@@ -799,7 +813,7 @@ export function useRequestElevation() {
   return useMutation({
     mutationFn: async (): Promise<ElevationResult> => {
       try {
-        const response = await api.pub.chive.governance.requestElevation({
+        const response = await authApi.pub.chive.governance.requestElevation({
           targetRole: 'trusted-editor',
         });
         return response.data;
@@ -840,7 +854,7 @@ export function useGrantDelegation() {
   return useMutation({
     mutationFn: async (input: GrantDelegationInput): Promise<DelegationResult> => {
       try {
-        const response = await api.pub.chive.governance.grantDelegation({
+        const response = await authApi.pub.chive.governance.grantDelegation({
           delegateDid: input.delegateDid,
           collections: input.collections,
           daysValid: input.daysValid ?? 365,
@@ -883,7 +897,7 @@ export function useRevokeDelegation() {
   return useMutation({
     mutationFn: async (input: RevokeDelegationInput): Promise<DelegationResult> => {
       try {
-        const response = await api.pub.chive.governance.revokeDelegation({
+        const response = await authApi.pub.chive.governance.revokeDelegation({
           delegationId: input.delegationId,
         });
         return response.data;

--- a/web/lib/metadata/EntityHeadTags.tsx
+++ b/web/lib/metadata/EntityHeadTags.tsx
@@ -50,7 +50,11 @@ export function EntityHeadTags({ tags }: EntityHeadTagsProps) {
           <script
             key={`ldjson-${i}`}
             type={tag.type}
-            // eslint-disable-next-line react/no-danger -- JSON-LD payload is built server-side from trusted sources
+            // The underlying values are user-controlled PDS fields, not trusted
+            // input. They are safe here only because serializeJsonLd escapes
+            // `<`, `>` and `&`, which makes an early `</script>` unrepresentable
+            // in the serialized JSON.
+            // eslint-disable-next-line react/no-danger -- payload escaped by serializeJsonLd
             dangerouslySetInnerHTML={{ __html: tag.content }}
           />
         );

--- a/web/lib/metadata/entity-metadata.test.ts
+++ b/web/lib/metadata/entity-metadata.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for JSON-LD serialization in entity head tags.
+ *
+ * @remarks
+ * The JSON-LD payload is rendered through `dangerouslySetInnerHTML` into a
+ * `<script type="application/ld+json">` element, and it carries eprint titles,
+ * abstracts and author names that come from user-controlled PDS records.
+ * `JSON.stringify` does not escape `<`, so a title containing `</script>` used
+ * to close the element early and let everything after it parse as markup —
+ * stored XSS on every page that rendered the record.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { buildEntityHeadTags } from './entity-metadata';
+
+const jsonLdOf = (title: string, description?: string): string => {
+  const tags = buildEntityHeadTags({
+    atUri: 'at://did:plc:abc/pub.chive.eprint.submission/xyz',
+    canonicalUrl: 'https://chive.pub/eprint/xyz',
+    title,
+    description,
+    entityType: 'research',
+  });
+  const script = tags.find((tag) => tag.kind === 'script');
+  expect(script).toBeDefined();
+  return (script as { content: string }).content;
+};
+
+describe('JSON-LD serialization', () => {
+  it('does not emit a literal closing script tag from a hostile title', () => {
+    const payload = jsonLdOf('Innocent</script><script>alert(1)</script>');
+    expect(payload).not.toContain('</script>');
+    expect(payload).not.toContain('<script>');
+  });
+
+  it('escapes angle brackets and ampersands as unicode escapes', () => {
+    const payload = jsonLdOf('a < b & c > d');
+    expect(payload).toContain('\\u003c');
+    expect(payload).toContain('\\u003e');
+    expect(payload).toContain('\\u0026');
+    expect(payload).not.toMatch(/[<>&]/);
+  });
+
+  it('escapes a hostile description too', () => {
+    const payload = jsonLdOf('Fine title', 'abstract </script><img src=x onerror=alert(1)>');
+    expect(payload).not.toContain('</script>');
+    expect(payload).not.toContain('<img');
+  });
+
+  // The escaping must not change what the JSON means: a consumer parsing the
+  // payload has to see the original characters back.
+  it('round-trips to the original string', () => {
+    const title = 'a < b & c > d </script>';
+    const parsed = JSON.parse(jsonLdOf(title)) as { name?: string; headline?: string };
+    expect(parsed.headline ?? parsed.name).toBe(title);
+  });
+
+  // U+2028/U+2029 are legal in JSON but terminate a line in JavaScript source.
+  it('escapes JavaScript line terminators', () => {
+    const payload = jsonLdOf('line break here');
+    expect(payload).not.toContain(' ');
+    expect(payload).not.toContain(' ');
+    expect(payload).toContain('\\u2028');
+  });
+});

--- a/web/lib/metadata/entity-metadata.ts
+++ b/web/lib/metadata/entity-metadata.ts
@@ -237,10 +237,35 @@ export function buildEntityHeadTags(input: EntityMetadataInput): EntityHeadTag[]
   tags.push({
     kind: 'script',
     type: 'application/ld+json',
-    content: JSON.stringify(buildSchemaOrg(input)),
+    content: serializeJsonLd(buildSchemaOrg(input)),
   });
 
   return tags;
+}
+
+/**
+ * Serializes a JSON-LD payload for embedding in a `<script>` element.
+ *
+ * @param payload - Schema.org object to serialize
+ * @returns JSON text safe to place inside `<script type="application/ld+json">`
+ *
+ * @remarks
+ * `JSON.stringify` escapes what JSON requires, which does not include `<`. The
+ * payload carries eprint titles, abstracts and author names that originate in
+ * user-controlled PDS records, so a title containing `</script>` closed the
+ * element and everything after it parsed as markup — stored XSS on every page
+ * that rendered the record. Escaping `<`, `>` and `&` as unicode escapes keeps
+ * the JSON semantically identical while making an early `</script>`
+ * unrepresentable. U+2028 and U+2029 are escaped too: they are valid in JSON
+ * but are line terminators in JavaScript source.
+ */
+function serializeJsonLd(payload: unknown): string {
+  return JSON.stringify(payload)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
 }
 
 /**

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -17,6 +17,22 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
+      // Frontend coverage was measured by nobody: this config declared no
+      // thresholds and CI ran the suite without `--coverage` at all, so the
+      // stated 70% bar in CLAUDE.md was unenforced end to end and the real
+      // figure had drifted to roughly 41% of lines.
+      //
+      // These numbers are set just under what the suite currently achieves, so
+      // they act as a ratchet against further slippage rather than as the bar
+      // the project actually wants. Raising them toward 70% is real test-writing
+      // work; pretending the bar is already met by declaring it here would just
+      // break every pull request on debt that predates the threshold.
+      thresholds: {
+        lines: 40,
+        statements: 40,
+        branches: 72,
+        functions: 43,
+      },
       exclude: ['node_modules/', '.next/', 'out/', 'tests/', '**/*.test.{ts,tsx}', '**/types/**'],
     },
     // Inline dependencies that have incomplete package.json exports


### PR DESCRIPTION
## Summary

Promotes 0.8.0 to main: fourteen remediation changes from the 0.8.0 backlog, plus the version bump and changelog.

Full detail is in `CHANGELOG.md`. The headline items:

**Security.** Service auth tokens were never scoped to a method, so a token minted for `pub.chive.metrics.recordView` was accepted at `pub.chive.admin.deleteContent`. PDS registration was unauthenticated and fetched caller-supplied URLs with no private-address block. The E2E auth bypass — request headers granting administrator — was compiled into production behind an unset environment variable. Stored XSS was possible through JSON-LD built from PDS-controlled titles. There was no security scanning of any kind.

**Silent no-ops.** A recurring shape: `/ready` answered 200 with its datastores down, because a fast-rejecting probe was recorded as passing. Telemetry was never started, so every span recorded nothing. Metrics had no scrape endpoint. Freshness-detected deletions were announced to a subscriber that was never written. Precomputed graph results had no reader. Admin cancellation flipped a flag while the loop ran to completion.

**Data integrity.** The admin reindex rebuilt search documents from nine fields and wiped the rest. Soft-deleted eprints appeared in profiles and browse. A verified ORCID was overwritten by the next profile index. Endorsement views returned the literal string `'placeholder'` for a required CID.

**Removed.** The 2FA layer — 3,000 lines, unreachable, no endpoint to enrol through.

## Deployment risk

Merging this deploys to production. Four things change behaviour in ways worth watching rather than assuming:

1. **Service tokens are now method-scoped.** Any client minting a token with an `lxm` claim for one method and calling another has been succeeding and will now get 401. That is the vulnerability being closed, but it will surface as sudden auth failures on calls that worked yesterday. Worth checking the frontend's token minting and any operational scripts.
2. **`/metrics` is served unauthenticated by default.** The API sits behind a public Traefik router, so either set `METRICS_TOKEN` or block the path at the edge before this is exposed.
3. **The scheduled health check now probes `/ready`.** It will go from always-green to red whenever a datastore is genuinely degraded — the point of the change, but the failure-alert job fires on it.
4. **Telemetry starts exporting** to `alloy:4318` in production, where it previously exported nothing. Worth watching Alloy's ingest rather than assuming it absorbs the new volume.

`GRAPH_PDS_DID` validation, which fails startup on a malformed value, is safe here: `deploy-app.yml` deliberately does not pass that variable, so the container takes the validated built-in default.

Two behaviours will produce output for the first time and have therefore never been exercised against real data: `getCommunities` and the collaboration/recommendation queries have only ever returned empty.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update

## How Has This Been Tested?

Each of the fourteen changes carried its own tests and passed the full 15-check CI suite on its own pull request before merging to staging. On this branch: 198 files, 4,418 tests passing; typecheck and lint clean; coverage thresholds met.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required) — passed on each contributing PR
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data) — this release removes the one path that could have violated it
- [x] Indexes can be rebuilt from firehose — improved: seven collections are now recoverable by manual reindex
- [x] PDS source is tracked for staleness detection

### Breaking Changes

- [x] Marked breaking above; each is described in the deployment-risk section
- [ ] Migration path documented

## Note on versioning

0.8.0 rather than 0.7.2 because the release carries breaking changes, which in 0.x semantics belong in the minor slot.

The 0.8.0 *backlog* is 175 items and 49 are done, so this ships under a version number whose planning document is far from complete. The alternative — holding fourteen merged fixes, including four security issues, until the remaining 126 items land — is worse. The remaining backlog needs a subsequent release; if you would rather this were 0.7.2 and the number reserved, the tag is trivial to move before it is announced anywhere.
