### PR TITLE
Deny the metrics endpoint at the public edge (0.8.1 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-26
+
+### Security
+
+- The Prometheus scrape endpoint is no longer reachable from the public internet. `/metrics` shipped in 0.8.0 unauthenticated by default, which is the usual arrangement for a metrics port on a private network — but Chive's API is fronted by two public Traefik routers, so on this deployment it was world-readable: request rates, per-endpoint latencies and error counts, and queue depths. It was serving 200 to anonymous requests after 0.8.0 deployed. Both public routes now deny the path at the edge, which holds whether or not `METRICS_TOKEN` is configured, and Prometheus scrapes the API directly over the compose network where it never traverses Traefik.
+
 ## [0.8.0] - 2026-08-25
 
 Remediation sweep against the 0.8.0 backlog. Fourteen changes, each with tests

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -339,6 +339,29 @@ services:
       - "traefik.http.middlewares.api-ratelimit.ratelimit.average=2000"
       - "traefik.http.middlewares.api-ratelimit.ratelimit.burst=500"
       - "traefik.http.routers.api.middlewares=api-ratelimit"
+      # Block /metrics from the public internet.
+      #
+      # The Prometheus scrape endpoint is unauthenticated by default so an
+      # in-network collector needs no credentials, which is the usual
+      # arrangement for a metrics port on a private network. Both routers above
+      # are public, so without this the endpoint is world-readable: request
+      # rates, latencies and error counts per endpoint, and queue depths.
+      #
+      # Prometheus reaches the API directly over the compose network at
+      # chive-api:3000/metrics and never traverses Traefik, so denying here
+      # costs nothing internally. The higher priority is required to beat the
+      # broader PathPrefix(`/api`) rule.
+      #
+      # Setting METRICS_TOKEN additionally enforces a bearer token at the
+      # application layer; this is the network half of the same control, and
+      # does not depend on that variable being set.
+      - "traefik.http.routers.api-metrics.rule=(Host(`api.${DOMAIN}`) && Path(`/metrics`)) || (Host(`${DOMAIN}`) && Path(`/api/metrics`))"
+      - "traefik.http.routers.api-metrics.priority=200"
+      - "traefik.http.routers.api-metrics.entrypoints=websecure"
+      - "traefik.http.routers.api-metrics.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.api-metrics.service=api"
+      - "traefik.http.middlewares.metrics-deny.ipallowlist.sourcerange=127.0.0.1/32"
+      - "traefik.http.routers.api-metrics.middlewares=metrics-deny"
 
   # ---------------------------------------------------------------------------
   # Chive Indexer (Firehose Consumer)

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -18,6 +18,18 @@ scrape_configs:
       - targets: ['otel-collector:8888']
 
   # PostgreSQL exporter (if deployed)
+  # The API's own metrics: request rate, latency and error counts, plus the
+  # eprint and database counters. Nothing scraped these before — the endpoint
+  # did not exist, and the only exposure was an admin-authenticated XRPC method
+  # returning JSON that Prometheus can neither authenticate against nor parse.
+  #
+  # Scraped over the compose network, so it never traverses Traefik and needs no
+  # credential; the public routers deny this path.
+  - job_name: 'chive-api'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['chive-api:3000']
+
   - job_name: 'postgres'
     static_configs:
       - targets: ['postgres-exporter:9187']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/tests/unit/config/metrics-exposure.test.ts
+++ b/tests/unit/config/metrics-exposure.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the network exposure of the Prometheus scrape endpoint.
+ *
+ * @remarks
+ * `/metrics` is unauthenticated by default so an in-network collector needs no
+ * credentials — the usual arrangement for a metrics port on a private network.
+ * Chive's API is fronted by two public Traefik routers, so on this deployment
+ * that default made the endpoint world-readable: request rates, per-endpoint
+ * latencies and error counts, and queue depths. It was verified returning 200
+ * from the public internet after v0.8.0 shipped.
+ *
+ * The fix is a network control rather than an application one, so that it holds
+ * whether or not `METRICS_TOKEN` is configured. Prometheus reaches the API
+ * directly over the compose network and never traverses Traefik, so denying at
+ * the edge costs nothing internally.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const read = (relative: string): string => readFileSync(join(process.cwd(), relative), 'utf8');
+
+describe('public metrics exposure', () => {
+  const compose = read('docker/docker-compose.prod.yml');
+
+  it('defines a router for the metrics path', () => {
+    expect(compose).toMatch(/routers\.api-metrics\.rule=.*Path\(`\/metrics`\)/);
+  });
+
+  // Both public routers serve the API, so the path has to be denied on each.
+  it('covers the path-prefixed route as well as the api subdomain', () => {
+    expect(compose).toMatch(/Path\(`\/api\/metrics`\)/);
+  });
+
+  // Without a higher priority the broader PathPrefix(`/api`) rule wins and the
+  // deny never applies.
+  it('outranks the broader api route', () => {
+    expect(compose).toMatch(/routers\.api-metrics\.priority=200/);
+  });
+
+  it('restricts the source range so public requests are refused', () => {
+    expect(compose).toMatch(/middlewares\.metrics-deny\.ipallowlist\.sourcerange=127\.0\.0\.1\/32/);
+    expect(compose).toMatch(/routers\.api-metrics\.middlewares=metrics-deny/);
+  });
+});
+
+describe('internal scraping still works', () => {
+  const prometheus = read('docker/prometheus.yml');
+
+  it('scrapes the API over the compose network', () => {
+    expect(prometheus).toMatch(/job_name: 'chive-api'/);
+    expect(prometheus).toMatch(/targets: \['chive-api:3000'\]/);
+  });
+
+  it('scrapes the metrics path', () => {
+    expect(prometheus).toMatch(/metrics_path: \/metrics/);
+  });
+
+  // The target is a compose service name, which only resolves inside the
+  // network — so the scrape never passes through the router that denies it.
+  it('does not scrape through the public hostname', () => {
+    expect(prometheus).not.toMatch(/targets: \['(api\.)?chive\.pub'\]/);
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

**0.8.1 — hotfix for an exposure that 0.8.0 introduced and that is live right now.**

v0.8.0 added `GET /metrics` (OBS-3: the service had Prometheus metrics and nothing could scrape them). The endpoint is unauthenticated by default, which is the normal arrangement for a metrics port on a private network — and which I flagged in that PR and in the release notes as requiring either `METRICS_TOKEN` or an edge block.

Neither was in place at deploy. I verified after the release: `https://chive.pub/api/metrics` returned **200 to an anonymous request**. It exposes request rates, per-endpoint latencies and error counts, and queue depths. No user content and no credentials, but more than should be public.

This is my regression: I shipped the endpoint and left its protection as a note in a PR body rather than as code.

## The fix

A network control rather than an application one, so it holds regardless of whether `METRICS_TOKEN` is ever set:

- A dedicated Traefik router matches `/metrics` on the `api.` subdomain and `/api/metrics` on the main domain — both public routes serve the API, so both need denying.
- It carries `priority=200` so it beats the broader `PathPrefix(`/api`)` rule; without that the deny never applies.
- The middleware restricts the source range to loopback, so public requests are refused.

Prometheus reaches the API at `chive-api:3000` over the compose network and never traverses Traefik, so denying at the edge costs nothing internally. That target did not exist before, so this also adds it — the metrics 0.8.0 made scrapeable were still not being scraped.

## Related Issues

Regression from OBS-3 in v0.8.0 (#108). This is a hotfix branched from `staging`, not from the wave queue, so it can ship without waiting on eleven stacked pull requests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

7 tests asserting both halves: the router matches both public paths, outranks the broader rule, and restricts the source range; and Prometheus scrapes `chive-api:3000/metrics` by compose service name rather than through a public hostname — which is what keeps the internal path clear of the deny.

These assert configuration, because that is what the defect is. The behavioural check is the one already run against production: `curl https://chive.pub/api/metrics` returned 200, and should return 403 after this deploys. I will verify that rather than assume it.

Full unit suite: 199 files, 4,425 tests passing. Typecheck and lint clean.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] N/A — network configuration; no data flow changes
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented

## Note for review

`ipallowlist` is a Traefik v3 label. If this deployment runs Traefik v2 the key is `ipwhitelist`, and the label would be silently ignored — leaving the endpoint open while the tests here still pass, since they assert the compose file's contents rather than Traefik's behaviour. That is the one thing worth confirming against the running Traefik version before trusting this, and it is why I intend to re-run the `curl` against production after the deploy rather than treat the merge as the end of it.
