### PR TITLE
Fetch the trending page in one query and hydrate its authors once (wave 28)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scanners: vuln,secret,misconfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-26
+
+### Security
+
+- The Prometheus scrape endpoint is no longer reachable from the public internet. `/metrics` shipped in 0.8.0 unauthenticated by default, which is the usual arrangement for a metrics port on a private network — but Chive's API is fronted by two public Traefik routers, so on this deployment it was world-readable: request rates, per-endpoint latencies and error counts, and queue depths. It was serving 200 to anonymous requests after 0.8.0 deployed. Both public routes now deny the path at the edge, which holds whether or not `METRICS_TOKEN` is configured, and Prometheus scrapes the API directly over the compose network where it never traverses Traefik.
+
+## [0.8.0] - 2026-08-25
+
+Remediation sweep against the 0.8.0 backlog. Fourteen changes, each with tests
+pinning the specific failure. A recurring shape runs through them: work that
+ran, reported success, and had no effect — telemetry recording into an SDK that
+was never started, metrics nothing could scrape, deletions announced to a
+subscriber that was never written, precomputed graph results with no reader.
+
+### Security
+
+- Service auth tokens are verified against the method being called. A JWT's `lxm` claim scopes it to one lexicon method, and the verifier has always accepted a method to check against — the middleware passed none. The claim was decoded, copied into `user.scopes`, which nothing reads, and never enforced, so a token minted for `pub.chive.metrics.recordView` was accepted at `pub.chive.admin.deleteContent`. Any holder of any valid token could call any endpoint their roles allowed.
+- PDS registration requires authentication and is bound to the caller's own identity. The handler was `auth: 'optional'`, and a registered host is later enumerated by the scanner, which indexes whatever repos that host claims to hold. The ownership check resolves the caller's DID document and fails open when resolution is inconclusive, which is recorded rather than hidden.
+- Server-side request forgery through PDS registration and `did:web` resolution is blocked. Both fetched caller-supplied hosts with no scheme allowlist, no private-address block and no redirect cap, reaching cloud metadata at `169.254.169.254`, loopback and RFC 1918 services. Every resolved address is checked, not just the hostname, and redirects are refused.
+- The E2E authentication bypass cannot be enabled in production. `X-E2E-Auth-Did` supplies an identity and `X-E2E-Auth-Admin: true` grants administrative access, with both header names in the production CORS allowlist; an unset environment variable was the only thing between a deploy and an open admin door. It is now gated on `NODE_ENV` as well, and the process refuses to start if the flag is set in production.
+- Stored cross-site scripting through JSON-LD is closed. The Schema.org payload is rendered with `dangerouslySetInnerHTML` and carries eprint titles, abstracts and author names taken from user-controlled PDS records; `JSON.stringify` does not escape `<`, so a title containing `</script>` closed the element and everything after it parsed as markup.
+- CodeQL, a dependency audit and a Trivy filesystem scan now run on every pull request and weekly. The repository had no scanning of any kind despite the architecture overview describing some. CodeQL gates; the dependency audit reports without failing, because the tree carries 343 known advisories (8 critical, 141 high) and a gate nobody can satisfy is one that gets disabled. Dependabot opens the update pull requests.
+
+### Fixed
+
+- `/ready` reports the state of its dependencies. Each probe was raced against a timeout with `.catch(() => undefined)` applied to the racer, so a dependency refusing connections rejected fast, resolved to `undefined`, and was recorded as passing. The endpoint answered 200 with PostgreSQL, Elasticsearch or Neo4j down, and Kubernetes kept routing to the pod. Only a probe that hung past the timeout could ever trip it.
+- The admin full reindex no longer destroys indexed fields. It rebuilt each search document from a hand-rolled nine-field projection, and Elasticsearch replaces whole documents rather than merging, so DOIs, publication status, external identifiers, funding, repositories, related works, supplementary materials, licence and document metadata were wiped from every eprint the reindex touched. It now uses the same mapper as the reindex script. Facets remain empty, because they live on the PDS record and not in the index.
+- Records deleted from their PDS are removed from the index. The freshness worker emitted `record.deletion_detected` and returned success; no subscriber to that event was ever written, so the scan reported a deletion and deleted nothing. `PDSSyncService.markAsDeleted` was already among the worker's own dependencies.
+- Telemetry is started. `initTelemetry` was referenced only in its own documentation, so the OpenTelemetry SDK never initialised, every `withSpan` executed its callback recording nothing, and no OTLP export happened. Both the API and the firehose indexer start it, since they are separate processes.
+- Request rate, latency and error metrics exist and can be scraped. The counter and histogram had no emission site — the middleware computed status and duration and only logged them — and the only exposure was an admin-authenticated XRPC method returning JSON, which Prometheus can neither authenticate against nor parse. `GET /metrics` now serves the exposition format, exempt from rate limiting, with optional bearer-token protection.
+- Cancelling a long-running admin operation cancels it. `startOperation` returns an `AbortSignal` that all seven trigger handlers discarded, so `cancelBackfill` flipped the operation's state in Redis while the loop ran to completion. The four handlers driving a loop locally now honour it, including both loops of the reindex and citation extraction.
+- Soft-deleted eprints no longer appear in author profiles, the counts beside them, field browse, or tag and keyword browse. The partial index the soft-delete migration created for exactly this filter was never used by any read path. The tag lookup needed a join rather than a predicate, since a tag row carries only the eprint URI.
+- Eprint deletion is reversible and reconcilable. It hard-deleted the PostgreSQL row and then removed the Elasticsearch document best-effort; when that failed the row was already gone, so nothing recorded that a document still needed removing and no sweep could find it. Deletion now marks the row, and `reconcileDeletedFromSearch` re-issues the removal.
+- A verified ORCID iD survives indexing. Verification wrote only to `authors_index`, which is rebuilt from the firehose, and both profile upserts assigned `orcid` straight from the incoming record — so a verified value was overwritten, usually with null, on the next profile update. An author who verified before being indexed lost it outright. Verification is now stored in its own table and seeded into new rows.
+- The child-facet hierarchy resolves. `getChildFacets` asked Cypher for `*1..$maxDepth`; a parameter is not accepted as a variable-length bound, so the query was a syntax error and the method threw on every call.
+- Recommendation and collaboration queries match the labels the write side creates. Fields are created as `(:Node:Field)` and were read as `(:FieldNode)`; authors are created as `(:Node:Object:Person)` keyed on `metadata.did` and were read as `(:Author {did})`, so collaboration strength was null for every pair of authors who had in fact collaborated. Cypher returns no rows for a label that matches nothing, so both read as "no data yet". Interest-based paths remain empty: nothing creates `INTERESTED_IN` at all.
+- Precomputed community and trending results are read. Two handlers looked for `services.graphAlgorithmCache`, which `ServerConfig` had no field for and nothing constructed, so `getCommunities` returned an empty list on every request while the graph algorithm job wrote results nobody read.
+- Trending pagination advances. The cursor was parsed only to build the next cursor and never passed to either data source, so every page returned the same entries while the cursor climbed.
+- The ORCID verification flow resolves. The callback is registered at `/v1/auth/orcid/callback` while the default redirect URI pointed at `/api/v1/...`, a prefix only one Traefik router strips.
+- Methods declared as procedures are served on POST. The router ignored a handler's `type` when no lexicon was registered, so a `procedure` was mounted as GET and its POST callers received 404. `pub.chive.claiming.dismissSuggestion`, the concrete victim, also gains the lexicon it never had.
+- Author autocomplete issues one query per page instead of one per hit — up to 75 sequential round trips per keystroke — and faceted browse one query per facet instead of one per edge.
+- Search is billed against the relaxed rate-limit tier. The autocomplete list named `pub.chive.search.searchSubmissions`, a method that does not exist; the real NSID is `pub.chive.eprint.searchSubmissions`, so search never matched and every anonymous request took the low tier.
+- Endorsement views carry the record CID. Handlers returned the literal string `'placeholder'` for a field the lexicon marks required, with a comment claiming the CID was not stored — it has always been stored, and the queries simply did not select it. Optimistic-concurrency writes were comparing against a constant that could never match.
+- The WhiteWind backlink plugin tracks `com.whtwnd.blog.entry`, the collection that exists. It subscribed to `com.whitewind.blog.entry` and so could never have matched a post.
+- The governance PDS DID is validated at load. Every environment file set `did:plc:chive-governance`, which is not a PLC identifier, overriding the correct default — so the governance sync resolved nothing and imported an empty graph. An ill-formed value now fails startup rather than being carried.
+- Thread loads no longer scan the whole review table. `parent_comment` carries a foreign key with no index, and PostgreSQL does not index foreign keys automatically.
+- A second paper login within five minutes no longer hangs. The popup's poll interval and timeout lived only in the promise closure, so the success path could not clear them and a stale timeout closed the next attempt's popup, leaving its promise unsettled.
+
+### Changed
+
+- Manual reindex accepts every collection the firehose indexes. Three lists described "the collections we index" and disagreed; `sync.indexRecord` accepted 13 while the event processor handled 20, so seven were unrecoverable by manual reindex — `pub.chive.graph.edgeProposal` among them. One list now serves both, derived from the event processor's own dispatch and asserted by test.
+- The scheduled health check probes `/ready` as well as `/api/health`. The latter is a static 200 that reports nothing about dependencies, so a datastore outage was invisible to monitoring.
+- `pnpm test` runs the backend suite. The root package is not a workspace member, so `turbo test` reached only the frontend and the command exited zero having run none of the 4,000-plus backend tests.
+- The developer test stack no longer collides with production containers, and the deploy sweep excludes it. Both used `chive-` names — `chive-grobid` identically — and `docker ps --filter "name=chive-"` matched the test stack, so a deploy could delete it mid-run.
+- Frontend coverage is measured and enforced. The config declared no thresholds and CI ran the suite without `--coverage`, so the stated 70% bar was unenforced end to end; the real figure is 41%. Thresholds are set just below current levels as a ratchet, and both configs now record the gap to the documented bar rather than a bare TODO.
+- Every environment variable the code reads is documented — 75 of 103 were not. Three clusters are marked as inert rather than presented as working configuration: the R2/CDN variables select an adapter that is never chosen, the governance PDS writer is never constructed, and the SMTP path is never invoked.
+- The XRPC method verb is resolved once, so the OpenAPI specification and the router cannot disagree and generate a client for a verb the server does not serve.
+
+### Removed
+
+- The second-factor authentication layer. WebAuthn, TOTP and JWT session management — 2,334 lines plus a 688-line authentication service — were unreachable: no route, handler or service imported them, and credentials were held in Redis under TTLs rather than in the tables built for them. No user could enrol, because no endpoint existed. Chive does not offer 2FA; the code and its two tables are gone rather than completed.
+- `document_base64` from the search document. It carried a base64 document body into Elasticsearch — implemented, typed and tested — which contradicts the rule that only BlobRefs are stored. Nothing populated it.
+- The `repo:pub.chive.graph.fieldProposal` scope, for a record type renamed to node/edgeProposal that has no lexicon.
+
 ## [0.7.1] - 2026-08-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/src/api/handlers/xrpc/metrics/getTrending.ts
+++ b/src/api/handlers/xrpc/metrics/getTrending.ts
@@ -14,7 +14,7 @@ import type {
   OutputSchema,
   TrendingEntry,
 } from '../../../../lexicons/generated/types/pub/chive/metrics/getTrending.js';
-import type { AtUri } from '../../../../types/atproto.js';
+import type { AtUri, DID } from '../../../../types/atproto.js';
 import { expandFieldsWithNarrower } from '../../../../utils/field-expansion.js';
 import { toWireFormat } from '../../../../utils/rich-text.js';
 import { STALENESS_THRESHOLD_MS } from '../../../config.js';
@@ -28,7 +28,7 @@ import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 export const getTrending: XRPCMethod<QueryParams, void, OutputSchema> = {
   auth: false,
   handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
-    const { metrics, eprint, graph, graphAlgorithmCache } = c.get('services');
+    const { metrics, eprint, graph, graphAlgorithmCache, profileHydrator } = c.get('services');
     const logger = c.get('logger');
 
     const limit = params.limit ?? 20;
@@ -83,123 +83,115 @@ export const getTrending: XRPCMethod<QueryParams, void, OutputSchema> = {
       }));
     }
 
-    // Enrich with eprint data
-    const enrichedTrending = await Promise.all(
-      trendingEntries.map(async (entry, index) => {
-        const eprintData = await eprint.getEprint(entry.uri as AtUri);
-
-        if (!eprintData) {
-          // Skip entries where eprint is no longer indexed
-          return null;
-        }
-
-        // Extract rkey for record URL
-        const rkey = eprintData.uri.split('/').pop() ?? '';
-        // Determine which PDS holds the record (paper's PDS if paperDid set, otherwise submitter's)
-        const recordOwner = eprintData.paperDid ?? eprintData.submittedBy;
-        const recordUrl = `${eprintData.pdsUrl}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(recordOwner)}&collection=pub.chive.eprint.submission&rkey=${rkey}`;
-
-        // Calculate staleness using configured threshold
-        const stalenessThreshold = Date.now() - STALENESS_THRESHOLD_MS;
-
-        // Fetch avatars for authors
-        const avatarMap = new Map<string, { handle?: string; avatar?: string }>();
-        const authorDids = eprintData.authors
-          .filter((a) => a.did && !a.avatarUrl)
-          .map((a) => a.did)
-          .filter(Boolean) as string[];
-
-        if (authorDids.length > 0) {
-          try {
-            const params = new URLSearchParams();
-            for (const did of authorDids.slice(0, 25)) {
-              params.append('actors', did);
-            }
-            const profileResponse = await fetch(
-              `https://public.api.bsky.app/xrpc/app.bsky.actor.getProfiles?${params.toString()}`,
-              {
-                headers: { Accept: 'application/json' },
-                signal: AbortSignal.timeout(5000),
-              }
-            );
-
-            if (profileResponse.ok) {
-              const data = (await profileResponse.json()) as {
-                profiles: { did: string; handle?: string; avatar?: string }[];
-              };
-              for (const profile of data.profiles) {
-                avatarMap.set(profile.did, { handle: profile.handle, avatar: profile.avatar });
-              }
-            }
-          } catch {
-            // Silently ignore avatar fetch failures
-          }
-        }
-
-        return {
-          uri: eprintData.uri,
-          cid: eprintData.cid,
-          title: eprintData.title,
-          abstract: toWireFormat(eprintData.abstract) ?? [],
-          authors: eprintData.authors.map((author) => {
-            const profile = author.did ? avatarMap.get(author.did) : undefined;
-            return {
-              did: author.did,
-              name: author.name,
-              orcid: author.orcid,
-              email: author.email,
-              order: author.order,
-              affiliations: (author.affiliations ?? []).map((aff) => ({
-                name: aff.name,
-                institutionUri: aff.institutionUri,
-                rorId: aff.rorId,
-                children: aff.children,
-              })),
-              contributions: (author.contributions ?? []).map((contrib) => ({
-                typeUri: contrib.typeUri,
-                typeId: contrib.typeId,
-                typeLabel: contrib.typeLabel,
-                degree: contrib.degree,
-              })),
-              isCorrespondingAuthor: author.isCorrespondingAuthor,
-              isHighlighted: author.isHighlighted,
-              handle: author.handle ?? profile?.handle,
-              avatarUrl: author.avatarUrl ?? profile?.avatar,
-            };
-          }),
-          submittedBy: eprintData.submittedBy,
-          paperDid: eprintData.paperDid,
-          fields: eprintData.fields?.map((f) => ({
-            id: f.id,
-            uri: f.uri,
-            label: f.label,
-            parentUri: f.parentUri,
-          })),
-          license: eprintData.license,
-          createdAt: eprintData.createdAt.toISOString(),
-          indexedAt: eprintData.indexedAt.toISOString(),
-          source: {
-            pdsEndpoint: eprintData.pdsUrl,
-            recordUrl,
-            blobUrl: undefined as string | undefined,
-            lastVerifiedAt: eprintData.indexedAt.toISOString(),
-            stale: eprintData.indexedAt.getTime() < stalenessThreshold,
-          },
-          metrics: eprintData.metrics
-            ? {
-                views: eprintData.metrics.views,
-                downloads: eprintData.metrics.downloads,
-                endorsements: eprintData.metrics.endorsements,
-              }
-            : undefined,
-          viewsInWindow: entry.score,
-          rank: index + 1,
-          // Lexicon expects velocity as integer percentage (scaled from 0-1 ratio)
-          velocity: entry.velocity !== undefined ? Math.round(entry.velocity * 100) : undefined,
-          inUserFields: undefined as boolean | undefined,
-        };
-      })
+    // One query for the page's eprints, and one profile lookup for every author
+    // across the whole page. This used to issue a `getEprint` and a separate
+    // call to the public Bluesky appview per entry — 40 network round trips for
+    // 20 entries — and its `slice(0, 25)` silently dropped authors beyond the
+    // first 25 of each eprint rather than batching them.
+    const eprintsByUri = await eprint.getEprints(
+      trendingEntries.map((entry) => entry.uri as AtUri)
     );
+
+    const authorDidsOnPage = [
+      ...new Set(
+        [...eprintsByUri.values()].flatMap((data) =>
+          (data.authors ?? [])
+            .filter((a): a is typeof a & { did: DID } => Boolean(a.did) && !a.avatarUrl)
+            .map((a) => a.did)
+        )
+      ),
+    ];
+
+    const profilesByDid = profileHydrator
+      ? await profileHydrator.hydrate(authorDidsOnPage)
+      : new Map<DID, { handle?: string; avatar?: string }>();
+
+    // Enrich with eprint data
+    // No longer async: the eprints and profiles for the whole page are already
+    // resolved above, so this is a pure mapping over data in hand.
+    const enrichedTrending = trendingEntries.map((entry, index) => {
+      const eprintData = eprintsByUri.get(entry.uri as AtUri);
+
+      if (!eprintData) {
+        // Skip entries where eprint is no longer indexed
+        return null;
+      }
+
+      // Extract rkey for record URL
+      const rkey = eprintData.uri.split('/').pop() ?? '';
+      // Determine which PDS holds the record (paper's PDS if paperDid set, otherwise submitter's)
+      const recordOwner = eprintData.paperDid ?? eprintData.submittedBy;
+      const recordUrl = `${eprintData.pdsUrl}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(recordOwner)}&collection=pub.chive.eprint.submission&rkey=${rkey}`;
+
+      // Calculate staleness using configured threshold
+      const stalenessThreshold = Date.now() - STALENESS_THRESHOLD_MS;
+
+      // Profiles for this entry's authors, taken from the page-wide lookup.
+      const avatarMap = profilesByDid;
+
+      return {
+        uri: eprintData.uri,
+        cid: eprintData.cid,
+        title: eprintData.title,
+        abstract: toWireFormat(eprintData.abstract) ?? [],
+        authors: eprintData.authors.map((author) => {
+          const profile = author.did ? avatarMap.get(author.did) : undefined;
+          return {
+            did: author.did,
+            name: author.name,
+            orcid: author.orcid,
+            email: author.email,
+            order: author.order,
+            affiliations: (author.affiliations ?? []).map((aff) => ({
+              name: aff.name,
+              institutionUri: aff.institutionUri,
+              rorId: aff.rorId,
+              children: aff.children,
+            })),
+            contributions: (author.contributions ?? []).map((contrib) => ({
+              typeUri: contrib.typeUri,
+              typeId: contrib.typeId,
+              typeLabel: contrib.typeLabel,
+              degree: contrib.degree,
+            })),
+            isCorrespondingAuthor: author.isCorrespondingAuthor,
+            isHighlighted: author.isHighlighted,
+            handle: author.handle ?? profile?.handle,
+            avatarUrl: author.avatarUrl ?? profile?.avatar,
+          };
+        }),
+        submittedBy: eprintData.submittedBy,
+        paperDid: eprintData.paperDid,
+        fields: eprintData.fields?.map((f) => ({
+          id: f.id,
+          uri: f.uri,
+          label: f.label,
+          parentUri: f.parentUri,
+        })),
+        license: eprintData.license,
+        createdAt: eprintData.createdAt.toISOString(),
+        indexedAt: eprintData.indexedAt.toISOString(),
+        source: {
+          pdsEndpoint: eprintData.pdsUrl,
+          recordUrl,
+          blobUrl: undefined as string | undefined,
+          lastVerifiedAt: eprintData.indexedAt.toISOString(),
+          stale: eprintData.indexedAt.getTime() < stalenessThreshold,
+        },
+        metrics: eprintData.metrics
+          ? {
+              views: eprintData.metrics.views,
+              downloads: eprintData.metrics.downloads,
+              endorsements: eprintData.metrics.endorsements,
+            }
+          : undefined,
+        viewsInWindow: entry.score,
+        rank: index + 1,
+        // Lexicon expects velocity as integer percentage (scaled from 0-1 ratio)
+        velocity: entry.velocity !== undefined ? Math.round(entry.velocity * 100) : undefined,
+        inUserFields: undefined as boolean | undefined,
+      };
+    });
 
     // Filter out null entries and build response
     const validEntries = enrichedTrending.filter((e): e is NonNullable<typeof e> => e !== null);

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -49,6 +49,7 @@ import type { ContentReportService } from '../services/moderation/content-report
 import type { IPDSRegistry } from '../services/pds-discovery/pds-registry.js';
 import type { PDSScanner } from '../services/pds-discovery/pds-scanner.js';
 import type { PDSSyncService } from '../services/pds-sync/sync-service.js';
+import type { ProfileHydrator } from '../services/profile/profile-hydrator.js';
 import type { ReviewService } from '../services/review/review-service.js';
 import type { RankingService } from '../services/search/ranking-service.js';
 import type { IRelevanceLogger } from '../services/search/relevance-logger.js';
@@ -241,6 +242,17 @@ export interface ServerConfig {
   readonly graphAlgorithmCache?: GraphAlgorithmCache;
 
   /**
+   * Shared, Redis-backed profile lookup.
+   *
+   * @remarks
+   * Handler-level profile fetching was open-coded at several sites, none of
+   * them cached. Passing one hydrator gives them a single implementation and
+   * a shared cache, so the same author rendered across a page costs one lookup
+   * rather than one per appearance.
+   */
+  readonly profileHydrator?: ProfileHydrator;
+
+  /**
    * Logger instance.
    */
   readonly logger: ILogger;
@@ -401,6 +413,7 @@ export function createServer(config: ServerConfig): Hono<ChiveEnv> {
       import: config.importService,
       pdsSync: config.pdsSyncService,
       graphAlgorithmCache: config.graphAlgorithmCache,
+      profileHydrator: config.profileHydrator,
       relevanceLogger: config.relevanceLogger,
       ranking: config.rankingService,
       discovery: config.discoveryService,

--- a/src/api/types/context.ts
+++ b/src/api/types/context.ts
@@ -36,6 +36,7 @@ import type { ContentReportService } from '../../services/moderation/content-rep
 import type { IPDSRegistry } from '../../services/pds-discovery/pds-registry.js';
 import type { PDSScanner } from '../../services/pds-discovery/pds-scanner.js';
 import type { PDSSyncService } from '../../services/pds-sync/sync-service.js';
+import type { ProfileHydrator } from '../../services/profile/profile-hydrator.js';
 import type { ReviewService } from '../../services/review/review-service.js';
 import type { RankingService } from '../../services/search/ranking-service.js';
 import type { IRelevanceLogger } from '../../services/search/relevance-logger.js';
@@ -79,6 +80,7 @@ export interface ChiveServices {
   readonly discovery?: DiscoveryService;
   readonly recommendationService?: RecommendationService;
   readonly graphAlgorithmCache?: GraphAlgorithmCache;
+  readonly profileHydrator?: ProfileHydrator;
   readonly trustedEditor?: TrustedEditorService;
   readonly governancePdsWriter?: GovernancePDSWriter;
   readonly pdsRegistry?: IPDSRegistry;

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ import { PDSRegistry } from './services/pds-discovery/pds-registry.js';
 import { PDSScanner } from './services/pds-discovery/pds-scanner.js';
 import { PDSRateLimiter } from './services/pds-sync/pds-rate-limiter.js';
 import { PDSSyncService } from './services/pds-sync/sync-service.js';
+import { ProfileHydrator } from './services/profile/profile-hydrator.js';
 import { ReviewService } from './services/review/review-service.js';
 import { TaxonomyCategoryMatcher } from './services/search/category-matcher.js';
 import { RankingService } from './services/search/ranking-service.js';
@@ -495,6 +496,10 @@ function createServices(
   // never used its cache. Same Redis, same key space as the job.
   const graphAlgorithmCache = new GraphAlgorithmCache({ redis, logger });
 
+  // The hydrator's cache is the point of it: without one it makes the same
+  // appview request per page render. Redis is already here, so it gets one.
+  const profileHydrator = new ProfileHydrator({ logger, cache: redis });
+
   const relevanceLogger = relevanceLoggingEnabled
     ? new RelevanceLogger({
         pool: pgPool,
@@ -620,6 +625,7 @@ function createServices(
     importService,
     pdsSyncService,
     graphAlgorithmCache,
+    profileHydrator,
     relevanceLogger,
     activityService,
     discoveryService,

--- a/tests/unit/api/handlers/xrpc/metrics/getTrending.test.ts
+++ b/tests/unit/api/handlers/xrpc/metrics/getTrending.test.ts
@@ -40,15 +40,36 @@ interface MockMetricsService {
 
 interface MockEprintService {
   getEprint: ReturnType<typeof vi.fn<(uri: string) => Promise<EprintView | null>>>;
+  getEprints: ReturnType<typeof vi.fn>;
 }
 
 const createMockMetricsService = (): MockMetricsService => ({
   getTrending: vi.fn().mockResolvedValue([]),
 });
 
-const createMockEprintService = (): MockEprintService => ({
-  getEprint: vi.fn().mockResolvedValue(null),
-});
+const createMockEprintService = (): MockEprintService => {
+  const service: MockEprintService = {
+    getEprint: vi.fn().mockResolvedValue(null),
+    getEprints: vi.fn(),
+  };
+
+  // The handler fetches a page in one call. Resolving through this service's
+  // own `getEprint` keeps the per-test stubs below describing what each case
+  // returns, rather than making every case build a Map by hand.
+  service.getEprints = vi.fn(async (uris: readonly string[]) => {
+    const found = new Map<string, EprintView>();
+    for (const uri of uris) {
+      const fetchOne = service.getEprint as (u: string) => Promise<EprintView | null>;
+      const eprint = await fetchOne(uri);
+      if (eprint) {
+        found.set(uri, eprint);
+      }
+    }
+    return found;
+  });
+
+  return service;
+};
 
 interface MockContext {
   get: ReturnType<typeof vi.fn>;

--- a/tests/unit/api/handlers/xrpc/trending-paging.test.ts
+++ b/tests/unit/api/handlers/xrpc/trending-paging.test.ts
@@ -22,7 +22,12 @@ describe('trending pagination', () => {
       if (key === 'services') {
         return {
           metrics: { getTrending: getTrendingMetrics },
-          eprint: { getEprint: vi.fn().mockResolvedValue(null) },
+          eprint: {
+            getEprint: vi.fn().mockResolvedValue(null),
+            // The handler fetches the page in one call now.
+            getEprints: vi.fn().mockResolvedValue(new Map()),
+          },
+          profileHydrator: { hydrate: vi.fn().mockResolvedValue(new Map()) },
           graph: undefined,
           graphAlgorithmCache: undefined,
         };

--- a/tests/unit/config/security-scanning.test.ts
+++ b/tests/unit/config/security-scanning.test.ts
@@ -41,6 +41,20 @@ describe('security scanning workflow', () => {
     expect(read(path)).toMatch(pattern);
   });
 
+  // A tag that does not exist fails at "Set up job", before any step runs, so
+  // the workflow reports a red check with no scan output to explain it. The
+  // first version of this file pinned `aquasecurity/trivy-action@0.28.0`, which
+  // is neither a real release nor the right tag format — the action's releases
+  // are v-prefixed.
+  it('pins third-party actions to v-prefixed release tags', () => {
+    const contents = read(path);
+    const thirdParty = [...contents.matchAll(/uses:\s+(?!\.\/)([\w-]+\/[\w./-]+)@(\S+)/g)];
+    expect(thirdParty.length).toBeGreaterThan(0);
+    for (const [, action, ref] of thirdParty) {
+      expect(ref, `${action ?? ''} is pinned to ${ref ?? ''}`).toMatch(/^v\d+/);
+    }
+  });
+
   it('grants the permission needed to publish findings', () => {
     expect(read(path)).toMatch(/security-events:\s*write/);
   });

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Wave 28 closes API-23, and completes the half of API-27 that wave 23 (#122) deliberately left open.

**Trending issued 40 network round trips for a 20-entry page.** Per entry: one `getEprint`, plus one call to the public Bluesky appview for author profiles. Its `slice(0, 25)` also silently dropped authors beyond the first 25 of each eprint rather than batching them.

It now fetches the page's eprints in one query and hydrates every author across the whole page in one pass.

**The profile hydrator finally has its cache.** Wave 23 introduced `ProfileHydrator` but constructed it without one, and I said so at the time: it removed duplication without saving a single request. It is now built in the composition root with Redis and threaded through the request context, so the caching actually applies — and the remaining handler-level call sites can adopt it the same way.

## Related Issues

Backlog 0.8.0: API-23; completes API-27's caching. Stacked on #137 (wave 27).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

Existing trending tests updated rather than replaced: the mock's batch method resolves through the per-test `getEprint` stub, so each case still describes what it returns instead of building a Map by hand. That required restructuring the mock factory to close over its own service object — the first attempt referenced a variable declared later and failed with a `ReferenceError` at call time.

Full unit suite: 204 files, 4,459 tests passing. Typecheck and lint clean.

Two of my own errors were caught by tooling here rather than by me: `eslint --fix` rewrote a cast into a forbidden non-null assertion (replaced with a type-guard filter), and the map callback stayed `async` after I removed the only `await` inside it.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [ ] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [ ] Compliance tests pass (`npm run test:compliance` — 100% required) — verified by CI
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented

## Note for review

Profile data now persists in Redis for an hour by default. A handle or avatar changed upstream will lag by up to that long on trending, which is a new behaviour — previously every render fetched fresh. That is the intended trade for removing 20 appview calls per page, but it is a real change in freshness rather than a pure optimisation.
