### PR TITLE
Persist submission wizard drafts so a refresh no longer discards nine steps of input

### DIFF
--- a/web/components/submit/submission-wizard.tsx
+++ b/web/components/submit/submission-wizard.tsx
@@ -16,7 +16,7 @@
  * @packageDocumentation
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -49,6 +49,13 @@ import { StepFacets } from './step-facets';
 import { StepPublication } from './step-publication';
 import { StepReview } from './step-review';
 import { getActivePaperSession, clearAllPaperSessions } from '@/lib/auth/paper-session';
+import {
+  clearDraft,
+  draftHasContent,
+  draftScope,
+  loadDraft,
+  saveDraft,
+} from '@/lib/submit/wizard-draft';
 import type { EprintAuthorFormData } from '@/components/forms/eprint-author-editor';
 
 // =============================================================================
@@ -570,6 +577,27 @@ const stepSchemas = {
   review: z.object({}), // No additional validation for review step
 };
 
+/**
+ * Render a draft's age in words.
+ *
+ * @param savedAt - Epoch milliseconds the draft was written
+ * @returns A phrase such as `'earlier today'` or `'3 days ago'`
+ *
+ * @remarks
+ * The banner needs to convey recency, not a timestamp. A user deciding whether
+ * to keep a draft cares whether it is this morning's work or last month's.
+ */
+function formatDraftAge(savedAt: number): string {
+  const elapsed = Date.now() - savedAt;
+  const hour = 60 * 60 * 1000;
+  const day = 24 * hour;
+
+  if (elapsed < hour) return 'a few minutes ago';
+  if (elapsed < day) return 'earlier today';
+  const days = Math.round(elapsed / day);
+  return days === 1 ? 'yesterday' : `${days} days ago`;
+}
+
 // =============================================================================
 // COMPONENT
 // =============================================================================
@@ -587,12 +615,28 @@ export function SubmissionWizard({
   isClaimMode = false,
   className,
 }: SubmissionWizardProps) {
-  const { isAuthenticated, user: _user } = useAuth();
+  const { isAuthenticated, user } = useAuth();
   const agent = useAgent();
 
   const [currentStep, setCurrentStep] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [restoredDraft, setRestoredDraft] = useState<{
+    savedAt: number;
+    missingFiles: string[];
+  } | null>(null);
+
+  // A draft belongs to one account and one submission source. Both are needed
+  // before anything can be read or written, so persistence stays inert until
+  // the user's DID is known.
+  const draftDid = user?.did;
+  const scope = useMemo(() => draftScope(prefilled), [prefilled]);
+
+  // Guards the autosave effect: saving before the restore pass has run would
+  // overwrite the stored draft with the wizard's own default values.
+  const hasAttemptedRestore = useRef(false);
+  // Set once the record lands in the PDS, so unload guards and autosave stop.
+  const hasSubmitted = useRef(false);
 
   // Clean up paper sessions when wizard unmounts
   useEffect(() => {
@@ -619,10 +663,8 @@ export function SubmissionWizard({
   // Initialize form with react-hook-form
   // Note: Using explicit type assertion since zodResolver inference
   // doesn't perfectly match our EprintFormValues interface
-  const form = useForm<EprintFormValues>({
-    resolver: zodResolver(formSchema) as never,
-    mode: 'onChange',
-    defaultValues: {
+  const defaultValues: EprintFormValues = useMemo(
+    () => ({
       // In claim mode, use prefilled document file if available
       documentFile: prefilled?.documentFile,
       // Destination defaults to user's own PDS
@@ -650,8 +692,110 @@ export function SubmissionWizard({
       conferencePresentation: {},
       // Cross-platform discovery is enabled by default
       enableCrossPlatformDiscovery: true,
-    },
+    }),
+    // Recomputed only when the claim-mode source changes; the wizard's own
+    // edits live in the form, not here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [prefilled]
+  );
+
+  const form = useForm<EprintFormValues>({
+    resolver: zodResolver(formSchema) as never,
+    mode: 'onChange',
+    defaultValues,
   });
+
+  // Restore a draft saved by an earlier visit.
+  //
+  // Runs once per account/scope pair. `usePaperPds` and `paperDid` are
+  // deliberately dropped: paper sessions are in-memory by design and cannot
+  // survive the page load that made this restore necessary, so a restored
+  // destination would point at an account the wizard can no longer sign with.
+  useEffect(() => {
+    if (!draftDid || hasAttemptedRestore.current) return;
+    hasAttemptedRestore.current = true;
+
+    const draft = loadDraft<EprintFormValues>(draftDid, scope, Date.now());
+    if (!draft || !draftHasContent(draft)) return;
+
+    form.reset({
+      ...defaultValues,
+      ...draft.values,
+      // Claim mode re-fetches the source document on every visit, so the live
+      // handle beats the draft's absence of one.
+      documentFile: prefilled?.documentFile,
+      usePaperPds: false,
+      paperDid: undefined,
+    } as EprintFormValues);
+
+    const lastStep = WIZARD_STEPS.length - 1;
+    setCurrentStep(Math.min(Math.max(draft.step, 0), lastStep));
+    setRestoredDraft({ savedAt: draft.savedAt, missingFiles: draft.missingFiles });
+  }, [draftDid, scope, form, defaultValues, prefilled?.documentFile]);
+
+  // Persist the draft as the user works.
+  //
+  // `form.watch` fires on every keystroke, so writes are debounced rather than
+  // run per character; localStorage writes are synchronous and would otherwise
+  // land on the typing path.
+  useEffect(() => {
+    if (!draftDid) return;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const subscription = form.watch((values) => {
+      if (hasSubmitted.current || !hasAttemptedRestore.current) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        saveDraft(draftDid, scope, {
+          step: currentStep,
+          values: values as EprintFormValues,
+          savedAt: Date.now(),
+        });
+      }, 800);
+    });
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      subscription.unsubscribe();
+    };
+  }, [draftDid, scope, form, currentStep]);
+
+  // Save immediately on step change, so a user who advances and then closes
+  // the tab does not lose the step they had reached to the debounce window.
+  useEffect(() => {
+    if (!draftDid || hasSubmitted.current || !hasAttemptedRestore.current) return;
+    saveDraft(draftDid, scope, {
+      step: currentStep,
+      values: form.getValues(),
+      savedAt: Date.now(),
+    });
+  }, [currentStep, draftDid, scope, form]);
+
+  // Warn before a close or reload discards work.
+  //
+  // The draft makes that loss recoverable, but only on this browser, and only
+  // for fields that are not file handles. The prompt is still worth showing.
+  useEffect(() => {
+    const handler = (event: BeforeUnloadEvent) => {
+      if (hasSubmitted.current || isSubmitting) return;
+      if (!form.formState.isDirty) return;
+      event.preventDefault();
+      // Assigning returnValue is what actually triggers the prompt in Chrome
+      // and Safari; the string itself has been ignored by browsers for years.
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [form, isSubmitting]);
+
+  // Discard the restored draft and start from a clean wizard.
+  const handleDiscardDraft = useCallback(() => {
+    if (draftDid) clearDraft(draftDid, scope);
+    form.reset(defaultValues);
+    setCurrentStep(0);
+    setRestoredDraft(null);
+  }, [draftDid, scope, form, defaultValues]);
 
   // Get current step key
   const currentStepKey = WIZARD_STEPS[currentStep].id as keyof typeof stepSchemas;
@@ -868,6 +1012,12 @@ export function SubmissionWizard({
       // Clean up paper session after successful submission
       clearAllPaperSessions();
 
+      // The work now lives in the user's PDS, so the local copy is obsolete.
+      // Clearing before onSuccess keeps a navigating callback from racing the
+      // unmount and leaving a draft that would be offered back on return.
+      hasSubmitted.current = true;
+      if (draftDid) clearDraft(draftDid, scope);
+
       onSuccess?.(result);
     } catch (error) {
       submitLogger.error('Submission error', error);
@@ -877,7 +1027,7 @@ export function SubmissionWizard({
     } finally {
       setIsSubmitting(false);
     }
-  }, [agent, isAuthenticated, form, onSuccess]);
+  }, [agent, isAuthenticated, form, onSuccess, draftDid, scope]);
 
   // Render current step content
   const renderStepContent = () => {
@@ -910,6 +1060,30 @@ export function SubmissionWizard({
 
   return (
     <div className={cn('space-y-8', className)}>
+      {restoredDraft && (
+        <div
+          role="status"
+          className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm dark:border-amber-800 dark:bg-amber-950"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <p className="font-medium">
+                Restored your unfinished submission from {formatDraftAge(restoredDraft.savedAt)}.
+              </p>
+              {restoredDraft.missingFiles.length > 0 && (
+                <p className="text-muted-foreground">
+                  Files are not saved in your browser, so you need to attach{' '}
+                  {restoredDraft.missingFiles.join(', ')} again on the Files step.
+                </p>
+              )}
+            </div>
+            <Button type="button" variant="ghost" size="sm" onClick={handleDiscardDraft}>
+              Start over
+            </Button>
+          </div>
+        </div>
+      )}
+
       {/* Progress indicator - desktop */}
       <div className="hidden md:block">
         <WizardProgress

--- a/web/lib/submit/wizard-draft.test.ts
+++ b/web/lib/submit/wizard-draft.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+import {
+  DRAFT_MAX_AGE_MS,
+  clearDraft,
+  draftHasContent,
+  draftScope,
+  loadDraft,
+  saveDraft,
+  stripFiles,
+} from './wizard-draft';
+
+const DID = 'did:plc:abc123';
+
+function makeFile(name: string): File {
+  return new File(['content'], name, { type: 'application/pdf' });
+}
+
+describe('draftScope', () => {
+  it('returns the plain submit scope when there is no source paper', () => {
+    expect(draftScope(undefined)).toBe('submit');
+  });
+
+  it('prefers the arXiv id, so the same paper always resolves to one scope', () => {
+    const scope = draftScope({ externalIds: { arxivId: '2401.01234' }, doi: '10.1/x', title: 'T' });
+    expect(scope).toBe('claim:2401-01234');
+  });
+
+  it('falls back through DOI and then title', () => {
+    expect(draftScope({ doi: '10.1000/Xyz' })).toBe('claim:10-1000-xyz');
+    expect(draftScope({ title: 'A Study of Things' })).toBe('claim:a-study-of-things');
+  });
+
+  it('separates two different claim sources', () => {
+    expect(draftScope({ doi: '10.1/a' })).not.toBe(draftScope({ doi: '10.1/b' }));
+  });
+
+  it('bounds the scope length so the key cannot grow without limit', () => {
+    const scope = draftScope({ title: 'word '.repeat(200) });
+    expect(scope.length).toBeLessThanOrEqual('claim:'.length + 96);
+  });
+});
+
+describe('stripFiles', () => {
+  it('removes the document file and records its name', () => {
+    const { values, missingFiles } = stripFiles({
+      title: 'T',
+      documentFile: makeFile('paper.pdf'),
+    });
+    expect(values).not.toHaveProperty('documentFile');
+    expect(values.title).toBe('T');
+    expect(missingFiles).toEqual(['paper.pdf']);
+  });
+
+  it('removes supplementary file arrays', () => {
+    const { values, missingFiles } = stripFiles({
+      supplementaryFiles: [makeFile('a.csv'), makeFile('b.csv')],
+    });
+    expect(values).not.toHaveProperty('supplementaryFiles');
+    expect(missingFiles).toEqual(['a.csv', 'b.csv']);
+  });
+
+  it('keeps supplementary material metadata while dropping the handle', () => {
+    const { values, missingFiles } = stripFiles({
+      supplementaryMaterials: [
+        { file: makeFile('data.zip'), label: 'Dataset', category: 'dataset', order: 1 },
+      ],
+    });
+    const materials = values.supplementaryMaterials as Array<Record<string, unknown>>;
+    expect(materials[0]).toEqual({ label: 'Dataset', category: 'dataset', order: 1 });
+    expect(materials[0]).not.toHaveProperty('file');
+    expect(missingFiles).toEqual(['data.zip']);
+  });
+
+  it('produces something JSON can serialize', () => {
+    const { values } = stripFiles({ title: 'T', documentFile: makeFile('p.pdf') });
+    expect(() => JSON.stringify(values)).not.toThrow();
+  });
+});
+
+describe('saveDraft and loadDraft', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('round-trips values and the step', () => {
+    saveDraft(DID, 'submit', {
+      step: 4,
+      values: { title: 'Held', keywords: ['a'] },
+      savedAt: 1000,
+    });
+
+    const draft = loadDraft(DID, 'submit', 2000);
+    expect(draft?.step).toBe(4);
+    expect(draft?.values).toEqual({ title: 'Held', keywords: ['a'] });
+    expect(draft?.savedAt).toBe(1000);
+  });
+
+  it('keeps drafts for different accounts apart', () => {
+    saveDraft(DID, 'submit', { step: 1, values: { title: 'Mine' }, savedAt: 1000 });
+    expect(loadDraft('did:plc:other', 'submit', 2000)).toBeNull();
+  });
+
+  it('keeps drafts for different sources apart', () => {
+    saveDraft(DID, 'claim:one', { step: 1, values: { title: 'One' }, savedAt: 1000 });
+    expect(loadDraft(DID, 'claim:two', 2000)).toBeNull();
+  });
+
+  it('returns null and deletes a draft past the age limit', () => {
+    saveDraft(DID, 'submit', { step: 1, values: { title: 'Old' }, savedAt: 0 });
+    expect(loadDraft(DID, 'submit', DRAFT_MAX_AGE_MS + 1)).toBeNull();
+    // Deleted rather than merely hidden, so it cannot resurface via a clock change.
+    expect(loadDraft(DID, 'submit', 1)).toBeNull();
+  });
+
+  it('keeps a draft that is exactly at the age limit', () => {
+    saveDraft(DID, 'submit', { step: 1, values: { title: 'Edge' }, savedAt: 0 });
+    expect(loadDraft(DID, 'submit', DRAFT_MAX_AGE_MS)).not.toBeNull();
+  });
+
+  it('discards unparseable stored data instead of returning it', () => {
+    window.localStorage.setItem(`chive:wizard-draft:v1:${DID}:submit`, '{not json');
+    expect(loadDraft(DID, 'submit', 1000)).toBeNull();
+    expect(window.localStorage.getItem(`chive:wizard-draft:v1:${DID}:submit`)).toBeNull();
+  });
+
+  it('discards a draft missing required fields', () => {
+    window.localStorage.setItem(
+      `chive:wizard-draft:v1:${DID}:submit`,
+      JSON.stringify({ values: { title: 'T' } })
+    );
+    expect(loadDraft(DID, 'submit', 1000)).toBeNull();
+  });
+
+  it('does not persist file handles', () => {
+    saveDraft(DID, 'submit', {
+      step: 0,
+      values: { title: 'T', documentFile: makeFile('secret.pdf') },
+      savedAt: 1000,
+    });
+    const raw = window.localStorage.getItem(`chive:wizard-draft:v1:${DID}:submit`) ?? '';
+    expect(raw).not.toContain('content');
+    expect(loadDraft(DID, 'submit', 2000)?.missingFiles).toEqual(['secret.pdf']);
+  });
+
+  it('clears a draft on request', () => {
+    saveDraft(DID, 'submit', { step: 1, values: { title: 'T' }, savedAt: 1000 });
+    clearDraft(DID, 'submit');
+    expect(loadDraft(DID, 'submit', 2000)).toBeNull();
+  });
+
+  it('reports failure rather than throwing when the quota is exhausted', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+    expect(saveDraft(DID, 'submit', { step: 1, values: { title: 'T' }, savedAt: 1 })).toBe(false);
+    spy.mockRestore();
+  });
+
+  it('returns null rather than throwing when storage access is blocked', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError');
+    });
+    expect(loadDraft(DID, 'submit', 1000)).toBeNull();
+    spy.mockRestore();
+  });
+});
+
+describe('draftHasContent', () => {
+  const base = { step: 0, savedAt: 0, missingFiles: [] as string[] };
+
+  it('rejects a draft holding only wizard defaults', () => {
+    expect(
+      draftHasContent({
+        ...base,
+        values: { title: '', abstract: '', keywords: [], authors: [], fieldNodes: [] },
+      })
+    ).toBe(false);
+  });
+
+  it('rejects whitespace-only text', () => {
+    expect(draftHasContent({ ...base, values: { title: '   ' } })).toBe(false);
+  });
+
+  it('accepts a draft with a title', () => {
+    expect(draftHasContent({ ...base, values: { title: 'Real' } })).toBe(true);
+  });
+
+  it('accepts a draft whose only content is an attached file', () => {
+    expect(draftHasContent({ ...base, missingFiles: ['p.pdf'], values: {} })).toBe(true);
+  });
+
+  it('accepts a draft carrying only authors', () => {
+    expect(draftHasContent({ ...base, values: { authors: [{ name: 'A' }] } })).toBe(true);
+  });
+});
+
+describe('storage in a non-browser context', () => {
+  const original = globalThis.window;
+
+  afterEach(() => {
+    globalThis.window = original;
+  });
+
+  it('treats a missing window as no storage rather than crashing', () => {
+    // @ts-expect-error deliberately simulating a server render
+    delete globalThis.window;
+    expect(saveDraft(DID, 'submit', { step: 0, values: {}, savedAt: 0 })).toBe(false);
+    expect(loadDraft(DID, 'submit', 0)).toBeNull();
+    expect(() => clearDraft(DID, 'submit')).not.toThrow();
+  });
+});

--- a/web/lib/submit/wizard-draft.ts
+++ b/web/lib/submit/wizard-draft.ts
@@ -1,0 +1,293 @@
+/**
+ * Draft persistence for the eprint submission wizard.
+ *
+ * @remarks
+ * The wizard collects nine steps of input before anything is written to the
+ * user's PDS. Until submission there is no server-side record of that work, so
+ * a refresh, a back-navigation, or a closed tab used to discard all of it.
+ * This module keeps a copy in `localStorage` so the wizard can offer it back.
+ *
+ * **Files are not persisted.** `File` handles cannot survive a page load, and
+ * copying document bytes into `localStorage` would both blow the storage quota
+ * and put user document content somewhere Chive has no business keeping it.
+ * The draft records file *names* instead, so the wizard can name what the user
+ * needs to re-attach rather than silently dropping a step.
+ *
+ * **Drafts are scoped** by account DID and by submission source. A claim-mode
+ * draft is keyed to the paper being claimed, so restoring can never graft one
+ * import's edits onto a different paper.
+ *
+ * @packageDocumentation
+ */
+
+/** Storage key prefix. The version segment lets a shape change orphan old drafts. */
+const DRAFT_KEY_PREFIX = 'chive:wizard-draft:v1';
+
+/** Drafts older than this are treated as absent rather than offered back. */
+export const DRAFT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Form keys holding `File` values, which are dropped on save. */
+const FILE_KEYS = ['documentFile', 'supplementaryFiles'] as const;
+
+/**
+ * A draft as stored, with file handles replaced by their names.
+ *
+ * @public
+ */
+export interface StoredDraft<TValues = Record<string, unknown>> {
+  /** Zero-based wizard step the user had reached. */
+  step: number;
+  /** Form values with every `File` removed. */
+  values: Partial<TValues>;
+  /** Names of files the user had attached and must attach again. */
+  missingFiles: string[];
+  /** Epoch milliseconds when the draft was written. */
+  savedAt: number;
+}
+
+/**
+ * Build the scope segment identifying which submission a draft belongs to.
+ *
+ * @param prefilled - Claim-mode source data, if any
+ * @returns `'submit'` for a fresh submission, or a claim scope tied to the source paper
+ *
+ * @remarks
+ * Claim mode starts from an external paper. Keying its draft by that paper's
+ * identity means a restore either matches the paper on screen or does not fire
+ * at all. Falling back to the title keeps sources that carry neither an arXiv
+ * ID nor a DOI separated from one another.
+ *
+ * @public
+ */
+export function draftScope(prefilled?: {
+  doi?: string;
+  externalId?: string;
+  title?: string;
+  externalIds?: { arxivId?: string; doi?: string };
+}): string {
+  if (!prefilled) return 'submit';
+  const identity =
+    prefilled.externalIds?.arxivId ??
+    prefilled.doi ??
+    prefilled.externalIds?.doi ??
+    prefilled.externalId ??
+    prefilled.title;
+  if (!identity) return 'claim';
+  // Collapse to a compact, key-safe token; collisions only ever merge drafts
+  // for papers with identical identifiers, which are the same paper.
+  return `claim:${identity
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .slice(0, 96)}`;
+}
+
+function draftKey(did: string, scope: string): string {
+  return `${DRAFT_KEY_PREFIX}:${did}:${scope}`;
+}
+
+/**
+ * Read `localStorage`, tolerating browsers that make access throw.
+ *
+ * @remarks
+ * Private-mode Safari and cookie-blocking settings throw on property access
+ * rather than returning null, and the wizard must keep working in those cases.
+ */
+function storage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Strip `File` values from form data and collect their names.
+ *
+ * @param values - Raw form values
+ * @returns Serializable values plus the names of the files that were removed
+ */
+export function stripFiles<TValues extends object>(
+  values: TValues
+): { values: Partial<TValues>; missingFiles: string[] } {
+  const missingFiles: string[] = [];
+  const out: Record<string, unknown> = { ...(values as Record<string, unknown>) };
+
+  for (const key of FILE_KEYS) {
+    const value = out[key];
+    if (value instanceof File) {
+      missingFiles.push(value.name);
+      delete out[key];
+    } else if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (entry instanceof File) missingFiles.push(entry.name);
+      }
+      delete out[key];
+    }
+  }
+
+  // Supplementary materials carry a File alongside metadata worth keeping, so
+  // the entries survive with the handle removed.
+  const materials = out.supplementaryMaterials;
+  if (Array.isArray(materials)) {
+    out.supplementaryMaterials = materials.map((material) => {
+      if (material === null || typeof material !== 'object') return material;
+      const { file, ...rest } = material as { file?: unknown };
+      if (file instanceof File) missingFiles.push(file.name);
+      return rest;
+    });
+  }
+
+  return { values: out as Partial<TValues>, missingFiles };
+}
+
+/**
+ * Write a draft for the given account and scope.
+ *
+ * @param did - Account DID the draft belongs to
+ * @param scope - Result of {@link draftScope}
+ * @param draft - Step and form values to persist
+ * @returns Whether the draft was written
+ *
+ * @remarks
+ * Returns `false` rather than throwing when storage is unavailable or the
+ * quota is exhausted. Draft persistence is a convenience; failing to save one
+ * must never interrupt a submission in progress.
+ */
+export function saveDraft<TValues extends object>(
+  did: string,
+  scope: string,
+  draft: { step: number; values: TValues; savedAt: number }
+): boolean {
+  const store = storage();
+  if (!store) return false;
+
+  const { values, missingFiles } = stripFiles(draft.values);
+  const payload: StoredDraft<TValues> = {
+    step: draft.step,
+    values,
+    missingFiles,
+    savedAt: draft.savedAt,
+  };
+
+  try {
+    store.setItem(draftKey(did, scope), JSON.stringify(payload));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a draft, if one exists and has not expired.
+ *
+ * @param did - Account DID the draft belongs to
+ * @param scope - Result of {@link draftScope}
+ * @param now - Current epoch milliseconds
+ * @returns The stored draft, or `null` when absent, expired, or unreadable
+ *
+ * @remarks
+ * A draft that fails to parse is deleted rather than returned. Leaving corrupt
+ * data in place would make every subsequent mount attempt the same failed read.
+ */
+export function loadDraft<TValues extends object>(
+  did: string,
+  scope: string,
+  now: number
+): StoredDraft<TValues> | null {
+  const store = storage();
+  if (!store) return null;
+
+  const key = draftKey(did, scope);
+  let raw: string | null;
+  try {
+    raw = store.getItem(key);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    clearDraft(did, scope);
+    return null;
+  }
+
+  if (parsed === null || typeof parsed !== 'object') {
+    clearDraft(did, scope);
+    return null;
+  }
+
+  const draft = parsed as Partial<StoredDraft<TValues>>;
+  if (
+    typeof draft.step !== 'number' ||
+    typeof draft.savedAt !== 'number' ||
+    draft.values === null ||
+    typeof draft.values !== 'object'
+  ) {
+    clearDraft(did, scope);
+    return null;
+  }
+
+  if (now - draft.savedAt > DRAFT_MAX_AGE_MS) {
+    clearDraft(did, scope);
+    return null;
+  }
+
+  return {
+    step: draft.step,
+    values: draft.values,
+    missingFiles: Array.isArray(draft.missingFiles) ? draft.missingFiles : [],
+    savedAt: draft.savedAt,
+  };
+}
+
+/**
+ * Delete a draft.
+ *
+ * @param did - Account DID the draft belongs to
+ * @param scope - Result of {@link draftScope}
+ */
+export function clearDraft(did: string, scope: string): void {
+  const store = storage();
+  if (!store) return;
+  try {
+    store.removeItem(draftKey(did, scope));
+  } catch {
+    // Nothing to do; the draft simply outlives this attempt.
+  }
+}
+
+/**
+ * Report whether a draft holds anything worth restoring.
+ *
+ * @param draft - A draft read by {@link loadDraft}
+ * @returns Whether the draft carries user input beyond wizard defaults
+ *
+ * @remarks
+ * A user who opens the wizard, types nothing, and leaves still triggers a
+ * save. Offering that back as a "restored draft" is noise, so the wizard uses
+ * this to decide whether to prompt.
+ */
+export function draftHasContent(draft: StoredDraft<object>): boolean {
+  const v = draft.values as Record<string, unknown>;
+  const nonEmpty = (value: unknown): boolean => {
+    if (value === undefined || value === null) return false;
+    if (typeof value === 'string') return value.trim().length > 0;
+    if (Array.isArray(value)) return value.length > 0;
+    return false;
+  };
+
+  return (
+    nonEmpty(v.title) ||
+    nonEmpty(v.abstract) ||
+    nonEmpty(v.keywords) ||
+    nonEmpty(v.authors) ||
+    nonEmpty(v.fieldNodes) ||
+    nonEmpty(v.facets) ||
+    nonEmpty(v.supplementaryMaterials) ||
+    draft.missingFiles.length > 0
+  );
+}


### PR DESCRIPTION
## Summary

FE-1. The submission wizard collects nine steps of input before anything is written to the user's PDS, and until this change nothing kept a copy. A refresh, a back-navigation, or a closed tab discarded all of it — title, abstract, every author, fields, facets, funding — with no way back. The unmount handler also cleared paper sessions, so returning to the page left the user starting over.

Drafts now persist to `localStorage` and are offered back on return.

## What is not persisted, and why

**Files.** `File` handles cannot survive a page load, and copying document bytes into `localStorage` would both exhaust the quota and put user document content somewhere Chive has no business keeping — the same reasoning that keeps blob data out of the index. The draft stores file *names* instead, and the restore banner names what needs re-attaching rather than silently dropping the Files step.

**The paper-PDS destination.** Paper sessions are in-memory by design (`web/lib/auth/paper-session.ts`) and cannot survive the page load that made the restore necessary. Restoring `usePaperPds`/`paperDid` would leave the wizard pointed at an account it can no longer sign with, so the destination resets to the user's own PDS.

## Scoping

Drafts are keyed by account DID **and** by submission source. Claim mode starts from an external paper, so its draft is keyed to that paper's arXiv ID, DOI, or title. A restore therefore either matches the paper on screen or does not fire at all — one import's edits can never be grafted onto a different paper, and one account's draft never surfaces in another's session on a shared browser.

## Behaviour

- Autosave debounced at 800ms (writes to `localStorage` are synchronous and would otherwise land on the typing path), plus an immediate save on every step change
- `beforeunload` prompt while the form is dirty and not submitting
- Draft cleared once the record lands in the PDS, before `onSuccess` — so a navigating callback cannot race the unmount and leave a draft to be offered back
- Drafts expire after 30 days
- Restore only fires when the draft holds real input, so an opened-and-abandoned wizard does not produce a "restored draft" banner
- Every storage call is guarded: private-mode Safari throws on access rather than returning null, and an exhausted quota returns `false` instead of interrupting a submission

## Testing

- 26 new tests in `web/lib/submit/wizard-draft.test.ts` covering round-trip, per-account and per-source isolation, expiry (including the exact boundary), corrupt and malformed payloads, quota exhaustion, blocked storage access, server-render with no `window`, and the assertion that document bytes never reach storage
- Full web suite: 144 files / 2,570 tests passing
- `tsc --noEmit` clean; lint clean

## Compliance

Frontend-only. No data-flow change; nothing new is sent to or stored by Chive.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source