### PR TITLE
Replace vacuous compliance assertions with checks that can fail

### DIFF
--- a/tests/compliance/README.md
+++ b/tests/compliance/README.md
@@ -55,3 +55,21 @@ pnpm test:compliance -- --reporter=verbose
 
 - `.claude/design/00-atproto-compliance.md` - ATProto compliance principles
 - `.claude/design/02-appview/indexing-pipeline.md` - Firehose indexing design
+
+## Rebuildability
+
+The rule that every index must be reconstructible from the firehose is checked
+by `tests/integration/compliance/index-reconstruction.test.ts`, not by a file in
+this directory: it needs a live PostgreSQL index to wipe and rebuild, so it runs
+with the integration suite. It replays a fixed firehose log through the real
+event processor, snapshots the index, deletes it, replays the same log, and
+requires the two snapshots to match.
+
+## Assertions must be able to fail
+
+Several tests here read source files through `helpers/source-scan.ts` and assert
+the absence of a call — that a service never invokes a repository write, that a
+cache never stores a value without an expiry. This replaced a set of tests whose
+body was `expect(true).toBe(true)` under a comment describing what had been
+verified by hand: those reported passes without checking anything, which is worse
+than having no test, because the suite claimed coverage it did not have.

--- a/tests/compliance/core-services-compliance.test.ts
+++ b/tests/compliance/core-services-compliance.test.ts
@@ -42,6 +42,8 @@ import type { AnnotationBody } from '../../src/types/models/annotation.js';
 import type { EprintAuthor } from '../../src/types/models/author.js';
 import type { Eprint } from '../../src/types/models/eprint.js';
 
+import { PDS_WRITE_CALLS, findCalls, readExecutableSource } from './helpers/source-scan.js';
+
 /** Creates a mock rich text abstract from plain text. */
 function createMockAbstract(text: string): AnnotationBody {
   return {
@@ -555,71 +557,75 @@ describe('ATProto Core Services Compliance', () => {
   });
 
   describe('CRITICAL: MetricsService - AppView-Local Only', () => {
-    it('metrics are stored locally, not in user PDSes', () => {
-      // MetricsService stores in Redis and PostgreSQL, never in PDSes
-      // This is verified by the service implementation using Redis counters
-      // and PostgreSQL persistence, with no IRepository writes
-
-      // The service interface takes Redis and IStorageBackend
-      // Neither of these write to user PDSes
-      expect(true).toBe(true); // Interface verification
+    it('never calls a repository write method', () => {
+      const source = readExecutableSource('src/services/metrics/metrics-service.ts');
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
     });
 
-    it('view counts do not modify ATProto records', () => {
-      // Recording views increments Redis counters
-      // This does NOT create/update any ATProto records in user PDSes
+    it('records views into Redis and PostgreSQL rather than a repository', () => {
+      const source = readExecutableSource('src/services/metrics/metrics-service.ts');
 
-      // Metrics are AppView-specific analytics, not part of the
-      // distributed ATProto data model
-      expect(true).toBe(true); // Design verification
+      // View counts are AppView analytics, not part of the distributed data
+      // model: they belong in stores Chive owns and may rebuild at will.
+      expect(findCalls(source, ['incr', 'hincrby', 'query'])).not.toEqual([]);
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
     });
   });
 
   describe('CRITICAL: BlobProxyService - No Authoritative Storage', () => {
-    it('cache is ephemeral (TTL-based), not permanent', () => {
-      // RedisCache uses TTL for all entries (default 1 hour)
-      // Entries expire automatically, ensuring no permanent storage
+    it('writes every cache entry with an expiry', () => {
+      const source = readExecutableSource('src/services/blob-proxy/redis-cache.ts');
 
-      // This is verified by the RedisCache.set() implementation
-      // which always calls setex (set with expiration)
-      expect(true).toBe(true); // Implementation verification
+      // `setex` carries a TTL; a bare `set` does not. A cached blob that never
+      // expires is Chive holding blob data indefinitely, which is the thing
+      // the compliance rule forbids.
+      expect(findCalls(source, ['setex'])).toEqual(['setex']);
+      expect(source).not.toMatch(/\.\s*set\s*\(/);
     });
 
-    it('blobs are fetched from PDS, not stored authoritatively', () => {
-      // BlobProxyService fetches blobs from user PDSes via IRepository.getBlob()
-      // Cached copies are temporary and served from cache when available
-      // If cache misses, always fetches from source PDS
+    it('never calls a repository write method', () => {
+      const files = [
+        'src/services/blob-proxy/proxy-service.ts',
+        'src/services/blob-proxy/redis-cache.ts',
+        'src/services/blob-proxy/cdn-adapter.ts',
+      ];
 
-      // Chive never becomes the source of truth for blobs
-      expect(true).toBe(true); // Design verification
+      for (const file of files) {
+        const source = readExecutableSource(file);
+        expect(findCalls(source, PDS_WRITE_CALLS), file).toEqual([]);
+      }
+    });
+
+    it('reaches the PDS only through the read side of the repository', () => {
+      const source = readExecutableSource('src/services/blob-proxy/proxy-service.ts');
+
+      // A cache miss must fall back to the source PDS, so the read call has to
+      // be present; its absence would mean Chive was serving blobs it had
+      // become the source of truth for.
+      expect(findCalls(source, ['getBlob'])).toEqual(['getBlob']);
     });
   });
 
   describe('CRITICAL: PDSSyncService - Read-Only PDS Access', () => {
-    it('only reads from PDS via getRecord, never writes', () => {
-      // PDSSyncService uses IRepository which only has read methods:
-      // - getRecord<T>(uri): Fetch single record
-      // - listRecords(): Iterator over records
-      // - getBlob(): Fetch blob data
+    it('the repository interface declares no write method', () => {
+      const source = readExecutableSource('src/types/interfaces/repository.interface.ts');
 
-      // IRepository interface intentionally excludes write methods:
-      // - NO createRecord
-      // - NO putRecord
-      // - NO deleteRecord
-
-      // This is enforced by the TypeScript interface definition
-      expect(true).toBe(true); // Interface verification
+      // The guarantee is structural: a caller cannot write through an
+      // interface that does not name a write. Declarations are what matter
+      // here, so this looks for the names at all, not just at call sites.
+      for (const method of PDS_WRITE_CALLS) {
+        expect(source, `${method} must not appear in IRepository`).not.toContain(method);
+      }
     });
 
-    it('staleness detection compares CIDs without modification', () => {
-      // Staleness check:
-      // 1. Read indexed CID from local storage
-      // 2. Fetch current CID from PDS via getRecord
-      // 3. Compare CIDs
-      // 4. If different, trigger re-index from firehose
+    it('the concrete repository calls no write method either', () => {
+      const source = readExecutableSource('src/atproto/repository/at-repository.ts');
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
+    });
 
-      // NO writes to PDS during staleness detection
-      expect(true).toBe(true); // Design verification
+    it('staleness detection compares CIDs without writing anywhere upstream', () => {
+      const source = readExecutableSource('src/storage/postgresql/staleness-detector.ts');
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
     });
   });
 

--- a/tests/compliance/helpers/source-scan.ts
+++ b/tests/compliance/helpers/source-scan.ts
@@ -1,0 +1,191 @@
+/**
+ * Source-level assertions for the ATProto compliance suite.
+ *
+ * @remarks
+ * Several compliance rules are claims about what code does *not* do — a
+ * service must never write to a user's PDS, a cache must never hold a value
+ * without an expiry. Those are awkward to demonstrate by executing the code,
+ * because the passing case is the absence of a call. Reading the source and
+ * asserting the call is not there tests exactly the claim, and fails the day
+ * somebody adds one.
+ *
+ * The scan strips comments and string literals first. Without that, a comment
+ * reading "never calls createRecord" would register as a `createRecord` call
+ * and the check would report a violation that does not exist — and, worse, a
+ * check written to require a call would pass on the strength of a comment.
+ *
+ * @packageDocumentation
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Repository root, resolved from this file's location. */
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+/**
+ * Method names that write to a repository through the ATProto XRPC surface.
+ *
+ * @remarks
+ * Chive is an AppView: it indexes what PDSes publish and owns none of it.
+ * Any of these appearing in AppView code means the service is attempting to
+ * mutate a repository it does not own.
+ *
+ * @public
+ */
+export const PDS_WRITE_CALLS = [
+  'createRecord',
+  'putRecord',
+  'deleteRecord',
+  'applyWrites',
+  'uploadBlob',
+  'importRepo',
+] as const;
+
+/**
+ * Read a repository file with comments and string literals removed.
+ *
+ * @param relativePath - Path relative to the repository root
+ * @returns Executable source text, with comments and literals blanked out
+ *
+ * @throws If the file does not exist. A compliance test naming a file that has
+ * been moved should fail loudly rather than vacuously pass on empty input.
+ *
+ * @public
+ */
+export function readExecutableSource(relativePath: string): string {
+  const source = readFileSync(join(REPO_ROOT, relativePath), 'utf8');
+  return stripCommentsAndStrings(source);
+}
+
+/**
+ * Remove comments and string literals from TypeScript source.
+ *
+ * @param source - Raw source text
+ * @returns The same text with comments and literal contents replaced by spaces
+ *
+ * @remarks
+ * Length is preserved so reported offsets still line up with the original.
+ * This is a lexical pass, not a parse: it tracks which of the five contexts
+ * (code, line comment, block comment, quoted string, template literal) each
+ * character sits in, which is all the call-site checks need.
+ */
+export function stripCommentsAndStrings(source: string): string {
+  const out: string[] = [];
+  let i = 0;
+  type Mode = 'code' | 'line' | 'block' | 'single' | 'double' | 'template';
+  let mode: Mode = 'code';
+
+  while (i < source.length) {
+    const ch = source[i] ?? '';
+    const next = source[i + 1] ?? '';
+
+    if (mode === 'code') {
+      if (ch === '/' && next === '/') {
+        mode = 'line';
+        out.push('  ');
+        i += 2;
+        continue;
+      }
+      if (ch === '/' && next === '*') {
+        mode = 'block';
+        out.push('  ');
+        i += 2;
+        continue;
+      }
+      if (ch === "'" || ch === '"' || ch === '`') {
+        mode = ch === "'" ? 'single' : ch === '"' ? 'double' : 'template';
+        out.push(' ');
+        i += 1;
+        continue;
+      }
+      out.push(ch);
+      i += 1;
+      continue;
+    }
+
+    if (mode === 'line') {
+      if (ch === '\n') {
+        mode = 'code';
+        out.push('\n');
+      } else {
+        out.push(' ');
+      }
+      i += 1;
+      continue;
+    }
+
+    if (mode === 'block') {
+      if (ch === '*' && next === '/') {
+        mode = 'code';
+        out.push('  ');
+        i += 2;
+        continue;
+      }
+      out.push(ch === '\n' ? '\n' : ' ');
+      i += 1;
+      continue;
+    }
+
+    // Inside a string or template literal.
+    if (ch === '\\') {
+      out.push('  ');
+      i += 2;
+      continue;
+    }
+    const closer = mode === 'single' ? "'" : mode === 'double' ? '"' : '`';
+    if (ch === closer) {
+      mode = 'code';
+      out.push(' ');
+      i += 1;
+      continue;
+    }
+    out.push(ch === '\n' ? '\n' : ' ');
+    i += 1;
+  }
+
+  return out.join('');
+}
+
+/**
+ * Find calls to any of the given method names in executable source.
+ *
+ * @param source - Source text, already passed through {@link readExecutableSource}
+ * @param methods - Method names to look for
+ * @returns The names found, deduplicated
+ *
+ * @remarks
+ * Matches `.name(` and bare `name(`, so both `agent.createRecord(...)` and a
+ * destructured `createRecord(...)` are caught. An explicit type argument list
+ * is allowed between the two — `getRecord<RawFacetRecord>(uri)` is the same
+ * call as `getRecord(uri)` and must not slip past the check.
+ *
+ * @public
+ */
+export function findCalls(source: string, methods: readonly string[]): string[] {
+  const found = new Set<string>();
+  for (const method of methods) {
+    const pattern = new RegExp(
+      `(?:^|[^A-Za-z0-9_$])${method}\\s*(?:<[^()<>]*(?:<[^()<>]*>[^()<>]*)*>)?\\s*\\(`,
+      'm'
+    );
+    if (pattern.test(source)) found.add(method);
+  }
+  return [...found];
+}
+
+/**
+ * Read a configuration file as text.
+ *
+ * @param relativePath - Path relative to the repository root
+ * @returns The file's contents
+ *
+ * @throws If the file does not exist, so a test cannot pass by asserting
+ * against a config that was deleted or renamed.
+ *
+ * @public
+ */
+export function readConfig(relativePath: string): string {
+  return readFileSync(join(REPO_ROOT, relativePath), 'utf8');
+}

--- a/tests/compliance/observability-compliance.test.ts
+++ b/tests/compliance/observability-compliance.test.ts
@@ -19,6 +19,13 @@ import type { ILogger } from '../../src/types/interfaces/logger.interface.js';
 import { LogLevel } from '../../src/types/interfaces/logger.interface.js';
 import type { IMetrics } from '../../src/types/interfaces/metrics.interface.js';
 
+import {
+  PDS_WRITE_CALLS,
+  findCalls,
+  readConfig,
+  readExecutableSource,
+} from './helpers/source-scan.js';
+
 describe('Observability ATProto Compliance', () => {
   describe('Logging - No PII in Logs', () => {
     let logger: ILogger;
@@ -273,21 +280,18 @@ describe('Observability ATProto Compliance', () => {
 
   describe('Health Check - ATProto Compliance', () => {
     it('Health check MUST NOT write to user PDSes', () => {
-      // Health checks only read from dependencies (Redis, PostgreSQL, etc.)
-      // This is verified by code review. health.ts uses read operations only:
-      // - redis.ping()
-      // - services.eprint.getEprintsByAuthor (read)
-      // - services.search.search (read)
-      // - services.graph.getFieldById (read)
-      expect(true).toBe(true);
+      const source = readExecutableSource('src/api/handlers/rest/health.ts');
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
     });
 
     it('Health check MUST NOT store any data', () => {
-      // Health checks are stateless (no data storage)
-      // This is verified by code review. health.ts:
-      // - Only checks dependency connectivity
-      // - Returns status without side effects
-      expect(true).toBe(true);
+      const source = readExecutableSource('src/api/handlers/rest/health.ts');
+
+      // A readiness probe that writes is a probe that can corrupt what it
+      // measures, and it runs on a timer against production.
+      const mutations = findCalls(source, ['set', 'setex', 'hset', 'lpush', 'insert', 'save']);
+      expect(mutations).toEqual([]);
+      expect(source).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b/i);
     });
   });
 
@@ -328,27 +332,43 @@ describe('Observability ATProto Compliance', () => {
   });
 
   describe('Kubernetes Configs - Security Compliance', () => {
-    it('OTEL Collector MUST use RBAC', () => {
-      // Verified in otel-collector.yaml:
-      // - ServiceAccount: otel-collector
-      // - No cluster-wide permissions
-      // - Only collects telemetry from Chive namespace
-      expect(true).toBe(true);
+    it('OTEL Collector MUST run under a dedicated ServiceAccount with no cluster-wide grant', () => {
+      const manifest = readConfig('k8s/monitoring/otel-collector.yaml');
+
+      expect(manifest).toContain('serviceAccountName: otel-collector');
+      expect(manifest).toMatch(/kind:\s*ServiceAccount/);
+      // A collector scraping one namespace has no reason to hold a
+      // ClusterRole; granting one would let a compromised collector read
+      // across every namespace on the cluster.
+      expect(manifest).not.toMatch(/kind:\s*ClusterRole\b/);
     });
 
     it('Promtail MUST have read-only access to logs', () => {
-      // Verified in promtail-config.yaml:
-      // - readOnly: true for volume mounts
-      // - ClusterRole only has get, watch, list permissions
-      expect(true).toBe(true);
+      const manifest = readConfig('k8s/monitoring/promtail-config.yaml');
+
+      expect(manifest).toContain('readOnly: true');
+      expect(manifest).toContain('readOnlyRootFilesystem: true');
+
+      // Promtail does hold a ClusterRole, since it discovers targets across
+      // the cluster. What matters is that every verb on it is a read.
+      const verbLines = manifest.match(/verbs:\s*\[[^\]]*\]/g) ?? [];
+      expect(verbLines.length).toBeGreaterThan(0);
+      for (const line of verbLines) {
+        expect(line, line).not.toMatch(/create|update|patch|delete|\*/);
+      }
     });
 
     it('Alert rules MUST NOT expose sensitive data', () => {
-      // Verified in alert-rules.yaml:
-      // - Annotations contain URLs, not secrets
-      // - Labels are categorization, not PII
-      // - Descriptions use metric values, not raw data
-      expect(true).toBe(true);
+      const manifest = readConfig('k8s/monitoring/alert-rules.yaml');
+
+      // Alert payloads travel to pagers, chat, and email. Anything
+      // credential-shaped that lands in one has left the cluster's trust
+      // boundary and cannot be recalled.
+      expect(manifest).not.toMatch(
+        /\b(password|passwd|secret|api[_-]?key|private[_-]?key|authorization|bearer)\b\s*[:=]/i
+      );
+      expect(manifest).not.toMatch(/\b(did:plc:|did:web:)/);
+      expect(manifest).not.toMatch(/[A-Za-z0-9+/]{40,}={0,2}\s*$/m);
     });
   });
 });

--- a/tests/compliance/phase-14-compliance.test.ts
+++ b/tests/compliance/phase-14-compliance.test.ts
@@ -36,6 +36,8 @@ import type {
 } from '../../src/types/interfaces/repository.interface.js';
 import { TEST_GRAPH_PDS_DID, TEST_USER_DIDS } from '../test-constants.js';
 
+import { PDS_WRITE_CALLS, findCalls, readExecutableSource } from './helpers/source-scan.js';
+
 // Test constants
 const TEST_USER_DID = TEST_USER_DIDS.USER_1;
 const TEST_GRAPH_PDS_URL = 'https://pds.chive-governance.test';
@@ -181,10 +183,11 @@ describe('ATProto Advanced Features Compliance', () => {
       await connector.getAuthorityRecord(TEST_AUTHORITY_URI);
       await connector.getAuthorityRecord(TEST_AUTHORITY_URI);
 
-      // Without cache, both calls hit repository
-      // With cache, second call would be cached
-      // In both cases, source of truth is Governance PDS
-      expect(true).toBe(true); // Design verification
+      // Cached or not, the Governance PDS stays the source of truth: the
+      // connector may read from it and may not write back to it.
+      const source = readExecutableSource('src/services/governance/governance-pds-connector.ts');
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
+      expect(findCalls(source, ['getRecord', 'listRecords'])).not.toEqual([]);
     });
 
     it('IRepository interface has no write methods', () => {
@@ -251,9 +254,10 @@ describe('ATProto Advanced Features Compliance', () => {
 
       await service.createNotification(input);
 
-      // Notification is stored in Redis (if configured) or memory
-      // NEVER written to user PDSes
-      expect(true).toBe(true); // Design verification
+      // Notifications are an AppView convenience. Writing one into a user's
+      // repository would put Chive's own state into data the user owns.
+      const source = readExecutableSource('src/services/notification/notification-service.ts');
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
     });
 
     it('references eprints via AT-URI, not local IDs', async () => {
@@ -297,123 +301,93 @@ describe('ATProto Advanced Features Compliance', () => {
   });
 
   describe('CRITICAL: Multi-Layer Cache - Ephemeral Storage', () => {
-    it('L1 cache (Redis) is ephemeral with TTL', () => {
-      // RedisCache uses SETEX for all entries
-      // TTL ensures entries expire (default 3600 seconds = 1 hour)
-      //
-      // Key pattern: chive:blob:{uri}:{cid}
-      // Value: blob data (limited by maxBlobSize)
-      // TTL: Configurable, defaults to 1 hour
-      //
-      // Implementation uses probabilistic early expiration
-      // (Vattani et al. 2015) to prevent cache stampedes
-      expect(true).toBe(true); // Implementation verification
+    it('L1 cache (Redis) writes every entry with an expiry', () => {
+      const source = readExecutableSource('src/services/blob-proxy/redis-cache.ts');
+
+      // `setex` carries a TTL and a bare `set` does not. A blob cached without
+      // one is Chive holding blob data indefinitely.
+      expect(findCalls(source, ['setex'])).toEqual(['setex']);
+      expect(source).not.toMatch(/\.\s*set\s*\(/);
     });
 
-    it('L2 cache (CDN) is ephemeral with TTL', () => {
-      // CDNAdapter (Cloudflare R2) stores blobs with:
-      // - Cache-Control: max-age=86400 (default 24 hours)
-      // - Metadata includes cachedAt timestamp
-      // - Records expire and are re-fetched from PDS
-      //
-      // CDN is a performance optimization, not permanent storage
-      expect(true).toBe(true); // Implementation verification
+    it('L2 cache (CDN) gives every stored object a bounded lifetime', () => {
+      const source = readExecutableSource('src/services/blob-proxy/cdn-adapter.ts');
+      expect(source).toMatch(/defaultTTL|ttl/);
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
     });
 
-    it('blobs fetched from PDS on cache miss', () => {
-      // BlobProxyService cache hierarchy:
-      // 1. Check L1 (Redis), hit rate ~40-50%
-      // 2. Check L2 (Cloudflare R2), hit rate ~85-90%
-      // 3. Fetch from user's PDS (source of truth)
-      //
-      // Cache miss always falls back to PDS via IRepository.getBlob()
-      expect(true).toBe(true); // Implementation verification
+    it('blobs are fetched from the PDS on cache miss', () => {
+      const source = readExecutableSource('src/services/blob-proxy/proxy-service.ts');
+
+      // Without this fallback a miss would have nowhere to go but Chive's own
+      // copy, which is what "never the source of truth" rules out.
+      expect(findCalls(source, ['getBlob'])).toEqual(['getBlob']);
     });
 
-    it('cache invalidation does not affect source PDSes', () => {
-      // Cache invalidation only affects local cache:
-      // - Redis DEL command for L1
-      // - R2 DELETE for L2
-      //
-      // User's PDS is never modified during cache operations
-      // Blobs remain in user's PDS regardless of cache state
-      expect(true).toBe(true); // Design verification
+    it('cache invalidation touches only Chive-owned stores', () => {
+      for (const file of [
+        'src/services/blob-proxy/proxy-service.ts',
+        'src/services/blob-proxy/redis-cache.ts',
+        'src/services/blob-proxy/cdn-adapter.ts',
+      ]) {
+        const source = readExecutableSource(file);
+        expect(findCalls(source, PDS_WRITE_CALLS), file).toEqual([]);
+      }
     });
   });
 
   describe('CRITICAL: MetricsService - AppView-Local Analytics', () => {
-    it('metrics stored in Redis/PostgreSQL, not user PDSes', () => {
-      // MetricsService uses:
-      // - Redis INCR for real-time counters
-      // - Redis ZADD for time-windowed trending
-      // - Redis PFADD for unique viewer HyperLogLog
-      // - PostgreSQL for persistent aggregates
-      //
-      // NO writes to user PDSes for any metric
-      expect(true).toBe(true); // Implementation verification
+    it('metrics are written to Redis and PostgreSQL, never to a repository', () => {
+      const source = readExecutableSource('src/services/metrics/metrics-service.ts');
+      expect(findCalls(source, ['incr', 'zadd', 'pfadd', 'query'])).not.toEqual([]);
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
     });
 
-    it('view counts are AppView-specific, not portable', () => {
-      // View counts are specific to this Chive instance
-      // Users cannot export/import view counts to other AppViews
-      //
-      // This is intentional:
-      // - Prevents gaming metrics
-      // - Each AppView has own analytics
-      // - Users own content, not popularity metrics
-      expect(true).toBe(true); // Design verification
+    it('view counts never leave the AppView as records', () => {
+      const source = readExecutableSource('src/services/metrics/metrics-service.ts');
+
+      // Popularity belongs to this instance, not to the user's repository.
+      // Emitting it as a record would make one AppView's analytics part of
+      // the portable data the user carries between AppViews.
+      expect(source).not.toContain('pub.chive.');
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
     });
 
-    it('metrics can be rebuilt from firehose events', () => {
-      // Metrics derived from:
-      // - Page view events (logged, not ATProto records)
-      // - Firehose indexing timestamps (when eprints were indexed)
-      //
-      // Note: View counts are NOT rebuildable (ephemeral analytics)
-      // But eprint existence/metadata IS rebuildable from firehose
-      expect(true).toBe(true); // Design verification
+    it('the metrics store is Chive-owned and therefore discardable', () => {
+      const source = readExecutableSource('src/services/metrics/metrics-service.ts');
+
+      // The rebuildability rule is about what Chive would lose if its
+      // databases were dropped: nothing a user owns. View counts are
+      // deliberately not rebuildable, and deliberately not the user's.
+      expect(findCalls(source, PDS_WRITE_CALLS)).toEqual([]);
     });
 
-    it('trending algorithm uses AppView-local data only', () => {
-      // Trending calculation:
-      // - Redis sorted sets with time-windowed scores
-      // - Score = views_24h * decay_factor
-      // - Completely local to this AppView
-      //
-      // Does NOT read from or write to PDSes
-      expect(true).toBe(true); // Implementation verification
+    it('trending reads only AppView-local state', () => {
+      const source = readExecutableSource('src/services/metrics/metrics-service.ts');
+      expect(findCalls(source, [...PDS_WRITE_CALLS, 'getRecord', 'listRecords'])).toEqual([]);
     });
   });
 
   describe('CRITICAL: WebSocket/SSE Handlers - No PDS Interaction', () => {
-    it('WebSocket connections are AppView-local sessions', () => {
-      // WebSocketHandler manages:
-      // - Connection state (in-memory Map)
-      // - DID-to-connection lookup
-      // - Keepalive pings
-      //
-      // No PDS reads or writes for connection management
-      expect(true).toBe(true); // Implementation verification
+    it('WebSocket connection handling touches no repository', () => {
+      const source = readExecutableSource('src/services/notification/websocket-handler.ts');
+      expect(findCalls(source, [...PDS_WRITE_CALLS, 'getRecord', 'listRecords'])).toEqual([]);
     });
 
-    it('SSE streams are AppView-local sessions', () => {
-      // SSEHandler manages:
-      // - Stream state (in-memory Map)
-      // - DID-to-stream lookup
-      // - Server-sent events
-      //
-      // No PDS reads or writes for stream management
-      expect(true).toBe(true); // Implementation verification
+    it('SSE stream handling touches no repository', () => {
+      const source = readExecutableSource('src/services/notification/sse-handler.ts');
+      expect(findCalls(source, [...PDS_WRITE_CALLS, 'getRecord', 'listRecords'])).toEqual([]);
     });
 
     it('notification delivery does not modify PDSes', () => {
-      // NotificationDeliveryHandler callback:
-      // - Receives Notification object
-      // - Sends via WebSocket or SSE
-      // - Updates local read status (Redis)
-      //
-      // Never writes to user PDSes
-      expect(true).toBe(true); // Design verification
+      for (const file of [
+        'src/services/notification/notification-service.ts',
+        'src/services/notification/websocket-handler.ts',
+        'src/services/notification/sse-handler.ts',
+      ]) {
+        const source = readExecutableSource(file);
+        expect(findCalls(source, PDS_WRITE_CALLS), file).toEqual([]);
+      }
     });
   });
 

--- a/tests/integration/compliance/index-reconstruction.test.ts
+++ b/tests/integration/compliance/index-reconstruction.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Index reconstruction compliance test.
+ *
+ * @remarks
+ * Chive's central promise is that its databases hold nothing a user owns: if
+ * the entire index were dropped, every eprint would still sit in its author's
+ * PDS and the index could be rebuilt by replaying the firehose. Every other
+ * compliance rule follows from that one, and until now it was the only golden
+ * rule with no executable test — its "verification" was the existence of a
+ * cursor table, which demonstrates nothing about whether a replay reproduces
+ * the state it replaced.
+ *
+ * This test replays a fixed sequence of firehose commits through the real
+ * event processor and a real PostgreSQL index, snapshots the result, wipes the
+ * index the way a lost database would, replays the identical sequence, and
+ * requires the two snapshots to match.
+ *
+ * Requires the Docker test stack (`./scripts/start-test-stack.sh`).
+ *
+ * @packageDocumentation
+ */
+
+import { Pool } from 'pg';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+import { EprintService } from '@/services/eprint/eprint-service.js';
+import { createEventProcessor } from '@/services/indexing/event-processor.js';
+import type { ProcessedEvent } from '@/services/indexing/indexing-service.js';
+import { PostgreSQLAdapter } from '@/storage/postgresql/adapter.js';
+import { getDatabaseConfig } from '@/storage/postgresql/config.js';
+import type { AtUri, DID } from '@/types/atproto.js';
+import type { IIdentityResolver } from '@/types/interfaces/identity.interface.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+import type { IRepository } from '@/types/interfaces/repository.interface.js';
+import type {
+  ISearchEngine,
+  IndexableEprintDocument,
+} from '@/types/interfaces/search.interface.js';
+
+const AUTHOR = 'did:plc:reconstructiontestauthor' as DID;
+const PDS_URL = 'https://pds.reconstruction.test';
+
+/**
+ * Tables the replayed collections write into, with the column identifying the
+ * rows this test owns.
+ */
+const INDEX_TABLES = [
+  { table: 'eprints_index', column: 'uri', match: 'prefix' },
+  { table: 'eprint_versions_index', column: 'uri', match: 'prefix' },
+  { table: 'authors_index', column: 'did', match: 'exact' },
+] as const;
+
+/**
+ * Columns recording *when Chive processed* a record rather than what it says.
+ *
+ * @remarks
+ * These are wall-clock stamps taken at indexing time, so two replays of the
+ * same log necessarily disagree on them; they are the AppView's own bookkeeping
+ * and none of them is user data. Every other column — including
+ * `deletion_source`, `created_at`, and `updated_at`, which all come from the
+ * record — must match exactly.
+ *
+ * The list is deliberately short. Each entry weakens the reconstruction check,
+ * so the test asserts below that every excluded column is actually present and
+ * populated, rather than letting a renamed column quietly widen the exemption.
+ */
+const LOCAL_TIMESTAMP_COLUMNS = ['indexed_at', 'last_synced_at', 'deleted_at'] as const;
+
+function createLogger(): ILogger {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+function createIdentity(): IIdentityResolver {
+  return {
+    resolveDID: vi.fn().mockResolvedValue({ id: AUTHOR, alsoKnownAs: [], verificationMethod: [] }),
+    resolveHandle: vi.fn().mockResolvedValue(AUTHOR),
+    getPDSEndpoint: vi.fn().mockResolvedValue(PDS_URL),
+  };
+}
+
+function createRepository(): IRepository {
+  // The processor must not read back from the PDS to rebuild; if it did, a
+  // replay would depend on live network state rather than the firehose log.
+  return {
+    getRecord: vi.fn().mockResolvedValue(null),
+    listRecords: vi.fn(),
+    getBlob: vi.fn().mockResolvedValue(null),
+  };
+}
+
+/**
+ * Search engine that records what was indexed instead of talking to a cluster.
+ *
+ * @remarks
+ * The search index has to be reconstructible too, and capturing the emitted
+ * documents tests that directly without making the assertion depend on
+ * Elasticsearch's own refresh timing.
+ */
+function createRecordingSearch(): ISearchEngine & { documents: Map<string, unknown> } {
+  const documents = new Map<string, unknown>();
+  return {
+    documents,
+    indexEprint: (doc: IndexableEprintDocument) => {
+      const { indexedAt: _indexedAt, ...stable } = doc;
+      documents.set(doc.uri, stable);
+      return Promise.resolve();
+    },
+    search: () => Promise.resolve({ hits: [], total: 0, took: 0 }),
+    facetedSearch: () => Promise.resolve({ hits: [], total: 0, took: 0, facets: {} }),
+    autocomplete: () => Promise.resolve([]),
+    deleteDocument: (uri: AtUri) => {
+      documents.delete(uri);
+      return Promise.resolve();
+    },
+    findSimilarByText: () => Promise.resolve([]),
+  };
+}
+
+function submissionRecord(title: string, abstract: string): Record<string, unknown> {
+  return {
+    $type: 'pub.chive.eprint.submission',
+    title,
+    abstract: {
+      type: 'RichText',
+      items: [{ type: 'text', content: abstract }],
+      format: 'application/x-chive-gloss+json',
+    },
+    authors: [{ did: AUTHOR, name: 'Reconstruction Author', order: 1 }],
+    keywords: ['reconstruction', 'compliance'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    document: {
+      $type: 'blob',
+      ref: { $link: 'bafkreiereconstructiondocument' },
+      mimeType: 'application/pdf',
+      size: 1024,
+    },
+  };
+}
+
+function commit(
+  seq: number,
+  rkey: string,
+  action: 'create' | 'update' | 'delete',
+  record?: Record<string, unknown>
+): ProcessedEvent {
+  return {
+    $type: 'commit',
+    seq,
+    time: new Date(Date.UTC(2026, 0, 1, 0, 0, seq)).toISOString(),
+    repo: AUTHOR,
+    collection: 'pub.chive.eprint.submission',
+    rkey,
+    action,
+    cid: `bafyreirecon${rkey}${action}`,
+    ...(record ? { record } : {}),
+  } as ProcessedEvent;
+}
+
+/**
+ * A fixed firehose log.
+ *
+ * @remarks
+ * It includes an update and a delete, not only creates: a replay that handles
+ * creates but loses ordering would still reproduce a create-only log, so a
+ * create-only fixture would pass while proving nothing.
+ */
+const FIREHOSE_LOG: readonly ProcessedEvent[] = [
+  commit(1, 'alpha', 'create', submissionRecord('Alpha', 'First submission.')),
+  commit(2, 'beta', 'create', submissionRecord('Beta', 'Second submission.')),
+  commit(3, 'alpha', 'update', submissionRecord('Alpha Revised', 'First submission, revised.')),
+  commit(4, 'gamma', 'create', submissionRecord('Gamma', 'Third submission.')),
+  commit(5, 'beta', 'delete'),
+];
+
+describe('ATProto compliance: the index is rebuildable from the firehose', () => {
+  let pool: Pool;
+  let storage: PostgreSQLAdapter;
+  let search: ReturnType<typeof createRecordingSearch>;
+  let replay: () => Promise<void>;
+
+  beforeAll(() => {
+    pool = new Pool(getDatabaseConfig());
+    storage = new PostgreSQLAdapter(pool);
+    search = createRecordingSearch();
+
+    const eprintService = new EprintService({
+      storage,
+      search,
+      repository: createRepository(),
+      identity: createIdentity(),
+      logger: createLogger(),
+    });
+
+    const process = createEventProcessor({
+      pool,
+      activity: {
+        correlateWithFirehose: vi.fn().mockResolvedValue({ ok: true, value: null }),
+      },
+      eprintService,
+      reviewService: {},
+      graphService: {},
+      identity: createIdentity(),
+      logger: createLogger(),
+      storage,
+    } as unknown as Parameters<typeof createEventProcessor>[0]);
+
+    replay = async () => {
+      for (const event of FIREHOSE_LOG) {
+        await process(event);
+      }
+    };
+  });
+
+  afterAll(async () => {
+    await wipeIndex();
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await wipeIndex();
+    search.documents.clear();
+  });
+
+  /** The WHERE clause and parameter selecting this test's rows in one table. */
+  function scope(spec: (typeof INDEX_TABLES)[number]): { where: string; param: string } {
+    return spec.match === 'prefix'
+      ? { where: `${spec.column} LIKE $1`, param: `at://${AUTHOR}/%` }
+      : { where: `${spec.column} = $1`, param: AUTHOR };
+  }
+
+  /** Delete everything this test's DID owns, as a lost database would. */
+  async function wipeIndex(): Promise<void> {
+    for (const spec of INDEX_TABLES) {
+      const { where, param } = scope(spec);
+      await pool.query(`DELETE FROM ${spec.table} WHERE ${where}`, [param]);
+    }
+  }
+
+  /** Read the indexed rows this test's DID owns, ordered deterministically. */
+  async function snapshotRows(): Promise<Record<string, unknown[]>> {
+    const snapshot: Record<string, unknown[]> = {};
+    for (const spec of INDEX_TABLES) {
+      const { where, param } = scope(spec);
+      const result = await pool.query<Record<string, unknown>>(
+        `SELECT * FROM ${spec.table} WHERE ${where} ORDER BY ${spec.column}`,
+        [param]
+      );
+      snapshot[spec.table] = result.rows.map((row) => {
+        const stable: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(row)) {
+          if (!(LOCAL_TIMESTAMP_COLUMNS as readonly string[]).includes(key)) stable[key] = value;
+        }
+        return stable;
+      });
+    }
+    return snapshot;
+  }
+
+  function snapshotSearch(): Record<string, unknown> {
+    return Object.fromEntries(
+      [...search.documents.entries()].sort(([a], [b]) => a.localeCompare(b))
+    );
+  }
+
+  it('replaying the same log twice produces the same index', async () => {
+    await replay();
+    const firstRows = await snapshotRows();
+    const firstSearch = snapshotSearch();
+
+    // Guard against a vacuous pass: two empty snapshots would match trivially.
+    expect(firstRows.eprints_index?.length ?? 0).toBeGreaterThan(0);
+    expect(Object.keys(firstSearch).length).toBeGreaterThan(0);
+
+    // Guard the exemption list: every excluded column must exist on the table
+    // it was excluded from. A renamed column would otherwise silently drop out
+    // of the comparison and take its real differences with it.
+    const rawEprints = await pool.query<Record<string, unknown>>(
+      `SELECT * FROM eprints_index WHERE uri LIKE $1 LIMIT 1`,
+      [`at://${AUTHOR}/%`]
+    );
+    const columns = Object.keys(rawEprints.rows[0] ?? {});
+    for (const excluded of LOCAL_TIMESTAMP_COLUMNS) {
+      expect(columns, `${excluded} is excluded from the comparison`).toContain(excluded);
+    }
+
+    await wipeIndex();
+    search.documents.clear();
+    expect((await snapshotRows()).eprints_index).toEqual([]);
+
+    await replay();
+
+    const secondRows = await snapshotRows();
+    // Compare per table so a failure names which index diverged.
+    for (const spec of INDEX_TABLES) {
+      expect(secondRows[spec.table], spec.table).toEqual(firstRows[spec.table]);
+    }
+    expect(snapshotSearch()).toEqual(firstSearch);
+  });
+
+  it('the rebuilt index reflects the log, not just its final create', async () => {
+    await replay();
+    const rows = ((await snapshotRows()).eprints_index ?? []) as Record<string, unknown>[];
+    const byUri = new Map(rows.map((row) => [String(row.uri), row]));
+
+    // The update at seq 3 must have been applied...
+    expect(byUri.get(`at://${AUTHOR}/pub.chive.eprint.submission/alpha`)?.title).toBe(
+      'Alpha Revised'
+    );
+    // ...and the delete at seq 5 must have tombstoned the record it named.
+    // The row survives on purpose: a hard delete would drop the evidence that
+    // the author retracted the eprint, which a later replay could not recover.
+    // `deleted_at` is a processing stamp and so is normalized out of the
+    // snapshot; read it from the table directly.
+    const tombstones = await pool.query<{ uri: string; deleted_at: Date | null }>(
+      `SELECT uri, deleted_at FROM eprints_index WHERE uri LIKE $1`,
+      [`at://${AUTHOR}/%`]
+    );
+    const deletedAt = new Map(tombstones.rows.map((row) => [row.uri, row.deleted_at]));
+
+    expect(byUri.has(`at://${AUTHOR}/pub.chive.eprint.submission/beta`)).toBe(true);
+    expect(deletedAt.get(`at://${AUTHOR}/pub.chive.eprint.submission/beta`)).not.toBeNull();
+    expect(deletedAt.get(`at://${AUTHOR}/pub.chive.eprint.submission/gamma`)).toBeNull();
+  });
+
+  it('the PDS wins when the local index disagrees with the record', async () => {
+    await replay();
+
+    // Corrupt the index the way a bad write or a stale row would.
+    await pool.query(`UPDATE eprints_index SET title = $1 WHERE uri = $2`, [
+      'Locally Corrupted Title',
+      `at://${AUTHOR}/pub.chive.eprint.submission/alpha`,
+    ]);
+
+    const corrupted = await pool.query(`SELECT title FROM eprints_index WHERE uri = $1`, [
+      `at://${AUTHOR}/pub.chive.eprint.submission/alpha`,
+    ]);
+    expect(corrupted.rows[0]?.title).toBe('Locally Corrupted Title');
+
+    // Re-deliver the same log. Chive holds no authority over the record, so
+    // the replayed value must overwrite the local one rather than be merged
+    // with it or skipped as already-seen.
+    await replay();
+
+    const rows = await pool.query(`SELECT title FROM eprints_index WHERE uri = $1`, [
+      `at://${AUTHOR}/pub.chive.eprint.submission/alpha`,
+    ]);
+    expect(rows.rows[0]?.title).toBe('Alpha Revised');
+  });
+});

--- a/tests/unit/compliance/source-scan.test.ts
+++ b/tests/unit/compliance/source-scan.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  PDS_WRITE_CALLS,
+  findCalls,
+  readExecutableSource,
+  stripCommentsAndStrings,
+} from '../../compliance/helpers/source-scan.js';
+
+describe('stripCommentsAndStrings', () => {
+  it('blanks line comments', () => {
+    const out = stripCommentsAndStrings('const a = 1; // createRecord(x)\nconst b = 2;');
+    expect(out).not.toContain('createRecord');
+    expect(out).toContain('const a = 1;');
+    expect(out).toContain('const b = 2;');
+  });
+
+  it('blanks block comments, including multi-line ones', () => {
+    const out = stripCommentsAndStrings('/* NO createRecord\n   here */ const a = 1;');
+    expect(out).not.toContain('createRecord');
+    expect(out).toContain('const a = 1;');
+  });
+
+  it('blanks the contents of every string form', () => {
+    const out = stripCommentsAndStrings(
+      `const a = 'createRecord('; const b = "putRecord("; const c = \`deleteRecord(\`;`
+    );
+    expect(out).not.toContain('createRecord');
+    expect(out).not.toContain('putRecord');
+    expect(out).not.toContain('deleteRecord');
+  });
+
+  it('does not treat an apostrophe inside a comment as a string opener', () => {
+    // Without comment handling running first, the apostrophe in "doesn't"
+    // would open a string and swallow the real call on the next line.
+    const out = stripCommentsAndStrings("// this doesn't write\nagent.createRecord(x);");
+    expect(out).toContain('createRecord');
+  });
+
+  it('does not treat a quote inside a string as a comment', () => {
+    const out = stripCommentsAndStrings(`const a = 'http://example.com'; agent.putRecord(x);`);
+    expect(out).toContain('putRecord');
+    expect(out).not.toContain('example.com');
+  });
+
+  it('handles an escaped quote without ending the string early', () => {
+    const out = stripCommentsAndStrings(`const a = 'it\\'s createRecord('; const b = 2;`);
+    expect(out).not.toContain('createRecord');
+    expect(out).toContain('const b = 2;');
+  });
+
+  it('preserves length so offsets still line up', () => {
+    const input = "const a = 'hidden'; // note\nconst b = 2;";
+    expect(stripCommentsAndStrings(input)).toHaveLength(input.length);
+  });
+
+  it('preserves newlines so line numbers still line up', () => {
+    const input = '/* one\ntwo\nthree */\nconst a = 1;';
+    const out = stripCommentsAndStrings(input);
+    expect(out.split('\n')).toHaveLength(input.split('\n').length);
+  });
+
+  it('leaves ordinary code untouched', () => {
+    const input = 'const x = a / b; const y = c /= d;';
+    expect(stripCommentsAndStrings(input)).toBe(input);
+  });
+});
+
+describe('findCalls', () => {
+  it('finds a method call on a receiver', () => {
+    expect(findCalls('agent.createRecord(x)', PDS_WRITE_CALLS)).toEqual(['createRecord']);
+  });
+
+  it('finds a bare call', () => {
+    expect(findCalls('createRecord(x)', PDS_WRITE_CALLS)).toEqual(['createRecord']);
+  });
+
+  it('finds a call carrying an explicit type argument', () => {
+    expect(findCalls('repo.getRecord<RawFacetRecord>(uri)', ['getRecord'])).toEqual(['getRecord']);
+  });
+
+  it('finds a call carrying nested type arguments', () => {
+    expect(findCalls('repo.listRecords<Map<string, Raw>>(nsid)', ['listRecords'])).toEqual([
+      'listRecords',
+    ]);
+  });
+
+  it('tolerates whitespace before the parenthesis', () => {
+    expect(findCalls('agent.putRecord  (x)', PDS_WRITE_CALLS)).toEqual(['putRecord']);
+  });
+
+  it('does not match a longer identifier that ends with the method name', () => {
+    expect(findCalls('safeCreateRecord(x)', ['createRecord'])).toEqual([]);
+  });
+
+  it('does not match a longer identifier that starts with the method name', () => {
+    expect(findCalls('createRecordSafely(x)', ['createRecord'])).toEqual([]);
+  });
+
+  it('does not match a property read', () => {
+    expect(findCalls('const f = agent.createRecord;', ['createRecord'])).toEqual([]);
+  });
+
+  it('returns nothing for source with no calls', () => {
+    expect(findCalls('const a = 1;', PDS_WRITE_CALLS)).toEqual([]);
+  });
+
+  it('deduplicates repeated calls', () => {
+    expect(findCalls('a.putRecord(x); b.putRecord(y);', ['putRecord'])).toEqual(['putRecord']);
+  });
+});
+
+describe('readExecutableSource', () => {
+  it('reads a real file and strips its comments', () => {
+    const source = readExecutableSource('tests/compliance/helpers/source-scan.ts');
+    expect(source.length).toBeGreaterThan(0);
+    // The forbidden names appear throughout this file's own prose and in the
+    // PDS_WRITE_CALLS literal; neither is a call, so neither should survive.
+    expect(findCalls(source, ['createRecord', 'putRecord'])).toEqual([]);
+  });
+
+  it('throws rather than returning empty for a missing file', () => {
+    // A compliance test naming a moved file must fail, not pass vacuously.
+    expect(() => readExecutableSource('src/does/not/exist.ts')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

CI-4. Twenty-four tests in the ATProto compliance suite had the body `expect(true).toBe(true)` under a comment describing what had been checked by hand. They reported passes without checking anything — worse than having no test, because `npm run test:compliance` is a required gate and its green result was read as coverage the suite did not have. The most expensive golden rule, that every index is rebuildable from the firehose, had no executable test at all: its verification was the existence of a cursor table, which demonstrates nothing about whether a replay reproduces the state it replaced.

## Rebuildability now has a real test

`tests/integration/compliance/index-reconstruction.test.ts` replays a fixed firehose log through the real event processor against a real PostgreSQL index, snapshots the result, deletes the index the way a lost database would, replays the identical log, and requires the two snapshots to match.

Three things make it hard to pass by accident:

- **The log is not create-only.** It contains an update at seq 3 and a delete at seq 5, so a replay that handled creates but lost ordering would still be caught. A separate test asserts the update was applied and the delete tombstoned the record it named.
- **The empty case is excluded.** Two empty snapshots would match trivially, so the test asserts the first snapshot is non-empty and that the wipe actually emptied the table.
- **The exemption list is guarded.** Three columns — `indexed_at`, `last_synced_at`, `deleted_at` — are wall-clock stamps taken at processing time, so two replays necessarily disagree on them. They are normalized out; every other column, `deletion_source` and `created_at` and `updated_at` included, must match exactly. The test then asserts each excluded column still *exists* on the table, so a rename cannot quietly widen the exemption.

Verified by mutation: inserting one spurious row between the replays fails the comparison.

Two further rules the backlog flagged as untested are now executable in the same file: **PDS-wins-on-conflict** (corrupt a row locally, replay, require the record's value to win) and, in the compliance suite, **BlobProxy ephemerality**.

## The 24 vacuous assertions

Each now checks the thing its title claims. Most reduce to one proposition — *this service never writes to a user's PDS* — which is a claim about absence, awkward to demonstrate by executing code and exact to check by reading it. `tests/compliance/helpers/source-scan.ts` reads the real source with comments and string literals stripped, then looks for calls to `createRecord`, `putRecord`, `deleteRecord`, `applyWrites`, `uploadBlob`, `importRepo`.

Stripping first is what makes it sound. Without it a comment reading "never calls createRecord" registers as a call, and a check written to *require* a call passes on the strength of a comment — the same failure mode being fixed here, one level down.

Where source is the wrong instrument, the tests read the real artifact instead: the OTEL collector manifest must name a ServiceAccount and hold no ClusterRole; every verb on Promtail's ClusterRole must be a read; alert rules must contain nothing credential- or DID-shaped, since alert payloads leave the cluster's trust boundary and cannot be recalled.

Verified by mutation: adding a `createRecord` call to `metrics-service.ts` fails two tests with `expected [ 'createRecord' ] to deeply equal []`.

## Testing

- Compliance: 14/14 files pass
- Unit: 207 files pass, including 21 new tests for the scanner itself — it is load-bearing now, so its own handling of nested comments, escaped quotes, apostrophes in prose, generic type arguments, and near-miss identifiers is tested
- Integration: 31 passed, 1 skipped
- `tsc --noEmit` clean; lint clean

## Note for whoever runs this locally

The suite needs `POSTGRES_DB=chive_test`; the default in `getDatabaseConfig()` is `chive`, which the Docker test stack does not create. That mismatch is CI-12 and is not fixed here.

## Compliance

Tests only. No production code changed.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose — now actually verified
- [x] Tracks PDS source
