### PR TITLE
Default the test suites to the Docker test stack database

### DIFF
--- a/tests/setup/global-setup.ts
+++ b/tests/setup/global-setup.ts
@@ -26,6 +26,8 @@ import {
 import { createNeo4jDriver, setupNeo4j } from '../../src/storage/neo4j/setup.js';
 import { getMigrationConfig } from '../../src/storage/postgresql/config.js';
 
+import { applyTestStackDefaults } from './test-env.js';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '../..');
 
@@ -37,6 +39,9 @@ const rootDir = path.resolve(__dirname, '../..');
  */
 export default async function setup(): Promise<void> {
   console.log('🔧 Running global test setup...');
+
+  // Must precede getMigrationConfig(): the migration URL is built from these.
+  applyTestStackDefaults();
 
   // PostgreSQL migrations - use tsx to support TypeScript migrations
   try {

--- a/tests/setup/test-env.ts
+++ b/tests/setup/test-env.ts
@@ -1,0 +1,65 @@
+/**
+ * Default connection settings for the local test stack.
+ *
+ * @remarks
+ * `getDatabaseConfig()` defaults `POSTGRES_DB` to `chive`, which is right for a
+ * deployment reading its configuration from the environment. The Docker test
+ * stack creates `chive_test`, so following the documented local flow —
+ * `./scripts/start-test-stack.sh` then `npm run test:compliance` — failed at
+ * migration time with `role "chive" does not exist`, a message that points at
+ * authentication rather than at the database name actually responsible.
+ *
+ * These defaults close that gap. Every one of them yields to an explicit value:
+ * CI sets the same variables, and a developer pointing the suite at another
+ * instance keeps doing so.
+ *
+ * @packageDocumentation
+ */
+
+/** Connection settings matching `docker/docker-compose.yml`. */
+export const TEST_STACK_DEFAULTS: Readonly<Record<string, string>> = {
+  POSTGRES_HOST: '127.0.0.1',
+  POSTGRES_PORT: '5432',
+  POSTGRES_DB: 'chive_test',
+  POSTGRES_USER: 'chive',
+  POSTGRES_PASSWORD: 'chive_test_password',
+  ELASTICSEARCH_URL: 'http://127.0.0.1:9200',
+  REDIS_URL: 'redis://127.0.0.1:6379',
+  NEO4J_URI: 'bolt://127.0.0.1:7687',
+  NEO4J_USER: 'neo4j',
+  NEO4J_PASSWORD: 'chive_test_password',
+};
+
+/**
+ * Resolve the test environment, preferring anything already set.
+ *
+ * @returns The variables to expose to tests
+ *
+ * @remarks
+ * Returning rather than mutating lets a Vitest config spread the result into
+ * `test.env` without a side effect at config-load time.
+ *
+ * @public
+ */
+export function testStackEnv(): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  for (const [key, fallback] of Object.entries(TEST_STACK_DEFAULTS)) {
+    resolved[key] = process.env[key] ?? fallback;
+  }
+  return resolved;
+}
+
+/**
+ * Apply the defaults to `process.env` for anything running outside a test file.
+ *
+ * @remarks
+ * Global setup runs migrations in the main process, before `test.env` reaches
+ * any worker, so it needs the values on `process.env` itself.
+ *
+ * @public
+ */
+export function applyTestStackDefaults(): void {
+  for (const [key, value] of Object.entries(TEST_STACK_DEFAULTS)) {
+    process.env[key] ??= value;
+  }
+}

--- a/tests/unit/setup/test-env.test.ts
+++ b/tests/unit/setup/test-env.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { TEST_STACK_DEFAULTS, applyTestStackDefaults, testStackEnv } from '../../setup/test-env.js';
+
+const KEYS = Object.keys(TEST_STACK_DEFAULTS);
+
+describe('testStackEnv', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it('supplies the Docker test stack database name', () => {
+    // The production default is `chive`; the stack creates `chive_test`, and
+    // the mismatch is what made the documented local flow fail.
+    expect(testStackEnv().POSTGRES_DB).toBe('chive_test');
+  });
+
+  it('supplies every key it declares', () => {
+    const env = testStackEnv();
+    for (const key of KEYS) {
+      expect(env[key], key).toBeDefined();
+    }
+  });
+
+  it('yields to a value already in the environment', () => {
+    process.env.POSTGRES_DB = 'somewhere_else';
+    expect(testStackEnv().POSTGRES_DB).toBe('somewhere_else');
+  });
+
+  it('yields per variable, not all or nothing', () => {
+    process.env.POSTGRES_PORT = '15432';
+    const env = testStackEnv();
+    expect(env.POSTGRES_PORT).toBe('15432');
+    expect(env.POSTGRES_DB).toBe('chive_test');
+  });
+
+  it('does not mutate the environment', () => {
+    testStackEnv();
+    expect(process.env.POSTGRES_DB).toBeUndefined();
+  });
+
+  it('treats an empty string as set, since an operator may mean it', () => {
+    process.env.POSTGRES_PASSWORD = '';
+    expect(testStackEnv().POSTGRES_PASSWORD).toBe('');
+  });
+});
+
+describe('applyTestStackDefaults', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it('writes the defaults onto process.env', () => {
+    applyTestStackDefaults();
+    expect(process.env.POSTGRES_DB).toBe('chive_test');
+    expect(process.env.NEO4J_URI).toBe('bolt://127.0.0.1:7687');
+  });
+
+  it('leaves an existing value alone', () => {
+    process.env.POSTGRES_DB = 'chosen_by_ci';
+    applyTestStackDefaults();
+    expect(process.env.POSTGRES_DB).toBe('chosen_by_ci');
+  });
+
+  it('is idempotent', () => {
+    applyTestStackDefaults();
+    applyTestStackDefaults();
+    expect(process.env.POSTGRES_DB).toBe('chive_test');
+  });
+});

--- a/vitest.compliance.config.ts
+++ b/vitest.compliance.config.ts
@@ -2,8 +2,12 @@ import path from 'path';
 
 import { defineConfig } from 'vitest/config';
 
+import { testStackEnv } from './tests/setup/test-env.js';
+
 export default defineConfig({
   test: {
+    // Point the suite at the Docker test stack unless told otherwise.
+    env: testStackEnv(),
     globals: true,
     environment: 'node',
     // Run migrations and setup before compliance tests

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,12 @@ import path from 'path';
 
 import { defineConfig } from 'vitest/config';
 
+import { testStackEnv } from './tests/setup/test-env.js';
+
 export default defineConfig({
   test: {
+    // Point the suite at the Docker test stack unless told otherwise.
+    env: testStackEnv(),
     globals: true,
     environment: 'node',
     globalSetup: ['./tests/setup/global-setup.ts'],

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -2,6 +2,8 @@ import path from 'path';
 
 import { defineConfig } from 'vitest/config';
 
+import { testStackEnv } from './tests/setup/test-env.js';
+
 /**
  * Vitest configuration for unit tests only.
  *
@@ -13,6 +15,8 @@ import { defineConfig } from 'vitest/config';
  */
 export default defineConfig({
   test: {
+    // Point the suite at the Docker test stack unless told otherwise.
+    env: testStackEnv(),
     globals: true,
     environment: 'node',
     // No globalSetup - unit tests should not require databases


### PR DESCRIPTION
## Summary

Following the documented local flow — `./scripts/start-test-stack.sh`, then `npm run test:compliance` — fails:

```
could not connect to postgres: error: role "chive" does not exist
```

The message points at authentication. The actual cause is the database name: `getDatabaseConfig()` defaults `POSTGRES_DB` to `chive`, while `docker/docker-compose.yml` creates `chive_test`. Postgres reports a missing role rather than a missing database when the connection names a database it cannot open, so the error sends you looking in the wrong place. CI passes because its workflow sets `POSTGRES_DB` explicitly; only local runs hit it.

## Approach

`tests/setup/test-env.ts` holds the connection settings matching the compose file, applied in two places because they are needed at two different times:

- `testStackEnv()` is spread into `test.env` in the three Vitest configs, for what test files read
- `applyTestStackDefaults()` runs at the top of `tests/setup/global-setup.ts`, before `getMigrationConfig()` — migrations run in the main process, ahead of `test.env` reaching any worker

The production default in `getDatabaseConfig()` is left alone. `chive` is the right default for a deployment reading its configuration from the environment; the test suites are what needed a test-shaped default.

Every value yields to one already set, per variable rather than all-or-nothing, so CI's explicit settings win and pointing the suite at another instance still works — that is how I verified this, running against a forwarded stack on a non-default port with only `POSTGRES_PORT` set.

Playwright already did this (`playwright.config.ts:135-143`); this brings the Vitest side in line.

## Testing

- `npm run test:compliance` with `POSTGRES_DB` unset: 14/14 files pass (previously failed at migration)
- 9 new tests in `tests/unit/setup/test-env.test.ts` — defaults supplied, per-variable override, no mutation of `process.env`, idempotence, and empty string treated as set rather than absent
- Unit: 207 files pass; `tsc --noEmit` clean; lint clean

## Compliance

Test configuration only. No production code or data flow changed.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source
