### PR TITLE
Measure coverage over all of src so the percentage stops describing only the tested subset

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
+      // Count every source file, not only the ones a test imports. See the
+      // longer note in vitest.unit.config.ts: without this the percentage is
+      // the tested subset measured against itself.
+      include: ['src/**/*.ts'],
       exclude: [
         'node_modules/',
         'dist/',
@@ -25,10 +29,17 @@ export default defineConfig({
         '**/lexicons/**',
       ],
       thresholds: {
-        lines: 80,
-        functions: 80,
-        branches: 75,
-        statements: 80,
+        // The full suite — unit, integration and compliance — measured over
+        // all of `src/`. The previous 80 matched the bar in CLAUDE.md rather
+        // than anything the suite achieved, and no workflow ran this config
+        // with `--coverage`, so it never failed and never said so.
+        //
+        // A floor, not a target. 80% remains the goal; raise these as coverage
+        // improves and never lower them for a new gap.
+        lines: 52,
+        functions: 54,
+        branches: 45,
+        statements: 52,
       },
     },
     include: [

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -24,6 +24,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
+      // Count every source file, not only the ones a test happens to import.
+      // Without this, v8 measures the tested subset against itself: a large
+      // module with no test at all simply left the denominator, so coverage
+      // could rise by deleting a test or fall by writing the first one for a
+      // big file. The percentage below is therefore of all of `src/`.
+      include: ['src/**/*.ts'],
       exclude: [
         'node_modules/',
         'dist/',
@@ -34,19 +40,23 @@ export default defineConfig({
         '**/lexicons/**',
       ],
       thresholds: {
-        // These sit below the 80% line / 100%-critical-path bar stated in
-        // CLAUDE.md. They were lowered to match what the suite actually
-        // achieved and the gap was never recorded anywhere but this TODO, so
-        // the stated bar and the enforced one have disagreed since.
+        // Measured over all of `src/`, which is the first time these numbers
+        // have meant that. The previous 70 was a percentage of the files a
+        // test imported, and roughly a third of the tree was outside that set;
+        // measured properly the same suite covers 46% of lines. Nothing got
+        // worse here — the figure was always this, and the earlier one was
+        // reporting a subset against itself.
         //
-        // Treat these as a ratchet, not as the target: raise them as coverage
-        // improves rather than lowering them to accommodate a new gap. The
-        // frontend equivalent lives in web/vitest.config.ts and is further
-        // behind still.
-        lines: 70,
-        functions: 70,
-        branches: 58,
-        statements: 70,
+        // These sit far below the 80% line / 100%-critical-path bar stated in
+        // CLAUDE.md. That bar remains the target; these are a floor.
+        //
+        // Treat them as a ratchet: raise them as coverage improves, never
+        // lower them to accommodate a new gap. The frontend equivalent lives
+        // in web/vitest.config.ts and is further behind still.
+        lines: 46,
+        functions: 48,
+        branches: 41,
+        statements: 46,
       },
     },
     include: [


### PR DESCRIPTION
## Summary

CI-5. The v8 provider was measuring only files that a test imported. A module with no test at all simply left the denominator — so coverage could *rise* by deleting a test, and *fall* by writing the first one for a large file. The reported 70% was the tested subset measured against itself.

Adding `include: ['src/**/*.ts']` makes the number mean what it reads as.

## What the real numbers are

| | reported before | measured over all of `src/` |
|---|---|---|
| Unit suite (the CI gate) | 70% lines | **46.4%** |
| Full suite (unit + integration + compliance) | 80% lines | **52.2%** |

**Nothing got worse.** The figure was always this; the old one was reporting a fraction of the tree. The thresholds now sit just under the measured values, as a ratchet — raise them as coverage improves, never lower them for a new gap. The 80% bar in CLAUDE.md stays the target, and the gap to it is now visible instead of hidden in the denominator.

The full-suite config had a second problem: its 80% threshold matched the stated bar rather than anything the suite achieved, and **no workflow ran that config with `--coverage`** — so it never failed and never said so. It is now enforceable and honest.

## What this does not do

CI-5 also asks for a per-plugin wire-or-delete decision on 12 dead-plugin test files (~11,300 lines testing classes nothing instantiates). Deleting 22 plugin implementations is a product call, not a mechanical one, and it belongs with the DEAD-2/3/4 decisions still waiting on you. What this PR fixes is the part that was actively lying: those tests were inflating a number people read as a quality gate. With the denominator corrected they no longer can, whatever is eventually decided about the plugins themselves.

## Testing

- Unit: 206 files pass, coverage 46.42/41.3/48.72/46.4 against thresholds 46/41/48/46
- Full: 250 passed, 1 skipped, coverage 52.03/45.78/54.49/52.11 against thresholds 52/45/54/52
- Verified both configs pass their new thresholds rather than being set and left unchecked

## Compliance

Test configuration only. No production code changed.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source
