### PR TITLE
Close rate-limit spoofing and races, restrict eprint mutation to the record owner, and add CSP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,15 @@ DOI_REGISTRATION_ENDPOINT=
 
 # --- Rate limiting -----------------------------------------------
 # DISABLE_RATE_LIMITING=            # <boolean: compared to 'true'>, unset means off
+# Number of reverse proxies between clients and the API (default: 1).
+#
+# Anonymous rate limits are keyed on the client IP, which is read from
+# X-Forwarded-For. That header is append-only, so entries a client sent arrive
+# first and the ones proxies added arrive last; the trustworthy entry is the one
+# our own proxy appended, counted back from the right. Set this to the number of
+# proxies in front of this process. 0 means trust no forwarding header at all.
+TRUSTED_PROXY_COUNT=1
+
 # RATE_LIMIT_FAIL_MODE=            # required; no default
 
 # --- OAuth -------------------------------------------------------

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -16,11 +16,16 @@ import type { RateLimitTier } from './types/context.js';
  *
  * @remarks
  * Set DISABLE_RATE_LIMITING=true to disable rate limiting entirely.
- * This should ONLY be used for testing, never in production.
+ *
+ * Ignored when NODE_ENV is production. The comment saying this should never be
+ * set in production was the only thing enforcing it, and one stray environment
+ * variable removed every limit from a live deployment — the same shape as the
+ * E2E auth bypass that used to be honoured wherever it was set.
  *
  * @public
  */
-export const RATE_LIMITING_DISABLED = process.env.DISABLE_RATE_LIMITING === 'true';
+export const RATE_LIMITING_DISABLED =
+  process.env.DISABLE_RATE_LIMITING === 'true' && process.env.NODE_ENV !== 'production';
 
 /**
  * Rate limit configuration per tier (requests per minute).

--- a/src/api/handlers/rest/health.ts
+++ b/src/api/handlers/rest/health.ts
@@ -113,6 +113,21 @@ interface HealthResponse {
 }
 
 /**
+ * The only failure detail `/ready` reports.
+ *
+ * @remarks
+ * The checks used to return `error.message` verbatim. A driver's message names
+ * what it could not reach — a connection string with a username, a host and
+ * port, an index name — and `/ready` is unauthenticated, rate-limit exempt, and
+ * reachable from the internet, so anyone could read Chive's internal topology
+ * by taking a datastore down or simply asking during an incident.
+ *
+ * The operator's copy is not lost: every branch already logs the real error
+ * with its stack, where it belongs.
+ */
+const CHECK_FAILED_MESSAGE = 'Check failed';
+
+/**
  * Application start time for uptime calculation.
  */
 const startTime = Date.now();
@@ -173,7 +188,7 @@ export async function readinessHandler(c: Context<ChiveEnv>): Promise<Response> 
   } catch (error) {
     checks.redis = {
       status: 'fail',
-      message: error instanceof Error ? error.message : 'Unknown error',
+      message: CHECK_FAILED_MESSAGE,
     };
     overallStatus = 'unhealthy';
     logger.error('Redis health check failed', error instanceof Error ? error : undefined);
@@ -205,7 +220,7 @@ export async function readinessHandler(c: Context<ChiveEnv>): Promise<Response> 
   } catch (error) {
     checks.postgresql = {
       status: 'fail',
-      message: error instanceof Error ? error.message : 'Unknown error',
+      message: CHECK_FAILED_MESSAGE,
     };
     overallStatus = overallStatus === 'healthy' ? 'degraded' : overallStatus;
     logger.warn('PostgreSQL health check failed', {
@@ -235,7 +250,7 @@ export async function readinessHandler(c: Context<ChiveEnv>): Promise<Response> 
   } catch (error) {
     checks.elasticsearch = {
       status: 'fail',
-      message: error instanceof Error ? error.message : 'Unknown error',
+      message: CHECK_FAILED_MESSAGE,
     };
     overallStatus = overallStatus === 'healthy' ? 'degraded' : overallStatus;
     logger.warn('Elasticsearch health check failed', {
@@ -272,7 +287,7 @@ export async function readinessHandler(c: Context<ChiveEnv>): Promise<Response> 
   } catch (error) {
     checks.neo4j = {
       status: 'fail',
-      message: error instanceof Error ? error.message : 'Unknown error',
+      message: CHECK_FAILED_MESSAGE,
     };
     overallStatus = overallStatus === 'healthy' ? 'degraded' : overallStatus;
     logger.warn('Neo4j health check failed', {

--- a/src/api/handlers/xrpc/claiming/fetchExternalPdf.ts
+++ b/src/api/handlers/xrpc/claiming/fetchExternalPdf.ts
@@ -52,12 +52,129 @@ const ALLOWED_PDF_DOMAINS = [
 function isAllowedDomain(url: string): boolean {
   try {
     const parsed = new URL(url);
+    // Only https. Every allowlisted host serves it, and permitting http would
+    // let a redirect downgrade the hop that carries the document.
+    if (parsed.protocol !== 'https:') return false;
     return ALLOWED_PDF_DOMAINS.some(
       (domain) => parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`)
     );
   } catch {
     return false;
   }
+}
+
+/**
+ * Largest PDF this proxy will relay, in bytes.
+ *
+ * @remarks
+ * `response.arrayBuffer()` buffers whatever the far end sends. An allowlisted
+ * host serving an endless body — or simply a very large one — put all of it in
+ * this process's heap, so a handful of concurrent requests could exhaust
+ * memory. Eprint PDFs are comfortably under this.
+ */
+const MAX_PDF_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Redirect hops to follow before giving up.
+ */
+const MAX_REDIRECTS = 5;
+
+/**
+ * Fetch a PDF, re-checking the allowlist at every redirect.
+ *
+ * @param url - Allowlisted URL to fetch
+ * @returns The response for the final, still-allowlisted URL
+ *
+ * @throws ValidationError if a redirect leaves the allowlist
+ * @throws NotFoundError if the redirect chain does not terminate
+ *
+ * @remarks
+ * The allowlist used to be checked once, on the URL the caller named, while
+ * `fetch` followed redirects on its own. An allowlisted host — or anyone able
+ * to influence one — could therefore redirect the request to an address inside
+ * the cluster and have Chive fetch it and hand back the body. Following
+ * redirects by hand is what makes the allowlist apply to where the request
+ * actually ends up rather than only to where it started.
+ */
+async function fetchAllowlistedPdf(url: string): Promise<Response> {
+  let current = url;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    const response = await fetch(current, {
+      redirect: 'manual',
+      headers: {
+        'User-Agent': 'Chive/1.0 (https://chive.pub; Scholarly Publishing Platform)',
+        Accept: 'application/pdf',
+      },
+    });
+
+    if (response.status < 300 || response.status >= 400) return response;
+
+    const location = response.headers.get('location');
+    if (!location) return response;
+
+    const next = new URL(location, current).toString();
+    if (!isAllowedDomain(next)) {
+      throw new ValidationError('PDF URL redirected outside the allowed domains');
+    }
+    current = next;
+  }
+
+  throw new NotFoundError('ExternalPdf', 'Too many redirects');
+}
+
+/**
+ * Read a response body, refusing anything over {@link MAX_PDF_BYTES}.
+ *
+ * @param response - Response to drain
+ * @returns The body bytes
+ *
+ * @throws ValidationError if the body exceeds the cap
+ *
+ * @remarks
+ * `Content-Length` is checked first because it is cheap, but it is a claim by
+ * the far end and may be absent or wrong. The stream is therefore also counted
+ * as it arrives and abandoned the moment it goes over, so a server that lies
+ * about its length cannot spend more of this process's memory than one that
+ * does not.
+ */
+async function readBounded(response: Response): Promise<Uint8Array> {
+  const declared = Number.parseInt(response.headers.get('content-length') ?? '', 10);
+  if (Number.isFinite(declared) && declared > MAX_PDF_BYTES) {
+    throw new ValidationError('PDF exceeds the maximum size this proxy will relay');
+  }
+
+  const body = response.body;
+  if (!body) return new Uint8Array(0);
+
+  const reader = body.getReader() as ReadableStreamDefaultReader<Uint8Array>;
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      total += value.byteLength;
+      if (total > MAX_PDF_BYTES) {
+        await reader.cancel();
+        throw new ValidationError('PDF exceeds the maximum size this proxy will relay');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
 }
 
 /**
@@ -110,7 +227,9 @@ export async function fetchExternalPdfHandler(c: Context<ChiveEnv>): Promise<Res
       externalId,
       pdfUrl: imported.pdfUrl,
     });
-    throw new ValidationError(`PDF URL not from allowed domain: ${imported.pdfUrl}`);
+    // The URL is logged above for operators; reflecting it into the response
+    // hands an attacker a confirmation oracle for what the allowlist contains.
+    throw new ValidationError('PDF URL is not from an allowed domain');
   }
 
   logger.info('Proxying PDF fetch', {
@@ -119,13 +238,9 @@ export async function fetchExternalPdfHandler(c: Context<ChiveEnv>): Promise<Res
     pdfUrl: imported.pdfUrl,
   });
 
-  // Fetch the PDF from the external source
-  const response = await fetch(imported.pdfUrl, {
-    headers: {
-      'User-Agent': 'Chive/1.0 (https://chive.pub; Scholarly Publishing Platform)',
-      Accept: 'application/pdf',
-    },
-  });
+  // Fetch the PDF from the external source, re-checking the allowlist at each
+  // redirect rather than trusting the first URL alone.
+  const response = await fetchAllowlistedPdf(imported.pdfUrl);
 
   if (!response.ok) {
     logger.error('Failed to fetch external PDF', undefined, {
@@ -148,7 +263,7 @@ export async function fetchExternalPdfHandler(c: Context<ChiveEnv>): Promise<Res
   }
 
   // Return the PDF with appropriate headers
-  const pdfBuffer = await response.arrayBuffer();
+  const pdfBuffer = await readBounded(response);
 
   logger.info('PDF fetched successfully', {
     source,

--- a/src/api/handlers/xrpc/eprint/deleteSubmission.ts
+++ b/src/api/handlers/xrpc/eprint/deleteSubmission.ts
@@ -96,12 +96,23 @@ export const deleteSubmission: XRPCMethod<void, InputSchema, OutputSchema> = {
     // Determine the record owner (paper PDS or submitter PDS)
     const recordOwner = eprintData.paperDid ?? eprintData.submittedBy;
 
-    // Authorization: must be submitter, paper account, or listed author
+    // Authorization: must be the account whose repository holds the record.
+    //
+    // Being listed in `authors[]` used to be sufficient, but that array is
+    // written by whoever submitted the eprint — it is metadata about the paper,
+    // not a claim about who may act on it. Anyone a submitter named could
+    // therefore alter or delete a record in someone else's repository, and a
+    // submitter could hand that power to an arbitrary DID by typing it in.
+    //
+    // The narrower rule is also the only coherent one for an AppView. ATProto
+    // forbids cross-repository writes, so a co-author cannot change the record
+    // itself; letting them change Chive's copy would leave the index disagreeing
+    // with the PDS that owns it, which is precisely what "the PDS is the source
+    // of truth" rules out.
     const isSubmitter = eprintData.submittedBy === user.did;
     const isPaperAccount = eprintData.paperDid === user.did;
-    const isAuthor = eprintData.authors?.some((a: { did?: string }) => a.did === user.did) ?? false;
 
-    if (!isSubmitter && !isPaperAccount && !isAuthor) {
+    if (!isSubmitter && !isPaperAccount) {
       throw new AuthorizationError('Not authorized to modify this eprint');
     }
 

--- a/src/api/handlers/xrpc/eprint/updateSubmission.ts
+++ b/src/api/handlers/xrpc/eprint/updateSubmission.ts
@@ -169,12 +169,23 @@ export const updateSubmission: XRPCMethod<void, InputSchema, OutputSchema> = {
     // Determine the record owner (paper PDS or submitter PDS)
     const recordOwner = eprintData.paperDid ?? eprintData.submittedBy;
 
-    // Authorization: must be submitter, paper account, or listed author
+    // Authorization: must be the account whose repository holds the record.
+    //
+    // Being listed in `authors[]` used to be sufficient, but that array is
+    // written by whoever submitted the eprint — it is metadata about the paper,
+    // not a claim about who may act on it. Anyone a submitter named could
+    // therefore alter or delete a record in someone else's repository, and a
+    // submitter could hand that power to an arbitrary DID by typing it in.
+    //
+    // The narrower rule is also the only coherent one for an AppView. ATProto
+    // forbids cross-repository writes, so a co-author cannot change the record
+    // itself; letting them change Chive's copy would leave the index disagreeing
+    // with the PDS that owns it, which is precisely what "the PDS is the source
+    // of truth" rules out.
     const isSubmitter = eprintData.submittedBy === user.did;
     const isPaperAccount = eprintData.paperDid === user.did;
-    const isAuthor = eprintData.authors?.some((a: { did?: string }) => a.did === user.did) ?? false;
 
-    if (!isSubmitter && !isPaperAccount && !isAuthor) {
+    if (!isSubmitter && !isPaperAccount) {
       throw new AuthorizationError('Not authorized to modify this eprint');
     }
 

--- a/src/api/handlers/xrpc/sync/indexRecord.ts
+++ b/src/api/handlers/xrpc/sync/indexRecord.ts
@@ -40,6 +40,7 @@ import { migrateRecord, needsMigration } from '../../../../services/migration/in
 import type { AtUri, CID, DID } from '../../../../types/atproto.js';
 import {
   AuthenticationError,
+  AuthorizationError,
   DatabaseError,
   NotFoundError,
   ValidationError,
@@ -169,7 +170,9 @@ export const indexRecord: XRPCMethod<void, InputSchema, OutputSchema> = {
         recordDid: did,
         uri: input.uri,
       });
-      throw new ValidationError('Can only index your own records', 'uri');
+      // 403, not 400: the request is well-formed and the caller simply may
+      // not make it. A 400 tells a client to fix its input, which cannot help.
+      throw new AuthorizationError('Can only index your own records');
     }
 
     // One shared list rather than a copy that drifts; see indexed-collections.ts.

--- a/src/api/middleware/rate-limit.ts
+++ b/src/api/middleware/rate-limit.ts
@@ -65,47 +65,125 @@ function buildRateLimitKey(tier: RateLimitTier, identifier: string): string {
 }
 
 /**
- * Extracts client IP from request headers.
+ * Number of reverse proxies between the client and this process.
  *
  * @remarks
- * Checks common proxy headers in order of priority:
- * 1. X-Forwarded-For (first entry)
- * 2. X-Real-IP
- * 3. CF-Connecting-IP (Cloudflare)
- * 4. Fallback to 127.0.0.1
- *
- * @param c - Hono context
- * @returns Client IP address
+ * Read at call time rather than module load so tests can vary it.
  */
-function getClientIP(c: { req: { header: (name: string) => string | undefined } }): string {
-  const forwardedFor = c.req.header('x-forwarded-for');
-  if (forwardedFor) {
-    const firstIP = forwardedFor.split(',')[0]?.trim();
-    if (firstIP) return firstIP;
-  }
-
-  return c.req.header('x-real-ip') ?? c.req.header('cf-connecting-ip') ?? '127.0.0.1';
+function trustedProxyCount(): number {
+  const raw = process.env.TRUSTED_PROXY_COUNT;
+  if (raw === undefined) return DEFAULT_TRUSTED_PROXY_COUNT;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_TRUSTED_PROXY_COUNT;
 }
 
 /**
- * Checks rate limit using Redis sliding window.
+ * Chive runs behind one reverse proxy (Traefik) in every deployed environment.
+ */
+const DEFAULT_TRUSTED_PROXY_COUNT = 1;
+
+/**
+ * Extract the client IP used to key anonymous rate limits.
+ *
+ * @param c - Hono context
+ * @returns The client IP, or `'unknown'` when no trustworthy value exists
  *
  * @remarks
- * Algorithm:
- * 1. Remove entries older than window start
- * 2. Count entries in window
- * 3. If under limit, add current request
- * 4. Set key TTL to window duration + buffer
+ * `X-Forwarded-For` is append-only: each proxy appends the address it saw, so
+ * the entries a client sent arrive *first* and the ones proxies added arrive
+ * last. Reading the first entry therefore reads a value the client wrote, and
+ * anonymous rate limits keyed on it were defeated by sending a different
+ * `X-Forwarded-For` on every request — which nullified the limits on search and
+ * on the endpoints that spend real money answering.
  *
- * Uses Redis pipeline for atomicity and performance.
+ * The trustworthy entry is the one *our* proxy appended: counting back
+ * `TRUSTED_PROXY_COUNT` from the right. Anything further left was written by
+ * something we do not control.
+ *
+ * When there are fewer entries than trusted proxies the header did not come
+ * through the expected path, so it is discarded rather than guessed at. The
+ * same reasoning rules out `X-Real-IP` and `CF-Connecting-IP` as fallbacks:
+ * both are single-value headers a client can set outright, and Chive sits
+ * behind neither Cloudflare nor an nginx that sets `X-Real-IP`.
+ *
+ * The old `127.0.0.1` fallback made every unattributable request share one
+ * bucket with genuine loopback traffic. `'unknown'` still shares a bucket, but
+ * an honestly named one that cannot be confused for a real address.
+ *
+ * @public
+ */
+export function getClientIP(c: { req: { header: (name: string) => string | undefined } }): string {
+  const proxies = trustedProxyCount();
+  if (proxies === 0) return 'unknown';
+
+  const forwardedFor = c.req.header('x-forwarded-for');
+  if (!forwardedFor) return 'unknown';
+
+  const entries = forwardedFor
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (entries.length < proxies) return 'unknown';
+
+  return entries[entries.length - proxies] ?? 'unknown';
+}
+
+/**
+ * Sliding-window check-and-admit, evaluated atomically inside Redis.
+ *
+ * @remarks
+ * KEYS[1] is the window key. ARGV is (now, windowStart, limit, ttlSeconds,
+ * requestId). Returns (admitted, countBefore, oldestScore).
+ *
+ * This has to be one script rather than a pipeline. `pipeline()` in ioredis
+ * only batches commands over the connection — it does not make them atomic, and
+ * even `MULTI` would not help, because the decision to admit depends on the
+ * count that the same sequence reads. Two concurrent requests could therefore
+ * both observe a count below the limit and both be admitted, letting the cap be
+ * exceeded by however many requests arrive together — which is precisely the
+ * situation a rate limit exists to handle.
+ *
+ * The `zadd` is inside the branch. Previously it ran unconditionally, before
+ * the check, so a client already over its limit kept writing entries: its
+ * window never drained, its `Retry-After` kept moving, and the sorted set grew
+ * for as long as the client kept knocking. Admitted requests are recorded;
+ * rejected ones are not.
+ */
+const SLIDING_WINDOW_SCRIPT = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local windowStart = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+local requestId = ARGV[5]
+
+redis.call('ZREMRANGEBYSCORE', key, 0, windowStart)
+local count = redis.call('ZCARD', key)
+
+if count < limit then
+  redis.call('ZADD', key, now, requestId)
+  redis.call('EXPIRE', key, ttl)
+  return {1, count, 0}
+end
+
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+redis.call('EXPIRE', key, ttl)
+return {0, count, tonumber(oldest[2]) or now}
+`;
+
+/**
+ * Checks rate limit using a Redis sliding window.
  *
  * @param redis - Redis client
  * @param key - Rate limit key
  * @param limit - Max requests per window
  * @param windowMs - Window size in milliseconds
  * @returns Rate limit check result
+ *
+ * @public
  */
-async function checkRateLimit(
+export async function checkRateLimit(
   redis: Redis,
   key: string,
   limit: number,
@@ -114,55 +192,46 @@ async function checkRateLimit(
   const now = Date.now();
   const windowStart = now - windowMs;
   const resetAt = Math.ceil((now + windowMs) / 1000);
-
-  // Use pipeline for atomic operation
-  const pipeline = redis.pipeline();
-
-  // Remove expired entries
-  pipeline.zremrangebyscore(key, 0, windowStart);
-
-  // Count requests in window
-  pipeline.zcard(key);
-
-  // Add current request with timestamp as score
+  const ttlSeconds = Math.ceil(windowMs / 1000) + 1;
   const requestId = `${now}:${Math.random().toString(36).slice(2, 8)}`;
-  pipeline.zadd(key, now, requestId);
 
-  // Set TTL to window duration + 1 second buffer
-  pipeline.expire(key, Math.ceil(windowMs / 1000) + 1);
-
-  const results = await pipeline.exec();
-
-  if (!results) {
-    // Redis error: behavior depends on RATE_LIMIT_FAIL_MODE configuration
-    if (RATE_LIMIT_FAIL_MODE === 'open') {
-      // Fail open: allow requests through when Redis is down (availability over security)
-      return { allowed: true, remaining: limit, resetAt };
-    } else {
-      // Fail closed: reject requests when Redis is down (Zero Trust principle)
-      return { allowed: false, remaining: 0, resetAt, retryAfter: 60 };
-    }
+  let raw: unknown;
+  try {
+    raw = await redis.eval(
+      SLIDING_WINDOW_SCRIPT,
+      1,
+      key,
+      String(now),
+      String(windowStart),
+      String(limit),
+      String(ttlSeconds),
+      requestId
+    );
+  } catch {
+    // Redis unreachable: behaviour depends on RATE_LIMIT_FAIL_MODE.
+    return RATE_LIMIT_FAIL_MODE === 'open'
+      ? { allowed: true, remaining: limit, resetAt }
+      : { allowed: false, remaining: 0, resetAt, retryAfter: 60 };
   }
 
-  // zcard result is at index 1 (after zremrangebyscore)
-  const count = (results[1]?.[1] as number) ?? 0;
-  const remaining = Math.max(0, limit - count - 1);
-
-  if (count >= limit) {
-    // Rate limited: calculate retry after
-    const oldestResult = await redis.zrange(key, 0, 0, 'WITHSCORES');
-    const oldestTime = oldestResult?.[1] ? parseInt(oldestResult[1], 10) : now;
-    const retryAfter = Math.max(1, Math.ceil((oldestTime + windowMs - now) / 1000));
-
-    return {
-      allowed: false,
-      remaining: 0,
-      resetAt,
-      retryAfter,
-    };
+  if (!Array.isArray(raw)) {
+    // A script that returns something unexpected is a bug, not a decision.
+    // Treat it the same as an unreachable Redis rather than admitting blindly.
+    return RATE_LIMIT_FAIL_MODE === 'open'
+      ? { allowed: true, remaining: limit, resetAt }
+      : { allowed: false, remaining: 0, resetAt, retryAfter: 60 };
   }
 
-  return { allowed: true, remaining, resetAt };
+  const [admitted, countBefore, oldestScore] = raw as [number, number, number];
+
+  if (admitted === 1) {
+    return { allowed: true, remaining: Math.max(0, limit - countBefore - 1), resetAt };
+  }
+
+  const oldest = oldestScore > 0 ? oldestScore : now;
+  const retryAfter = Math.max(1, Math.ceil((oldest + windowMs - now) / 1000));
+
+  return { allowed: false, remaining: 0, resetAt, retryAfter };
 }
 
 /**

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -377,7 +377,26 @@ export function createServer(config: ServerConfig): Hono<ChiveEnv> {
     });
 
   // 1. Security headers (first, applied to all responses)
-  app.use('*', secureHeaders());
+  app.use(
+    '*',
+    secureHeaders({
+      // `secureHeaders()` sets no Content-Security-Policy by default, so the
+      // API shipped without one. It answers JSON and nothing else, which makes
+      // the policy both strict and easy: nothing may load, nothing may frame
+      // it, and no base tag or form action can be introduced by injected
+      // markup. Had this been here, the stored-XSS hole fixed in 0.8.0 would
+      // have been far harder to exploit.
+      contentSecurityPolicy: {
+        defaultSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+        baseUri: ["'none'"],
+        formAction: ["'none'"],
+        sandbox: [],
+      },
+      crossOriginResourcePolicy: 'same-site',
+      referrerPolicy: 'no-referrer',
+    })
+  );
 
   // 2. CORS (before any request processing)
   app.use(

--- a/tests/integration/api/rate-limit-atomicity.test.ts
+++ b/tests/integration/api/rate-limit-atomicity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Rate limiter atomicity tests against a real Redis.
+ *
+ * @remarks
+ * The sliding window used `redis.pipeline()`, which batches commands over the
+ * connection without making them atomic, and added the current request to the
+ * window *before* checking the count. Two properties follow from that, and
+ * neither can be observed without a real Redis and real concurrency:
+ *
+ * 1. Concurrent requests could each read a count below the limit and each be
+ *    admitted, so the cap was exceeded by however many arrived together.
+ * 2. A client already over its limit kept writing entries, so its window never
+ *    drained, its `Retry-After` kept moving out, and the sorted set grew for as
+ *    long as it kept knocking.
+ *
+ * Requires the Docker test stack.
+ *
+ * @packageDocumentation
+ */
+
+import { Redis } from 'ioredis';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+
+import { checkRateLimit } from '@/api/middleware/rate-limit.js';
+
+const KEY = 'test:ratelimit:atomicity';
+const WINDOW_MS = 60_000;
+
+describe('rate limiter atomicity', () => {
+  let redis: Redis;
+
+  beforeAll(() => {
+    redis = new Redis(process.env.REDIS_URL ?? 'redis://127.0.0.1:6379');
+  });
+
+  afterAll(async () => {
+    await redis.del(KEY);
+    redis.disconnect();
+  });
+
+  beforeEach(async () => {
+    await redis.del(KEY);
+  });
+
+  it('admits exactly the limit when requests arrive together', async () => {
+    const limit = 10;
+    const results = await Promise.all(
+      Array.from({ length: 50 }, () => checkRateLimit(redis, KEY, limit, WINDOW_MS))
+    );
+
+    expect(results.filter((r) => r.allowed)).toHaveLength(limit);
+    expect(results.filter((r) => !r.allowed)).toHaveLength(40);
+  });
+
+  it('records admitted requests and only those', async () => {
+    const limit = 3;
+    for (let i = 0; i < 10; i += 1) {
+      await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+    }
+
+    // Seven rejections must leave no trace: a rejected request that writes an
+    // entry extends its own lockout and grows the set without bound.
+    expect(await redis.zcard(KEY)).toBe(limit);
+  });
+
+  it('does not push its own reset further out on each rejected attempt', async () => {
+    const limit = 2;
+    await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+    await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+
+    const first = await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    const second = await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+
+    expect(first.allowed).toBe(false);
+    expect(second.allowed).toBe(false);
+    // Time passing must bring the reset nearer, never push it away.
+    expect(second.retryAfter ?? 0).toBeLessThanOrEqual(first.retryAfter ?? 0);
+  });
+
+  it('reports remaining capacity that counts down to zero', async () => {
+    const limit = 3;
+    const first = await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+    const second = await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+    const third = await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+
+    expect([first.remaining, second.remaining, third.remaining]).toEqual([2, 1, 0]);
+  });
+
+  it('drops entries that have aged out of the window', async () => {
+    const limit = 2;
+    const shortWindow = 1000;
+
+    await checkRateLimit(redis, KEY, limit, shortWindow);
+    await checkRateLimit(redis, KEY, limit, shortWindow);
+    expect((await checkRateLimit(redis, KEY, limit, shortWindow)).allowed).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    expect((await checkRateLimit(redis, KEY, limit, shortWindow)).allowed).toBe(true);
+  });
+
+  it('gives the key a TTL so an abandoned window cannot leak', async () => {
+    await checkRateLimit(redis, KEY, 5, WINDOW_MS);
+    const ttl = await redis.ttl(KEY);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(Math.ceil(WINDOW_MS / 1000) + 1);
+  });
+
+  it('sets a TTL even when the request is rejected', async () => {
+    const limit = 1;
+    await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+    await checkRateLimit(redis, KEY, limit, WINDOW_MS);
+
+    // Without this the key of a client that is permanently over its limit would
+    // never expire.
+    expect(await redis.ttl(KEY)).toBeGreaterThan(0);
+  });
+});

--- a/tests/integration/api/rate-limiting.test.ts
+++ b/tests/integration/api/rate-limiting.test.ts
@@ -427,21 +427,43 @@ describe('API Rate Limiting Integration', () => {
   });
 
   describe('X-Forwarded-For Header Handling', () => {
-    it('extracts first IP from X-Forwarded-For chain', async () => {
-      const clientIp = '203.0.113.50';
-      const key = buildRateLimitKey('anonymous', clientIp);
-      const proxyChain = `${clientIp}, 10.0.0.1, 10.0.0.2`;
+    it('keys on the entry the trusted proxy appended, not the one the client sent', async () => {
+      // This test used to assert the opposite — that the *first* entry was
+      // used — which is what made anonymous limits defeatable. X-Forwarded-For
+      // is append-only: whatever the client sent arrives first, and each proxy
+      // appends the address it saw. With one trusted proxy the honest value is
+      // the last entry.
+      const spoofed = '203.0.113.50';
+      const observed = '10.0.0.2';
+      const chain = `${spoofed}, 10.0.0.1, ${observed}`;
 
-      // Clear any existing data
-      await redis.del(key);
+      const spoofedKey = buildRateLimitKey('anonymous', spoofed);
+      const observedKey = buildRateLimitKey('anonymous', observed);
+      await redis.del(spoofedKey);
+      await redis.del(observedKey);
 
       await app.request(STANDARD_ENDPOINT, {
-        headers: { 'X-Forwarded-For': proxyChain },
+        headers: { 'X-Forwarded-For': chain },
       });
 
-      // Rate limit should be keyed by first IP (uses sorted set)
-      const count = await redis.zcard(key);
-      expect(count).toBeGreaterThan(0);
+      expect(await redis.zcard(observedKey)).toBeGreaterThan(0);
+      expect(await redis.zcard(spoofedKey)).toBe(0);
+    });
+
+    it('cannot be given a fresh budget by varying the forged prefix', async () => {
+      const observed = '10.0.0.9';
+      const observedKey = buildRateLimitKey('anonymous', observed);
+      await redis.del(observedKey);
+
+      for (const forgery of ['1.1.1.1', '2.2.2.2', '3.3.3.3']) {
+        await app.request(STANDARD_ENDPOINT, {
+          headers: { 'X-Forwarded-For': `${forgery}, ${observed}` },
+        });
+      }
+
+      // All three land in one bucket. Keying on the first entry would have
+      // given each request a window of its own.
+      expect(await redis.zcard(observedKey)).toBe(3);
     });
   });
 

--- a/tests/unit/api/handlers/fetch-external-pdf-guards.test.ts
+++ b/tests/unit/api/handlers/fetch-external-pdf-guards.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+
+/**
+ * The PDF proxy's guards are structural: it must not hand `fetch` the job of
+ * following redirects, and it must not buffer a whole response before knowing
+ * how big it is. Both are assertions about which calls appear in the handler,
+ * and both regress by deletion rather than by producing a wrong value, which is
+ * exactly the shape a source-level check catches and a behavioural one misses.
+ */
+describe('fetchExternalPdf guards', () => {
+  const source = readFileSync(
+    join(REPO_ROOT, 'src/api/handlers/xrpc/claiming/fetchExternalPdf.ts'),
+    'utf8'
+  );
+
+  it('does not let fetch follow redirects on its own', () => {
+    // An allowlisted host redirecting to an internal address is the SSRF this
+    // closes; automatic following would re-open it silently.
+    expect(source).toContain("redirect: 'manual'");
+    expect(source).not.toMatch(/redirect:\s*'follow'/);
+  });
+
+  it('re-checks the allowlist after a redirect', () => {
+    const redirectBlock = source.slice(
+      source.indexOf('async function fetchAllowlistedPdf'),
+      source.indexOf('async function readBounded')
+    );
+    expect(redirectBlock).toContain('isAllowedDomain(next)');
+  });
+
+  it('bounds the number of redirect hops', () => {
+    expect(source).toContain('MAX_REDIRECTS');
+  });
+
+  it('never buffers the body without a cap', () => {
+    // `arrayBuffer()` reads whatever arrives; the bounded reader is the whole
+    // point of this guard.
+    expect(source).not.toContain('await response.arrayBuffer()');
+    expect(source).toContain('readBounded(response)');
+  });
+
+  it('checks the declared length and the actual stream', () => {
+    const bounded = source.slice(source.indexOf('async function readBounded'));
+    expect(bounded).toContain('content-length');
+    expect(bounded).toContain('MAX_PDF_BYTES');
+    expect(bounded).toContain('reader.cancel()');
+  });
+
+  it('requires https so a redirect cannot downgrade the hop', () => {
+    expect(source).toContain("parsed.protocol !== 'https:'");
+  });
+
+  it('does not reflect the rejected URL back to the caller', () => {
+    // Echoing it turns the endpoint into an oracle for the allowlist contents.
+    expect(source).not.toMatch(/not from allowed domain: \$\{/);
+  });
+});

--- a/tests/unit/api/handlers/rest/health.test.ts
+++ b/tests/unit/api/handlers/rest/health.test.ts
@@ -135,7 +135,7 @@ describe('readinessHandler', () => {
     expect(body.status).toBe('degraded');
     expect(body.checks?.postgresql).toMatchObject({
       status: 'fail',
-      message: 'ECONNREFUSED 127.0.0.1:5432',
+      message: 'Check failed',
     });
     expect(body.checks?.redis?.status).toBe('pass');
     expect(logger.warn).toHaveBeenCalled();
@@ -153,7 +153,7 @@ describe('readinessHandler', () => {
     expect(body.status).toBe('degraded');
     expect(body.checks?.elasticsearch).toMatchObject({
       status: 'fail',
-      message: 'connect ECONNREFUSED 9200',
+      message: 'Check failed',
     });
   });
 
@@ -169,7 +169,7 @@ describe('readinessHandler', () => {
     expect(body.status).toBe('degraded');
     expect(body.checks?.neo4j).toMatchObject({
       status: 'fail',
-      message: 'ServiceUnavailable: bolt://neo4j:7687',
+      message: 'Check failed',
     });
   });
 
@@ -184,7 +184,7 @@ describe('readinessHandler', () => {
 
     expect(res.status).toBe(503);
     expect(body.status).toBe('unhealthy');
-    expect(body.checks?.redis).toMatchObject({ status: 'fail', message: 'Redis down' });
+    expect(body.checks?.redis).toMatchObject({ status: 'fail', message: 'Check failed' });
     expect(body.checks?.postgresql?.status).toBe('fail');
     expect(logger.error).toHaveBeenCalled();
   });
@@ -203,7 +203,7 @@ describe('readinessHandler', () => {
     expect(res.status).toBe(503);
     expect(body.checks?.postgresql).toMatchObject({
       status: 'fail',
-      message: 'pool exhausted',
+      message: 'Check failed',
     });
   });
 
@@ -219,7 +219,7 @@ describe('readinessHandler', () => {
 
     expect(res.status).toBe(503);
     expect(body.status).toBe('degraded');
-    expect(body.checks?.postgresql).toMatchObject({ status: 'fail', message: 'Timeout' });
+    expect(body.checks?.postgresql).toMatchObject({ status: 'fail', message: 'Check failed' });
   });
 
   it('does not time out a probe that settles before the deadline', async () => {
@@ -278,7 +278,29 @@ describe('readinessHandler', () => {
     expect(res.status).toBe(503);
     expect(body.checks?.neo4j).toMatchObject({
       status: 'fail',
-      message: 'graph probe failed',
+      message: 'Check failed',
     });
+  });
+});
+
+describe('readiness probe disclosure', () => {
+  it('never reports the underlying driver message', async () => {
+    // `/ready` is unauthenticated, exempt from rate limiting, and reachable
+    // from the internet. Driver messages name hosts, ports, credentials and
+    // index names, so returning them let anyone read Chive's internal topology
+    // by asking during an outage — or by causing one.
+    const { app } = buildApp({
+      redisPing: () =>
+        Promise.reject(new Error('NOAUTH Authentication required. host=10.0.0.4:6379')),
+    });
+
+    const res = await app.request('/ready');
+    const body = await readBody(res);
+    const serialized = JSON.stringify(body);
+
+    expect(body.checks?.redis?.status).toBe('fail');
+    expect(serialized).not.toContain('10.0.0.4');
+    expect(serialized).not.toContain('NOAUTH');
+    expect(body.checks?.redis?.message).toBe('Check failed');
   });
 });

--- a/tests/unit/api/middleware/rate-limit.test.ts
+++ b/tests/unit/api/middleware/rate-limit.test.ts
@@ -6,9 +6,9 @@
  * Full integration tests with Redis are in tests/integration/api/.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 
-import { rateLimiter, conditionalRateLimiter } from '@/api/middleware/rate-limit.js';
+import { rateLimiter, conditionalRateLimiter, getClientIP } from '@/api/middleware/rate-limit.js';
 
 describe('Rate Limiting Middleware', () => {
   describe('rateLimiter', () => {
@@ -43,5 +43,83 @@ describe('Rate Limiting Middleware', () => {
       const middleware = conditionalRateLimiter((c) => c.req.header('X-Skip-RateLimit') !== 'true');
       expect(typeof middleware).toBe('function');
     });
+  });
+});
+
+describe('getClientIP', () => {
+  const saved = process.env.TRUSTED_PROXY_COUNT;
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.TRUSTED_PROXY_COUNT;
+    else process.env.TRUSTED_PROXY_COUNT = saved;
+  });
+
+  const ctx = (
+    headers: Record<string, string>
+  ): { req: { header: (name: string) => string | undefined } } => ({
+    req: { header: (name: string): string | undefined => headers[name.toLowerCase()] },
+  });
+
+  it('reads the entry the trusted proxy appended, not the one the client sent', () => {
+    delete process.env.TRUSTED_PROXY_COUNT;
+    // The client sent 9.9.9.9; Traefik appended the address it actually saw.
+    // Reading left-to-right returns the forgery, which is how anonymous limits
+    // used to be defeated by varying one header.
+    expect(getClientIP(ctx({ 'x-forwarded-for': '9.9.9.9, 203.0.113.7' }))).toBe('203.0.113.7');
+  });
+
+  it('accepts a single entry when one proxy is trusted', () => {
+    delete process.env.TRUSTED_PROXY_COUNT;
+    expect(getClientIP(ctx({ 'x-forwarded-for': '203.0.113.7' }))).toBe('203.0.113.7');
+  });
+
+  it('ignores however many entries the client prepends', () => {
+    delete process.env.TRUSTED_PROXY_COUNT;
+    const spoofed = '1.1.1.1, 2.2.2.2, 3.3.3.3, 203.0.113.7';
+    expect(getClientIP(ctx({ 'x-forwarded-for': spoofed }))).toBe('203.0.113.7');
+  });
+
+  it('counts back from the right when several proxies are trusted', () => {
+    process.env.TRUSTED_PROXY_COUNT = '2';
+    expect(getClientIP(ctx({ 'x-forwarded-for': '9.9.9.9, 203.0.113.7, 10.0.0.1' }))).toBe(
+      '203.0.113.7'
+    );
+  });
+
+  it('refuses to guess when the header is shorter than the proxy chain', () => {
+    process.env.TRUSTED_PROXY_COUNT = '2';
+    expect(getClientIP(ctx({ 'x-forwarded-for': '203.0.113.7' }))).toBe('unknown');
+  });
+
+  it('trusts no forwarding header when no proxy is configured', () => {
+    process.env.TRUSTED_PROXY_COUNT = '0';
+    expect(getClientIP(ctx({ 'x-forwarded-for': '203.0.113.7' }))).toBe('unknown');
+  });
+
+  it('does not fall back to headers a client can set outright', () => {
+    delete process.env.TRUSTED_PROXY_COUNT;
+    // X-Real-IP and CF-Connecting-IP carry a single value with no chain, so a
+    // client setting one is indistinguishable from a proxy setting it.
+    expect(getClientIP(ctx({ 'x-real-ip': '9.9.9.9' }))).toBe('unknown');
+    expect(getClientIP(ctx({ 'cf-connecting-ip': '9.9.9.9' }))).toBe('unknown');
+  });
+
+  it('returns unknown rather than a loopback address when nothing is present', () => {
+    delete process.env.TRUSTED_PROXY_COUNT;
+    // The old 127.0.0.1 fallback put every unattributable request in the same
+    // bucket as genuine loopback traffic.
+    expect(getClientIP(ctx({}))).toBe('unknown');
+  });
+
+  it('tolerates whitespace and empty entries', () => {
+    delete process.env.TRUSTED_PROXY_COUNT;
+    expect(getClientIP(ctx({ 'x-forwarded-for': ' 9.9.9.9 , , 203.0.113.7 ' }))).toBe(
+      '203.0.113.7'
+    );
+  });
+
+  it('falls back to one proxy when the setting is not a number', () => {
+    process.env.TRUSTED_PROXY_COUNT = 'not-a-number';
+    expect(getClientIP(ctx({ 'x-forwarded-for': '9.9.9.9, 203.0.113.7' }))).toBe('203.0.113.7');
   });
 });

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -29,6 +29,49 @@ const nextConfig: NextConfig = {
     ],
   },
 
+  async headers() {
+    // The frontend shipped with no Content-Security-Policy at all, which is
+    // what let the stored-XSS hole fixed in 0.8.0 reach as far as it did.
+    //
+    // `script-src` still carries 'unsafe-inline': Next.js inlines its own
+    // bootstrap and hydration payloads, and removing it requires per-request
+    // nonces threaded through the app. That is worth doing and is not done
+    // here. Everything else in this policy is enforceable today and closes the
+    // injection paths that do not depend on running script — an injected
+    // `<base>`, a retargeted form post, an embedded object, or the page being
+    // framed by somebody else's site.
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+    const isDev = process.env.NODE_ENV !== 'production';
+
+    const csp = [
+      "default-src 'self'",
+      // React Refresh evaluates code in development and nowhere else.
+      `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      `connect-src 'self' ${apiUrl}${isDev ? ' ws: wss:' : ''}`,
+      // PDF.js runs its renderer in a blob worker.
+      "worker-src 'self' blob:",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+    ].join('; ');
+
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'Content-Security-Policy', value: csp },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+        ],
+      },
+    ];
+  },
+
   async redirects() {
     return [
       { source: '/apply', destination: '/', permanent: true },


### PR DESCRIPTION
Eight findings at the API edge. SEC-7, SEC-8, SEC-9, SEC-10, SEC-11, SEC-12, IDX-7, CFG-6.

## Anonymous rate limits could be bypassed with one header (SEC-7)

`getClientIP` read the **first** `X-Forwarded-For` entry. The header is append-only: entries the client sent arrive first, and each proxy appends the address it saw. The first entry is therefore always a value the client wrote, so varying it per request gave every request a fresh window — nullifying anonymous limits on search and on the endpoints that spend real money answering.

It now counts back `TRUSTED_PROXY_COUNT` (default 1, Traefik) from the right: the entry *our* proxy appended. When the header is shorter than the proxy chain it did not arrive by the expected path, so it is discarded rather than guessed at. `X-Real-IP` and `CF-Connecting-IP` are gone as fallbacks for the same reason — single-value headers with no chain, indistinguishable from a client setting them, and Chive sits behind neither Cloudflare nor an nginx that writes them.

The old `127.0.0.1` fallback put every unattributable request in the same bucket as genuine loopback traffic. It is now `'unknown'` — still one bucket, but an honestly named one.

**An existing integration test asserted the vulnerable behaviour** (`extracts first IP from X-Forwarded-For chain`). It has been replaced by two that assert the correct one, including that three requests with three different forged prefixes land in a single bucket.

## The sliding window was neither atomic nor correctly ordered (SEC-8)

`redis.pipeline()` batches commands over the connection; it does not make them atomic, and `MULTI` would not have helped either, because the decision to admit depends on the count the same sequence reads. Two concurrent requests could each see a count below the limit and each be admitted.

Worse, `zadd` ran *unconditionally, before the check*. A client already over its limit kept writing entries: its window never drained, its `Retry-After` kept moving further out, and the sorted set grew for as long as it kept knocking.

Both are now one Lua script evaluated inside Redis, with the `zadd` inside the admit branch. Verified against a real Redis: 50 concurrent requests against a limit of 10 admit exactly 10, and seven rejections after a limit of 3 leave exactly 3 entries. Mutation-checked — moving the `zadd` back outside the branch fails the second test.

## Anyone a submitter named could delete someone else's eprint (SEC-9)

`deleteSubmission` and `updateSubmission` authorised anyone listed in the record's `authors[]`. That array is written by whoever submitted the eprint — it is metadata about the paper, not a claim about who may act on it. A submitter could hand delete rights to an arbitrary DID by typing it in.

Authorisation is now the account whose repository holds the record. The narrower rule is also the only coherent one for an AppView: ATProto forbids cross-repository writes, so a co-author cannot change the record itself, and letting them change Chive's copy would leave the index disagreeing with the PDS that owns it.

## No Content-Security-Policy on either side (SEC-10)

`secureHeaders()` sets none by default, and `next.config.ts` had no `headers()` block. This is what let the stored-XSS hole fixed in 0.8.0 reach as far as it did.

The API answers JSON and nothing else, so its policy is absolute: `default-src 'none'`, no framing, no base tag, no form action.

The frontend policy is real but **not complete, and I want to be plain about that**: `script-src` still carries `'unsafe-inline'`, because Next.js inlines its own bootstrap and hydration payloads and removing it needs per-request nonces threaded through the app. That work is worth doing and is not done here. Everything else is enforceable today and closes the injection paths that do not require running script — an injected `<base>`, a retargeted form post, an embedded object, the page being framed by someone else's site.

## /ready published the internals of every datastore (SEC-11)

Each failing check returned `error.message` verbatim. Driver messages name connection strings, hosts, ports and index names, and `/ready` is unauthenticated, exempt from rate limiting, and reachable from the internet — so anyone could read Chive's internal topology by asking during an outage, or by causing one. It now returns `Check failed`; the real error still goes to the log with its stack, where operators read it.

## The PDF proxy followed redirects out of its own allowlist (SEC-12)

The allowlist was checked once, on the URL the caller named, while `fetch` followed redirects on its own — so an allowlisted host could redirect the request to an address inside the cluster and have Chive fetch it and hand back the body. Redirects are now followed by hand, re-checking the allowlist at each hop, bounded to five, https only.

`response.arrayBuffer()` also buffered whatever arrived, with no cap. Bodies are now read through a counting reader that abandons the stream past 50MB, so a server that lies about its `Content-Length` cannot spend more memory than one that does not.

The rejected URL is no longer reflected into the error, which had made the endpoint an oracle for the allowlist contents.

## Two smaller ones

- **IDX-7**: DID-ownership failure threw `ValidationError` (400) where the request is well-formed and the caller simply may not make it — now `AuthorizationError` (403). A 400 tells a client to fix its input, which cannot help here.
- **CFG-6**: `DISABLE_RATE_LIMITING=true` removed every limit with no environment guard. One stray variable disabled rate limiting on a live deployment — the same shape as the E2E auth bypass fixed in 0.8.0. It is now ignored when `NODE_ENV=production`.

## Testing

- Unit: 208 files pass, including 11 new tests for IP resolution and 7 for the proxy's guards
- Integration: 31 passed, 1 skipped — including 7 new atomicity tests against a real Redis
- Compliance: 14/14
- `tsc --noEmit` clean, lint clean
- `TRUSTED_PROXY_COUNT` documented in `.env.example`

## Deployment note

`TRUSTED_PROXY_COUNT` defaults to 1, which matches every current deployment (Traefik). Anyone running Chive behind a different number of proxies must set it, or anonymous rate limiting will bucket all traffic under `unknown`.

## Compliance

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source