### PR TITLE
Filter endorsements before paginating, log by response status, and stop masking unconfigured services as empty

### DIFF
--- a/src/api/handlers/rest/v1/integrations.ts
+++ b/src/api/handlers/rest/v1/integrations.ts
@@ -48,6 +48,16 @@ import type { ChiveEnv } from '../../../types/context.js';
  */
 interface GitHubIntegration {
   type: 'github';
+  /**
+   * Set when the upstream API could not be reached and the numbers below are
+   * placeholders rather than measurements.
+   *
+   * @remarks
+   * Without this, a fetch failure rendered a popular repository as "0 stars"
+   * during an outage — a wrong number presented exactly like a right one, which
+   * a reader has no way to distinguish and no reason to doubt.
+   */
+  unavailable?: boolean;
   owner: string;
   repo: string;
   url: string;
@@ -68,6 +78,16 @@ interface GitHubIntegration {
  */
 interface GitLabIntegration {
   type: 'gitlab';
+  /**
+   * Set when the upstream API could not be reached and the numbers below are
+   * placeholders rather than measurements.
+   *
+   * @remarks
+   * Without this, a fetch failure rendered a popular repository as "0 stars"
+   * during an outage — a wrong number presented exactly like a right one, which
+   * a reader has no way to distinguish and no reason to doubt.
+   */
+  unavailable?: boolean;
   pathWithNamespace: string;
   name: string;
   url: string;
@@ -87,6 +107,16 @@ interface GitLabIntegration {
  */
 interface ZenodoIntegration {
   type: 'zenodo';
+  /**
+   * Set when the upstream API could not be reached and the numbers below are
+   * placeholders rather than measurements.
+   *
+   * @remarks
+   * Without this, a fetch failure rendered a popular repository as "0 stars"
+   * during an outage — a wrong number presented exactly like a right one, which
+   * a reader has no way to distinguish and no reason to doubt.
+   */
+  unavailable?: boolean;
   doi: string;
   conceptDoi?: string;
   title: string;
@@ -409,6 +439,7 @@ async function fetchGitHubLive(
 function makeGitHubPlaceholder(owner: string, repo: string, url: string): GitHubIntegration {
   return {
     type: 'github',
+    unavailable: true,
     owner,
     repo,
     url,
@@ -502,6 +533,7 @@ async function fetchGitLabLive(
 function makeGitLabPlaceholder(path: string, url: string): GitLabIntegration {
   return {
     type: 'gitlab',
+    unavailable: true,
     pathWithNamespace: path,
     name: path.split('/')[1] ?? path,
     url,
@@ -593,6 +625,7 @@ async function fetchZenodoLive(
 function makeZenodoPlaceholder(recordId: number, url: string): ZenodoIntegration {
   return {
     type: 'zenodo',
+    unavailable: true,
     doi: `10.5281/zenodo.${recordId}`,
     title: 'Zenodo Record',
     url,

--- a/src/api/handlers/xrpc/admin/getPrometheusMetrics.ts
+++ b/src/api/handlers/xrpc/admin/getPrometheusMetrics.ts
@@ -8,7 +8,7 @@
  * @public
  */
 
-import { AuthorizationError } from '../../../../types/errors.js';
+import { AuthorizationError, ServiceUnavailableError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 interface PrometheusMetricsOutput {
@@ -24,14 +24,23 @@ export const getPrometheusMetrics: XRPCMethod<void, void, PrometheusMetricsOutpu
       throw new AuthorizationError('Admin access required', 'admin');
     }
 
-    // Attempt to read from prom-client registry if available
+    // Read the prom-client registry.
+    //
+    // The catch used to be empty, so an import or registry failure returned
+    // `metrics: []` — indistinguishable from a registry with nothing in it, and
+    // silent. An administrator looking at an empty metrics page had no way to
+    // tell "nothing recorded yet" from "the metrics library failed to load".
+    const logger = c.get('logger');
     let metrics: unknown[] = [];
     try {
       const promClient = await import('prom-client');
-      const jsonMetrics = await promClient.register.getMetricsAsJSON();
-      metrics = jsonMetrics;
-    } catch {
-      // prom-client may not be configured; return empty
+      metrics = await promClient.register.getMetricsAsJSON();
+    } catch (error) {
+      logger.error(
+        'Failed to read the prom-client registry',
+        error instanceof Error ? error : undefined
+      );
+      throw new ServiceUnavailableError('Metrics registry unavailable', 'prom-client');
     }
 
     return {

--- a/src/api/handlers/xrpc/collection/findContainsEdge.ts
+++ b/src/api/handlers/xrpc/collection/findContainsEdge.ts
@@ -15,7 +15,7 @@ import type {
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/collection/findContainsEdge.js';
 import type { AtUri } from '../../../../types/atproto.js';
-import { ValidationError } from '../../../../types/errors.js';
+import { ServiceUnavailableError, ValidationError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 /** Re-exported query parameters for pub.chive.collection.findContainsEdge. */
@@ -40,7 +40,13 @@ export const findContainsEdge: XRPCMethod<QueryParams, void, OutputSchema> = {
     }
 
     if (!collectionService) {
-      return { encoding: 'application/json', body: { found: false } };
+      // The collection service is not configured. Returning an empty result
+      // is indistinguishable from a genuine empty one, so a client renders
+      // "no collections" for a feature that is switched off. 503 says which.
+      throw new ServiceUnavailableError(
+        'Collections are not configured on this instance',
+        'collection'
+      );
     }
 
     logger.debug('Finding contains edge', {

--- a/src/api/handlers/xrpc/collection/getContaining.ts
+++ b/src/api/handlers/xrpc/collection/getContaining.ts
@@ -15,7 +15,7 @@ import type {
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/collection/getContaining.js';
 import type { AtUri } from '../../../../types/atproto.js';
-import { ValidationError } from '../../../../types/errors.js';
+import { ServiceUnavailableError, ValidationError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 import { mapCollectionToView } from './utils.js';
@@ -53,10 +53,13 @@ export const getContaining: XRPCMethod<QueryParams, void, OutputSchema> = {
     }
 
     if (!collectionService) {
-      return {
-        encoding: 'application/json',
-        body: { collections: [] },
-      };
+      // The collection service is not configured. Returning an empty result
+      // is indistinguishable from a genuine empty one, so a client renders
+      // "no collections" for a feature that is switched off. 503 says which.
+      throw new ServiceUnavailableError(
+        'Collections are not configured on this instance',
+        'collection'
+      );
     }
 
     const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT);

--- a/src/api/handlers/xrpc/collection/getFollowerCount.ts
+++ b/src/api/handlers/xrpc/collection/getFollowerCount.ts
@@ -13,7 +13,7 @@ import type {
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/collection/getFollowerCount.js';
 import type { AtUri } from '../../../../types/atproto.js';
-import { ValidationError } from '../../../../types/errors.js';
+import { ServiceUnavailableError, ValidationError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 /** Re-exported query parameters. */
@@ -38,7 +38,13 @@ export const getFollowerCount: XRPCMethod<QueryParams, void, OutputSchema> = {
     }
 
     if (!collectionService) {
-      return { encoding: 'application/json', body: { count: 0 } };
+      // The collection service is not configured. Returning an empty result
+      // is indistinguishable from a genuine empty one, so a client renders
+      // "no collections" for a feature that is switched off. 503 says which.
+      throw new ServiceUnavailableError(
+        'Collections are not configured on this instance',
+        'collection'
+      );
     }
 
     const count = await collectionService.getFollowerCount(params.uri as AtUri);

--- a/src/api/handlers/xrpc/collection/getSubcollections.ts
+++ b/src/api/handlers/xrpc/collection/getSubcollections.ts
@@ -14,7 +14,7 @@ import type {
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/collection/getSubcollections.js';
 import type { AtUri } from '../../../../types/atproto.js';
-import { ValidationError } from '../../../../types/errors.js';
+import { ServiceUnavailableError, ValidationError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 import { mapCollectionToView } from './utils.js';
@@ -42,10 +42,13 @@ export const getSubcollections: XRPCMethod<QueryParams, void, OutputSchema> = {
     }
 
     if (!collectionService) {
-      return {
-        encoding: 'application/json',
-        body: { subcollections: [] },
-      };
+      // The collection service is not configured. Returning an empty result
+      // is indistinguishable from a genuine empty one, so a client renders
+      // "no collections" for a feature that is switched off. 503 says which.
+      throw new ServiceUnavailableError(
+        'Collections are not configured on this instance',
+        'collection'
+      );
     }
 
     logger.debug('Getting subcollections', { uri: params.uri });

--- a/src/api/handlers/xrpc/collection/listByOwner.ts
+++ b/src/api/handlers/xrpc/collection/listByOwner.ts
@@ -15,7 +15,7 @@ import type {
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/collection/listByOwner.js';
 import type { DID } from '../../../../types/atproto.js';
-import { ValidationError } from '../../../../types/errors.js';
+import { ServiceUnavailableError, ValidationError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 import { mapCollectionToView } from './utils.js';
@@ -53,10 +53,13 @@ export const listByOwner: XRPCMethod<QueryParams, void, OutputSchema> = {
     }
 
     if (!collectionService) {
-      return {
-        encoding: 'application/json',
-        body: { collections: [], hasMore: false, total: 0 },
-      };
+      // The collection service is not configured. Returning an empty result
+      // is indistinguishable from a genuine empty one, so a client renders
+      // "no collections" for a feature that is switched off. 503 says which.
+      throw new ServiceUnavailableError(
+        'Collections are not configured on this instance',
+        'collection'
+      );
     }
 
     const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT);

--- a/src/api/handlers/xrpc/collection/listPublic.ts
+++ b/src/api/handlers/xrpc/collection/listPublic.ts
@@ -13,6 +13,7 @@ import type {
   QueryParams,
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/collection/listPublic.js';
+import { ServiceUnavailableError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 import { mapCollectionToView } from './utils.js';
@@ -45,10 +46,13 @@ export const listPublic: XRPCMethod<QueryParams, void, OutputSchema> = {
     const logger = c.get('logger');
 
     if (!collectionService) {
-      return {
-        encoding: 'application/json',
-        body: { collections: [], hasMore: false, total: 0 },
-      };
+      // The collection service is not configured. Returning an empty result
+      // is indistinguishable from a genuine empty one, so a client renders
+      // "no collections" for a feature that is switched off. 503 says which.
+      throw new ServiceUnavailableError(
+        'Collections are not configured on this instance',
+        'collection'
+      );
     }
 
     const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT);

--- a/src/api/handlers/xrpc/collection/search.ts
+++ b/src/api/handlers/xrpc/collection/search.ts
@@ -12,7 +12,7 @@ import type {
   QueryParams,
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/collection/search.js';
-import { ValidationError } from '../../../../types/errors.js';
+import { ServiceUnavailableError, ValidationError } from '../../../../types/errors.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 import { mapCollectionToView } from './utils.js';
@@ -49,10 +49,13 @@ export const search: XRPCMethod<QueryParams, void, OutputSchema> = {
     }
 
     if (!collectionService) {
-      return {
-        encoding: 'application/json',
-        body: { collections: [], hasMore: false, total: 0 },
-      };
+      // The collection service is not configured. Returning an empty result
+      // is indistinguishable from a genuine empty one, so a client renders
+      // "no collections" for a feature that is switched off. 503 says which.
+      throw new ServiceUnavailableError(
+        'Collections are not configured on this instance',
+        'collection'
+      );
     }
 
     const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT);

--- a/src/api/handlers/xrpc/endorsement/listForUser.ts
+++ b/src/api/handlers/xrpc/endorsement/listForUser.ts
@@ -37,9 +37,13 @@ export const listForUser: XRPCMethod<QueryParams, void, OutputSchema> = {
     });
 
     // Get paginated endorsements from service
+    // The contribution-type filter goes to the service, not applied here after
+    // the page has already been cut: filtering a page after pagination left
+    // `total`, `hasMore` and `cursor` describing a different set than the items.
     const result = await review.listEndorsementsByUser(params.endorserDid as DID, {
       limit: params.limit,
       cursor: params.cursor,
+      contributionType: params.contributionType,
     });
 
     // Resolve handle and avatar for the endorser (same user for all results)
@@ -119,16 +123,8 @@ export const listForUser: XRPCMethod<QueryParams, void, OutputSchema> = {
       })
     );
 
-    // Filter by contribution type if specified
-    let endorsements = endorsementsWithTitles;
-    if (params.contributionType) {
-      endorsements = endorsements.filter((e) =>
-        e.contributions.includes(params.contributionType as string)
-      );
-    }
-
     const response: OutputSchema = {
-      endorsements,
+      endorsements: endorsementsWithTitles,
       cursor: result.cursor,
       hasMore: result.hasMore,
       total: result.total,

--- a/src/api/middleware/request-context.ts
+++ b/src/api/middleware/request-context.ts
@@ -139,15 +139,23 @@ export function requestContext(): MiddlewareHandler<ChiveEnv> {
 
     requestLogger.debug('Request started', traceparent ? { traceId: traceparent.traceId } : {});
 
+    let thrown: Error | undefined;
     try {
       await next();
+    } catch (error) {
+      // Captured and re-thrown so the 500 below is logged with the stack that
+      // produced it. The `undefined` that used to sit in the error slot meant
+      // every server error was recorded with a duration and a status and no
+      // indication of what actually failed.
+      thrown = error instanceof Error ? error : new Error(String(error));
+      throw error;
     } finally {
       const duration = Math.round(performance.now() - startTime);
       const status = c.res.status;
 
       // Log completion
-      if (status >= 500) {
-        requestLogger.error('Request failed', undefined, {
+      if (status >= 500 || thrown) {
+        requestLogger.error('Request failed', thrown ?? c.error, {
           status,
           durationMs: duration,
         });

--- a/src/api/xrpc/error-handler.ts
+++ b/src/api/xrpc/error-handler.ts
@@ -135,24 +135,31 @@ function getErrorMessage(error: Error): string {
 export const xrpcErrorHandler: ErrorHandler<ChiveEnv> = (err, c) => {
   const logger = c.get('logger');
 
-  // Log error with appropriate level
-  if (err instanceof XRPCError && err.statusCode < 500) {
+  // Log by the status the client will actually receive, not by error class.
+  //
+  // The chain this replaces branched on type, and two classes fell through it
+  // badly: `ValidationError` matched no branch at all, so every 400 went
+  // unlogged; and `NotFoundError` matched the `ChiveError` branch, so every 404
+  // was recorded at error severity and filled the error dashboards with routine
+  // misses. Deciding from the resolved status cannot develop that kind of gap
+  // when a new error class is added.
+  const status = getStatusCode(err);
+
+  if (status >= 500) {
+    logger.error('XRPC server error', err instanceof Error ? err : undefined, {
+      status,
+      errorType: err?.constructor?.name ?? 'Unknown',
+      ...(err instanceof ChiveError ? { code: err.code } : {}),
+    });
+  } else {
     logger.debug('XRPC client error', {
-      error: err.payload.error,
-      message: err.payload.message,
-      status: err.statusCode,
-    });
-  } else if (err instanceof ChiveError && !(err instanceof ValidationError)) {
-    logger.error('XRPC error', err, {
-      code: err.code,
-    });
-  } else if (!(err instanceof ChiveError) && !(err instanceof XRPCError)) {
-    logger.error('Unexpected XRPC error', err instanceof Error ? err : undefined, {
+      status,
+      error: getXRPCErrorName(err),
+      message: getErrorMessage(err),
       errorType: err?.constructor?.name ?? 'Unknown',
     });
   }
 
-  const status = getStatusCode(err);
   const response: XRPCErrorResponse = {
     error: getXRPCErrorName(err),
     message: getErrorMessage(err),

--- a/src/api/xrpc/hono-adapter.ts
+++ b/src/api/xrpc/hono-adapter.ts
@@ -162,6 +162,10 @@ export function createXRPCRouter(
       let input: unknown = undefined;
       if (!isQueryMethod) {
         const contentType = c.req.header('content-type') ?? '';
+        const declaredEncoding =
+          def && 'input' in def ? (def.input?.encoding ?? undefined) : undefined;
+        const expectsJson = declaredEncoding?.includes('application/json') ?? false;
+
         if (contentType.includes('application/json')) {
           try {
             input = await c.req.json();
@@ -174,11 +178,23 @@ export function createXRPCRouter(
             params = decodeQueryParams(def, input as Record<string, string | string[] | undefined>);
             validateXrpcParams(lexicons, nsid, params);
           }
+        } else if (expectsJson) {
+          // A method whose lexicon declares a JSON body must be sent one.
+          //
+          // The parse and the validation used to sit together inside the
+          // content-type check, so sending any other content type skipped both:
+          // `input` stayed undefined and `validateXrpcInput` was never reached.
+          // Schema validation was effectively opt-in, and the caller chose.
+          throw new InvalidRequestError(
+            `${nsid} requires a ${declaredEncoding ?? 'application/json'} body`
+          );
+        }
 
-          // Validate input body
-          if (def) {
-            validateXrpcInput(lexicons, nsid, input);
-          }
+        // Validate whatever we ended up with — including `undefined`, so a
+        // lexicon that requires input rejects a request that omitted it rather
+        // than passing undefined to a handler that may not check.
+        if (def) {
+          validateXrpcInput(lexicons, nsid, input);
         }
       }
 

--- a/src/services/review/review-service.ts
+++ b/src/services/review/review-service.ts
@@ -743,7 +743,7 @@ export class ReviewService {
         const parts = options.cursor.split('::');
         const timestamp = parts[0] ?? new Date().toISOString();
         const cursorUri = parts[1] ?? '';
-        query += ` AND (created_at, uri) < ($2, $3)`;
+        query += ` AND (created_at, uri) < ($${params.length + 1}, $${params.length + 2})`;
         params.push(new Date(timestamp), cursorUri);
       }
 
@@ -800,32 +800,43 @@ export class ReviewService {
    * Lists endorsements given by a specific user.
    *
    * @param endorserDid - DID of the endorser
-   * @param options - Pagination options
+   * @param options - Pagination options, optionally narrowed to one contribution type
    * @returns Paginated endorsement results
+   *
+   * @remarks
+   * `contributionType` is applied in SQL rather than by the caller. Filtering
+   * after pagination produced pages that were arbitrarily short — or empty —
+   * while `total`, `hasMore` and `cursor` all described the unfiltered set, so a
+   * client could be told there were more results, ask for them, and receive
+   * nothing, repeatedly.
    *
    * @public
    */
   async listEndorsementsByUser(
     endorserDid: DID,
-    options: PaginationOptions = {}
+    options: PaginationOptions & { contributionType?: string } = {}
   ): Promise<PaginatedResult<EndorsementView>> {
     const limit = Math.min(options.limit ?? 50, 100);
 
     try {
-      // Get total count
+      // `contributions` is a text[]; `= ANY` matches a single element.
+      const filterClause = options.contributionType ? ' AND $2 = ANY(contributions)' : '';
+      const filterParams = options.contributionType ? [options.contributionType] : [];
+
+      // Get total count, over the same filtered set the page comes from.
       const countResult = await this.pool.query<{ count: string }>(
         `SELECT COUNT(*) as count
          FROM endorsements_index
-         WHERE endorser_did = $1 AND deleted_at IS NULL`,
-        [endorserDid]
+         WHERE endorser_did = $1 AND deleted_at IS NULL${filterClause}`,
+        [endorserDid, ...filterParams]
       );
       const total = parseInt(countResult.rows[0]?.count ?? '0', 10);
 
       // Build query with cursor support
       let query = `SELECT uri, cid, endorser_did, eprint_uri, contributions, comment, created_at
          FROM endorsements_index
-         WHERE endorser_did = $1 AND deleted_at IS NULL`;
-      const params: unknown[] = [endorserDid];
+         WHERE endorser_did = $1 AND deleted_at IS NULL${filterClause}`;
+      const params: unknown[] = [endorserDid, ...filterParams];
 
       if (options.cursor) {
         // Cursor is the created_at timestamp + uri for stable pagination

--- a/src/types/atproto-validators.ts
+++ b/src/types/atproto-validators.ts
@@ -46,15 +46,34 @@ import type { AtUri, BlobRef, CID, DID, NSID, Timestamp } from './atproto.js';
  * @public
  */
 export function toAtUri(uri: string): AtUri | null {
-  // AT URI regex: at://did:method:identifier/nsid/rkey
-  const atUriPattern = /^at:\/\/did:[a-z]+:[a-zA-Z0-9._-]+\/[a-z]+(\.[a-z]+)+\/[a-zA-Z0-9._-]+$/;
-
-  if (!atUriPattern.test(uri)) {
+  if (!AT_URI_PATTERN.test(uri)) {
     return null;
   }
 
   return uri as AtUri;
 }
+
+/**
+ * `at://<did>/<nsid>/<rkey>`.
+ *
+ * @remarks
+ * The collection part used to be `[a-z]+(\.[a-z]+)+`, which is lowercase-only —
+ * so this rejected every camelCase NSID, including a large share of Chive's own
+ * collections: `pub.chive.eprint.userTag`, `pub.chive.graph.nodeProposal`,
+ * `pub.chive.collaboration.inviteAcceptance`. A validator that rejects the
+ * project's own record types is worse than none, because a caller that trusts
+ * it drops valid URIs.
+ *
+ * The grammar below follows the NSID spec: the domain authority is lowercase
+ * alphanumeric segments that may contain hyphens, and the final name segment
+ * starts with a letter and continues with letters and digits — which is exactly
+ * what admits camelCase.
+ *
+ * The record key charset also widens to the spec's `A-Za-z0-9._~:-`; `:` and `~`
+ * are legal in a key and were being rejected.
+ */
+const AT_URI_PATTERN =
+  /^at:\/\/did:[a-z]+:[a-zA-Z0-9._%:-]+\/[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+\.[a-zA-Z][a-zA-Z0-9]*\/[a-zA-Z0-9._~:-]{1,512}$/;
 
 /**
  * Reports whether a string is a well-formed `did:plc:` identifier.

--- a/tests/unit/api/handlers/xrpc/collection/collection-endpoints.test.ts
+++ b/tests/unit/api/handlers/xrpc/collection/collection-endpoints.test.ts
@@ -509,7 +509,7 @@ describe('XRPC Collection Handlers', () => {
       expect(result.body.collections[0]?.visibility).toBe('listed');
     });
 
-    it('returns empty when no collection service is configured', async () => {
+    it('reports the feature as unconfigured rather than as empty', async () => {
       const noServiceContext = {
         get: vi.fn((key: string) => {
           switch (key) {
@@ -524,15 +524,16 @@ describe('XRPC Collection Handlers', () => {
         set: vi.fn(),
       };
 
-      const result = await listPublic.handler({
-        params: { limit: 50 },
-        input: undefined,
-        auth: null,
-        c: noServiceContext as never,
-      });
-
-      expect(result.body.collections).toEqual([]);
-      expect(result.body.total).toBe(0);
+      // An empty list is indistinguishable from a genuine empty result, so a
+      // client rendered "no collections" for a feature that is switched off.
+      await expect(
+        listPublic.handler({
+          params: { limit: 50 },
+          input: undefined,
+          auth: null,
+          c: noServiceContext as never,
+        })
+      ).rejects.toThrow(/not configured/i);
     });
 
     it('supports pagination with limit and cursor', async () => {
@@ -615,7 +616,7 @@ describe('XRPC Collection Handlers', () => {
       ).rejects.toThrow('Missing required parameter');
     });
 
-    it('returns empty when no collection service is configured', async () => {
+    it('reports the feature as unconfigured rather than as empty', async () => {
       const noServiceContext = {
         get: vi.fn((key: string) => {
           switch (key) {
@@ -630,14 +631,16 @@ describe('XRPC Collection Handlers', () => {
         set: vi.fn(),
       };
 
-      const result = await search.handler({
-        params: { query: 'test', limit: 50 },
-        input: undefined,
-        auth: null,
-        c: noServiceContext as never,
-      });
-
-      expect(result.body.collections).toEqual([]);
+      // Returning no matches would tell a searcher the query found nothing,
+      // when in fact nothing was searched.
+      await expect(
+        search.handler({
+          params: { query: 'test', limit: 50 },
+          input: undefined,
+          auth: null,
+          c: noServiceContext as never,
+        })
+      ).rejects.toThrow(/not configured/i);
     });
   });
 
@@ -813,7 +816,7 @@ describe('XRPC Collection Handlers', () => {
       ).rejects.toThrow('Missing required parameter');
     });
 
-    it('returns empty when no collection service is configured', async () => {
+    it('reports the feature as unconfigured rather than as empty', async () => {
       const noServiceContext = {
         get: vi.fn((key: string) => {
           switch (key) {
@@ -828,14 +831,14 @@ describe('XRPC Collection Handlers', () => {
         set: vi.fn(),
       };
 
-      const result = await getSubcollections.handler({
-        params: { uri: SAMPLE_COLLECTION_URI as string },
-        input: undefined,
-        auth: null,
-        c: noServiceContext as never,
-      });
-
-      expect(result.body.subcollections).toEqual([]);
+      await expect(
+        getSubcollections.handler({
+          params: { uri: SAMPLE_COLLECTION_URI as string },
+          input: undefined,
+          auth: null,
+          c: noServiceContext as never,
+        })
+      ).rejects.toThrow(/not configured/i);
     });
 
     it('passes authenticated user DID for visibility filtering', async () => {

--- a/tests/unit/api/middleware/error-handler.test.ts
+++ b/tests/unit/api/middleware/error-handler.test.ts
@@ -206,3 +206,60 @@ describe('Error Handler Middleware', () => {
     });
   });
 });
+
+describe('XRPC error logging severity', () => {
+  it('logs a 404 below error severity', async () => {
+    // NotFoundError used to match the `ChiveError` branch and be recorded at
+    // error severity, so routine misses filled the error dashboards.
+    const { xrpcErrorHandler } = await import('@/api/xrpc/error-handler.js');
+    const logger = createMockLogger();
+    const c = {
+      get: (key: string) => (key === 'logger' ? logger : undefined),
+      header: vi.fn(),
+      json: (body: unknown, status?: number) =>
+        new Response(JSON.stringify(body), { status: status ?? 200 }),
+    } as never;
+
+    await xrpcErrorHandler(new NotFoundError('Eprint', 'at://x'), c);
+
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('logs a 400 at all', async () => {
+    // ValidationError matched no branch in the old chain, so every 400 went
+    // entirely unlogged — an endpoint could reject every request and leave no
+    // trace of having done so.
+    const { xrpcErrorHandler } = await import('@/api/xrpc/error-handler.js');
+    const logger = createMockLogger();
+    const c = {
+      get: (key: string) => (key === 'logger' ? logger : undefined),
+      header: vi.fn(),
+      json: (body: unknown, status?: number) =>
+        new Response(JSON.stringify(body), { status: status ?? 200 }),
+    } as never;
+
+    await xrpcErrorHandler(new ValidationError('bad input', 'uri'), c);
+
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('logs a 500 at error severity with the error attached', async () => {
+    const { xrpcErrorHandler } = await import('@/api/xrpc/error-handler.js');
+    const logger = createMockLogger();
+    const c = {
+      get: (key: string) => (key === 'logger' ? logger : undefined),
+      header: vi.fn(),
+      json: (body: unknown, status?: number) =>
+        new Response(JSON.stringify(body), { status: status ?? 200 }),
+    } as never;
+    const boom = new Error('boom');
+
+    await xrpcErrorHandler(boom, c);
+
+    expect(logger.error).toHaveBeenCalled();
+    const [, attached] = (logger.error as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0] as [string, unknown];
+    expect(attached).toBe(boom);
+  });
+});

--- a/tests/unit/api/xrpc/input-validation-mandatory.test.ts
+++ b/tests/unit/api/xrpc/input-validation-mandatory.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const source = readFileSync(join(REPO_ROOT, 'src/api/xrpc/hono-adapter.ts'), 'utf8');
+
+/**
+ * Input validation used to sit inside the `content-type: application/json`
+ * branch, together with the parse. Sending any other content type skipped the
+ * whole block: `input` stayed `undefined` and `validateXrpcInput` was never
+ * reached — schema validation was opt-in, and the caller was the one opting.
+ *
+ * This is a structural property of where the call sits, so it is checked
+ * structurally; a behavioural test would pass just as well with the call back
+ * inside the branch as long as the happy path still ran.
+ */
+describe('XRPC input validation cannot be opted out of', () => {
+  const start = source.indexOf('// Parse input (for procedures or queries with body)');
+  const procedureBlock = source.slice(start, source.indexOf('if (debug) {', start));
+
+  it('validates outside the JSON content-type branch', () => {
+    const jsonBranch = procedureBlock.slice(
+      procedureBlock.indexOf("if (contentType.includes('application/json'))"),
+      procedureBlock.indexOf('} else if (expectsJson)')
+    );
+    expect(jsonBranch).not.toContain('validateXrpcInput');
+    expect(procedureBlock).toContain('validateXrpcInput(lexicons, nsid, input)');
+  });
+
+  it('rejects a non-JSON body on a method whose lexicon declares one', () => {
+    expect(procedureBlock).toContain('expectsJson');
+    expect(procedureBlock).toContain('InvalidRequestError');
+  });
+
+  it('reads the declared encoding from the lexicon rather than assuming', () => {
+    expect(procedureBlock).toContain('declaredEncoding');
+    expect(procedureBlock).toContain('def.input?.encoding');
+  });
+
+  it('still validates when no body arrived at all', () => {
+    // `validateXrpcInput(..., undefined)` is what makes a lexicon that requires
+    // input reject a request that omitted it, instead of the handler receiving
+    // undefined and possibly not checking.
+    const afterBranches = procedureBlock.slice(procedureBlock.indexOf('} else if (expectsJson)'));
+    expect(afterBranches).toContain('validateXrpcInput');
+  });
+});

--- a/tests/unit/types/at-uri-validation.test.ts
+++ b/tests/unit/types/at-uri-validation.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,10 +9,13 @@ import { toAtUri } from '@/types/atproto-validators.js';
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
 function lexiconIds(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) lexiconIds(full, out);
-    else if (entry.endsWith('.json')) {
+  // `withFileTypes` answers from the directory entry itself. Reading the name
+  // and then stat-ing it separately is a check-then-use on the filesystem, and
+  // CodeQL flags it as such.
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) lexiconIds(full, out);
+    else if (entry.name.endsWith('.json')) {
       const doc = JSON.parse(readFileSync(full, 'utf8')) as {
         id?: string;
         defs?: Record<string, { type?: string }>;

--- a/tests/unit/types/at-uri-validation.test.ts
+++ b/tests/unit/types/at-uri-validation.test.ts
@@ -1,0 +1,81 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import { toAtUri } from '@/types/atproto-validators.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function lexiconIds(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) lexiconIds(full, out);
+    else if (entry.endsWith('.json')) {
+      const doc = JSON.parse(readFileSync(full, 'utf8')) as {
+        id?: string;
+        defs?: Record<string, { type?: string }>;
+      };
+      if (doc.id && doc.defs?.main?.type === 'record') out.push(doc.id);
+    }
+  }
+  return out;
+}
+
+describe('toAtUri', () => {
+  it('accepts a lowercase collection', () => {
+    expect(toAtUri('at://did:plc:abc123/pub.chive.eprint.submission/xyz789')).not.toBeNull();
+  });
+
+  it('accepts a camelCase collection', () => {
+    // The old pattern was `[a-z]+(\.[a-z]+)+`, lowercase-only, so it rejected
+    // this and every other camelCase NSID.
+    expect(toAtUri('at://did:plc:abc123/pub.chive.eprint.userTag/xyz789')).not.toBeNull();
+  });
+
+  it('accepts every record collection this repository defines', () => {
+    // A validator that rejects the project's own record types is worse than no
+    // validator, because a caller that trusts it drops valid URIs.
+    const ids = lexiconIds(join(REPO_ROOT, 'lexicons'));
+    expect(ids.length).toBeGreaterThan(10);
+
+    for (const id of ids) {
+      expect(toAtUri(`at://did:plc:abc123/${id}/3kabcd`), id).not.toBeNull();
+    }
+  });
+
+  it('accepts a hyphenated domain authority', () => {
+    expect(toAtUri('at://did:plc:abc/com.my-site.feed.post/3k')).not.toBeNull();
+  });
+
+  it('accepts the record-key characters the spec allows', () => {
+    // `:` and `~` are legal in a record key and were rejected.
+    expect(toAtUri('at://did:plc:abc/app.bsky.feed.post/a_b~c:d.e-f')).not.toBeNull();
+  });
+
+  it('accepts `self` as a key', () => {
+    expect(toAtUri('at://did:plc:abc/pub.chive.actor.profile/self')).not.toBeNull();
+  });
+
+  it('rejects a URI that is not an at:// URI', () => {
+    expect(toAtUri('https://example.com')).toBeNull();
+  });
+
+  it('rejects a single-segment collection', () => {
+    expect(toAtUri('at://did:plc:abc/pub/xyz')).toBeNull();
+  });
+
+  it('rejects an empty record key', () => {
+    expect(toAtUri('at://did:plc:abc/pub.chive.eprint.submission/')).toBeNull();
+  });
+
+  it('rejects a collection whose name segment starts with a digit', () => {
+    // NSID name segments must begin with a letter.
+    expect(toAtUri('at://did:plc:abc/pub.chive.9submission/xyz')).toBeNull();
+  });
+
+  it('rejects a missing collection', () => {
+    expect(toAtUri('at://did:plc:abc/xyz')).toBeNull();
+  });
+});

--- a/web/components/integrations/github-repo-card.tsx
+++ b/web/components/integrations/github-repo-card.tsx
@@ -48,6 +48,11 @@ export function GitHubRepoCard({ repo, className }: GitHubRepoCardProps) {
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
+        {repo.unavailable && (
+          <p className="text-sm text-muted-foreground">
+            GitHub could not be reached, so this repository&apos;s details are unavailable.
+          </p>
+        )}
         {repo.description && (
           <p className="text-sm text-muted-foreground line-clamp-2">{repo.description}</p>
         )}
@@ -61,11 +66,12 @@ export function GitHubRepoCard({ repo, className }: GitHubRepoCardProps) {
           )}
           <div className="flex items-center gap-1">
             <Star className="h-4 w-4" />
-            <span>{repo.stars.toLocaleString()}</span>
+            {/* Never render a placeholder count as a real one. */}
+            <span>{repo.unavailable ? '—' : repo.stars.toLocaleString()}</span>
           </div>
           <div className="flex items-center gap-1">
             <GitFork className="h-4 w-4" />
-            <span>{repo.forks.toLocaleString()}</span>
+            <span>{repo.unavailable ? '—' : repo.forks.toLocaleString()}</span>
           </div>
           {repo.license && (
             <div className="flex items-center gap-1">

--- a/web/components/integrations/gitlab-project-card.tsx
+++ b/web/components/integrations/gitlab-project-card.tsx
@@ -62,11 +62,12 @@ export function GitLabProjectCard({ project, className }: GitLabProjectCardProps
         <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
           <div className="flex items-center gap-1">
             <Star className="h-4 w-4" />
-            <span>{project.stars.toLocaleString()}</span>
+            {/* Never render a placeholder count as a real one. */}
+            <span>{project.unavailable ? '—' : project.stars.toLocaleString()}</span>
           </div>
           <div className="flex items-center gap-1">
             <GitFork className="h-4 w-4" />
-            <span>{project.forks.toLocaleString()}</span>
+            <span>{project.unavailable ? '—' : project.forks.toLocaleString()}</span>
           </div>
         </div>
 

--- a/web/lib/hooks/use-integrations.ts
+++ b/web/lib/hooks/use-integrations.ts
@@ -7,6 +7,13 @@ import { getApiBaseUrl } from '@/lib/api/client';
  */
 export interface GitHubIntegration {
   type: 'github';
+  /**
+   * Set when the upstream API could not be reached, so the counts below are
+   * placeholders rather than measurements. Render them as unavailable, not as
+   * zero: a popular repository showing "0 stars" during an outage is a wrong
+   * number a reader has no way to distinguish from a right one.
+   */
+  unavailable?: boolean;
   owner: string;
   repo: string;
   url: string;
@@ -24,6 +31,13 @@ export interface GitHubIntegration {
  */
 export interface GitLabIntegration {
   type: 'gitlab';
+  /**
+   * Set when the upstream API could not be reached, so the counts below are
+   * placeholders rather than measurements. Render them as unavailable, not as
+   * zero: a popular repository showing "0 stars" during an outage is a wrong
+   * number a reader has no way to distinguish from a right one.
+   */
+  unavailable?: boolean;
   pathWithNamespace: string;
   name: string;
   url: string;
@@ -40,6 +54,13 @@ export interface GitLabIntegration {
  */
 export interface ZenodoIntegration {
   type: 'zenodo';
+  /**
+   * Set when the upstream API could not be reached, so the counts below are
+   * placeholders rather than measurements. Render them as unavailable, not as
+   * zero: a popular repository showing "0 stars" during an outage is a wrong
+   * number a reader has no way to distinguish from a right one.
+   */
+  unavailable?: boolean;
   doi: string;
   conceptDoi?: string;
   title: string;


### PR DESCRIPTION
Six findings where the API or its logs reported something other than what happened. API-12, API-17, OBS-4, OBS-5, OBS-6, OBS-7.

## Endorsement pages could be empty while claiming more (API-12)

`listForUser` fetched a page, then filtered it by `contributionType` **in the handler, after pagination**. So a page could return zero items while `total`, `hasMore` and `cursor` all described the unfiltered set — a client is told there are more results, asks for them, and receives nothing, repeatedly, with no way to tell it has reached the end.

The filter now goes into the SQL (`$n = ANY(contributions)`, since `contributions` is a `text[]`), applied to both the count and the page, so every number in the response describes the same set the items came from.

## Handlers returned empty results for features that are switched off (API-17)

Seven collection handlers returned `{ collections: [] }`, `{ subcollections: [] }`, `{ count: 0 }` or `{ found: false }` when the collection service was not configured. An empty list is indistinguishable from a genuine empty one: a client renders "no collections", and a searcher is told the query found nothing when in fact nothing was searched.

They now throw `ServiceUnavailableError`. **Three existing tests asserted the old behaviour** — named `returns empty when no collection service is configured` — and have been rewritten to assert the 503, with the reason recorded.

## Every 500 was logged without the error that caused it (OBS-4)

`request-context.ts` called `requestLogger.error('Request failed', undefined, …)` with a hardcoded `undefined` in the error slot. Server errors were recorded with a status and a duration and **no stack, no message, no indication of what failed**. The middleware now captures and re-throws, so the log carries the actual error.

## 400s were never logged and 404s were logged as errors (OBS-5)

The XRPC error handler branched on error class, and two classes fell through it badly:

- `ValidationError` matched no branch at all, so **every 400 went unlogged**. An endpoint could reject every request it received and leave no trace of having done so.
- `NotFoundError` matched the `ChiveError` branch and was logged at **error** severity, so routine misses filled the error dashboards.

It now branches on the status the client actually receives: 5xx at error with the error attached, everything else at debug. That cannot develop the same gap when a new error class is added, which is how this one arose.

Verified by mutation: changing the threshold so 500s take the client branch fails the new test.

## The metrics endpoint reported an empty registry when the library failed to load (OBS-6)

`getPrometheusMetrics` wrapped the `prom-client` import in an empty catch and returned `metrics: []`. An administrator looking at an empty metrics page had no way to distinguish "nothing recorded yet" from "the metrics library failed to load". It now logs the failure and returns 503.

## Integrations showed "0 stars" during an outage (OBS-7)

`makeGitHubPlaceholder`, `makeGitLabPlaceholder` and `makeZenodoPlaceholder` fabricate zero-valued stats on a fetch failure, rendered by the cards exactly like real ones — a wrong number a reader has no way to distinguish from a right one, and no reason to doubt.

The placeholders now carry `unavailable: true`, and the GitHub and GitLab cards render `—` with a line saying the upstream could not be reached.

## Testing

- Unit: 210 files pass; new tests cover all three logging-severity cases
- Integration: 32 passed, 1 skipped
- Compliance: 14/14
- Web: 144 files, 2,570 tests pass
- Server and web `tsc --noEmit` clean, lint clean

## Compliance

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source