### PR TITLE
Derive canonical and Open Graph URLs from the deployment origin instead of hard-coding production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -213,3 +213,13 @@ TRUSTED_PROXY_COUNT=1
 # ZULIP_SERVER_URL=            # required; no default
 # ZULIP_BOT_EMAIL=            # required; no default
 # ZULIP_BOT_API_KEY=            # required; no default
+
+# Public origin this deployment serves from, without a trailing slash.
+#
+# Feeds canonical links, Open Graph URLs and metadataBase. These were hard-coded
+# to https://chive.pub, so a staging deployment advertised production as the
+# canonical home of every page it served. Read at build time, since Next.js
+# generates that metadata during the build.
+#
+# Defaults to https://chive.pub when unset.
+NEXT_PUBLIC_SITE_URL=https://chive.pub

--- a/web/app/eprints/[...uri]/page.tsx
+++ b/web/app/eprints/[...uri]/page.tsx
@@ -13,6 +13,7 @@ import {
   type EntityExternalId,
 } from '@/lib/metadata/entity-metadata';
 import { EntityHeadTags } from '@/lib/metadata/EntityHeadTags';
+import { absoluteUrl } from '@/lib/site/url';
 
 /**
  * Eprint detail page route parameters.
@@ -117,7 +118,7 @@ export default async function EprintPage({ params }: EprintPageProps) {
     const serverApi = createServerClient();
     const response = await serverApi.pub.chive.eprint.getSubmission({ uri: fullUri });
     const value = response.data.value as SubmissionRecord;
-    const canonicalUrl = `https://chive.pub/eprints/${encodeURIComponent(fullUri)}`;
+    const canonicalUrl = absoluteUrl(`/eprints/${encodeURIComponent(fullUri)}`);
     const externalIds: EntityExternalId[] = [];
     const publishedDoi = value.publishedVersion?.doi;
     if (publishedDoi) {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { GeistSans } from 'geist/font/sans';
 import { GeistMono } from 'geist/font/mono';
 
+import { absoluteUrl, siteUrl } from '@/lib/site/url';
 import { Providers } from '@/components/providers';
 import { FaroInit } from '@/components/observability';
 import { ConditionalHeader } from '@/components/conditional-header';
@@ -14,6 +15,9 @@ import 'highlight.js/styles/github-dark.css';
 import '@/styles/globals.css';
 
 export const metadata: Metadata = {
+  // Absolute URLs come from NEXT_PUBLIC_SITE_URL rather than a literal, so a
+  // staging deployment stops advertising production as its canonical home.
+  metadataBase: new URL(siteUrl()),
   title: {
     default: 'Chive | Decentralized Eprint Service',
     template: '%s | Chive',
@@ -28,7 +32,7 @@ export const metadata: Metadata = {
     'open access',
     'scholarly communication',
   ],
-  authors: [{ name: 'Aaron Steven White', url: 'https://chive.pub' }],
+  authors: [{ name: 'Aaron Steven White', url: siteUrl() }],
   icons: {
     icon: '/chive-logo.svg',
     apple: '/chive-logo.svg',
@@ -36,13 +40,13 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: 'https://chive.pub',
+    url: siteUrl(),
     siteName: 'Chive',
     title: 'Chive | Decentralized Eprint Service',
     description: 'Decentralized eprints on ATProto.',
     images: [
       {
-        url: 'https://chive.pub/og',
+        url: absoluteUrl('/og'),
         width: 1200,
         height: 630,
         alt: 'Chive | Decentralized Eprint Service',
@@ -53,7 +57,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Chive | Decentralized Eprint Service',
     description: 'Decentralized eprints on ATProto.',
-    images: ['https://chive.pub/og'],
+    images: [absoluteUrl('/og')],
   },
   robots: {
     index: true,

--- a/web/lib/hooks/use-collections.ts
+++ b/web/lib/hooks/use-collections.ts
@@ -1655,8 +1655,16 @@ export function useCreateMarginAnnotation() {
  * @returns Mutation object for creating bookmarks
  */
 export function useCreateMarginBookmark() {
-  const queryClient = useQueryClient();
-
+  // No `queryClient` and no invalidation on purpose.
+  //
+  // `at.margin.bookmark` records are written to the user's PDS and indexed into
+  // `margin_bookmarks_index`, but no XRPC method reads that table and no hook
+  // queries it, so there is no cached list for a new bookmark to be missing
+  // from. The unused `queryClient` that used to sit here read as an oversight —
+  // an invalidation someone had forgotten to write — rather than as the absence
+  // of anything to invalidate.
+  //
+  // Whoever adds a bookmark list needs to add the invalidation with it.
   return useMutation({
     mutationFn: async (input: {
       sourceUrl: string;

--- a/web/lib/site/url.test.ts
+++ b/web/lib/site/url.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { absoluteUrl, siteUrl } from './url';
+
+describe('siteUrl', () => {
+  const saved = process.env.NEXT_PUBLIC_SITE_URL;
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.NEXT_PUBLIC_SITE_URL;
+    else process.env.NEXT_PUBLIC_SITE_URL = saved;
+  });
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  });
+
+  it('falls back to the production origin', () => {
+    expect(siteUrl()).toBe('https://chive.pub');
+  });
+
+  it('uses a configured origin', () => {
+    // Without this, staging pages advertised production as their canonical
+    // home, which invites a search engine to treat one as a duplicate of the
+    // other — or to index the wrong one.
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://staging.chive.pub';
+    expect(siteUrl()).toBe('https://staging.chive.pub');
+  });
+
+  it('strips a trailing slash so paths do not double up', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://staging.chive.pub/';
+    expect(siteUrl()).toBe('https://staging.chive.pub');
+    expect(absoluteUrl('/og')).toBe('https://staging.chive.pub/og');
+  });
+
+  it('strips several trailing slashes', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://staging.chive.pub///';
+    expect(siteUrl()).toBe('https://staging.chive.pub');
+  });
+
+  it('ignores a blank value rather than producing a relative URL', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = '   ';
+    expect(siteUrl()).toBe('https://chive.pub');
+  });
+
+  it('joins a path that has no leading slash', () => {
+    expect(absoluteUrl('og')).toBe('https://chive.pub/og');
+  });
+
+  it('produces a URL the URL constructor accepts', () => {
+    // `metadataBase` is `new URL(siteUrl())`, which throws on a malformed value
+    // and would fail the build rather than the page.
+    expect(() => new URL(siteUrl())).not.toThrow();
+  });
+});

--- a/web/lib/site/url.ts
+++ b/web/lib/site/url.ts
@@ -1,0 +1,45 @@
+/**
+ * The public origin this deployment serves from.
+ *
+ * @remarks
+ * Canonical links, Open Graph URLs and the client-metadata document all need an
+ * absolute origin, and they were hard-coded to `https://chive.pub`. Staging
+ * therefore emitted production canonicals: every staging page told search
+ * engines that its content lived at the production URL, which is how a staging
+ * host ends up displacing production in an index, or being crawled as a
+ * duplicate of it.
+ *
+ * `NEXT_PUBLIC_SITE_URL` is read at build time, since the metadata it feeds is
+ * generated during the build. The production origin remains the fallback so a
+ * deployment that sets nothing behaves as it did.
+ *
+ * @packageDocumentation
+ */
+
+/** Origin used when `NEXT_PUBLIC_SITE_URL` is unset. */
+const DEFAULT_SITE_URL = 'https://chive.pub';
+
+/**
+ * Absolute origin for this deployment, without a trailing slash.
+ *
+ * @returns The configured origin, or the production one when none is set
+ *
+ * @public
+ */
+export function siteUrl(): string {
+  const configured = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (!configured) return DEFAULT_SITE_URL;
+  return configured.replace(/\/+$/, '');
+}
+
+/**
+ * Build an absolute URL for a path on this deployment.
+ *
+ * @param path - Path beginning with `/`
+ * @returns The path resolved against {@link siteUrl}
+ *
+ * @public
+ */
+export function absoluteUrl(path: string): string {
+  return `${siteUrl()}${path.startsWith('/') ? path : `/${path}`}`;
+}


### PR DESCRIPTION
FE-9 and FE-7.

## Staging told search engines its pages lived on production (FE-9)

`web/app/layout.tsx` and the eprint page built canonical links, Open Graph URLs and image URLs from the literal `https://chive.pub`. Every page staging served carried a canonical pointing at the production URL — which is how a staging host ends up crawled as a duplicate of production, or displacing it in an index. There was no `metadataBase` either, so relative metadata URLs had nothing to resolve against.

`web/lib/site/url.ts` reads `NEXT_PUBLIC_SITE_URL` and falls back to the production origin, so a deployment that sets nothing behaves exactly as before. It is read at build time because that is when Next.js generates the metadata it feeds.

Seven tests cover it, including the trailing-slash normalisation that keeps `absoluteUrl('/og')` from producing a double slash, a blank value being ignored rather than yielding a relative URL, and — since `metadataBase` is `new URL(siteUrl())` and a malformed value fails the *build*, not the page — that the result is always something `URL` accepts.

`NEXT_PUBLIC_SITE_URL` is documented in `.env.example`.

One hard-coded origin is deliberately left alone: `oauth/client-metadata.json/route.ts` derives its origin from the request host and uses the literal only as a last-resort fallback. OAuth client metadata must match the origin actually serving it, so deriving it from the request is correct there.

## The unused queryClient in useCreateMarginBookmark (FE-7)

The backlog reads this as a missing `onSuccess`/invalidation. It isn't, quite: `at.margin.bookmark` records are written to the user's PDS and indexed into `margin_bookmarks_index`, but **no XRPC method reads that table and no hook queries it**, so there is no cached list for a new bookmark to be absent from. There is nothing to invalidate.

What was actually wrong is that the hook obtained a `queryClient` and never used it, which reads as an invalidation someone forgot to write. It is removed, with the reason recorded and a note that whoever adds a bookmark list needs to add the invalidation alongside it. That also clears one of the `js/unused-local-variable` alerts standing on `main`.

## Testing

- Web: 145 files, 2,577 tests pass
- Server `tsc --noEmit` clean; web typecheck clean; lint clean

## Compliance

Frontend metadata only. No data-flow change.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source