### PR TITLE
Correct the documented health endpoints and resolve PDS endpoints through the shared resolver

### DIFF
--- a/docs/api-reference/rest-endpoints.md
+++ b/docs/api-reference/rest-endpoints.md
@@ -242,7 +242,7 @@ Health check endpoints for monitoring and orchestration:
 ### Liveness probe
 
 ```http
-GET /health/liveness
+GET /health
 ```
 
 Returns 200 if the service is running.
@@ -250,7 +250,7 @@ Returns 200 if the service is running.
 ### Readiness probe
 
 ```http
-GET /health/readiness
+GET /ready
 ```
 
 Returns 200 if the service is ready to handle requests. Checks database connections and cache availability.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -277,25 +277,25 @@ kubectl exec -it deploy/chive-api -n chive -- \
 
 ### Endpoints
 
-| Endpoint        | Purpose                        |
-| --------------- | ------------------------------ |
-| `/health`       | Basic liveness check           |
-| `/health/ready` | Readiness (includes DB checks) |
-| `/health/live`  | Liveness (process running)     |
+| Endpoint  | Purpose                                                       |
+| --------- | ------------------------------------------------------------- |
+| `/health` | Basic liveness check                                          |
+| `/ready`  | Readiness (checks Redis, PostgreSQL, Elasticsearch and Neo4j) |
+| `/health` | Liveness (process running)                                    |
 
 ### Kubernetes probes
 
 ```yaml
 livenessProbe:
   httpGet:
-    path: /health/live
+    path: /health
     port: 3000
   initialDelaySeconds: 10
   periodSeconds: 30
 
 readinessProbe:
   httpGet:
-    path: /health/ready
+    path: /ready
     port: 3000
   initialDelaySeconds: 5
   periodSeconds: 10

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -11,7 +11,7 @@ Common issues and their solutions when operating Chive.
 curl -s https://api.chive.pub/health | jq
 
 # Detailed health
-curl -s https://api.chive.pub/health/ready | jq
+curl -s https://api.chive.pub/ready | jq
 ```
 
 ### Service status

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -133,10 +133,10 @@ pnpm openapi:generate
 curl http://localhost:3001/health
 
 # Readiness check (includes database checks)
-curl http://localhost:3001/health/ready
+curl http://localhost:3001/ready
 
 # Liveness check
-curl http://localhost:3001/health/live
+curl http://localhost:3001/health
 ```
 
 ## Scripts directory

--- a/src/api/handlers/xrpc/admin/triggerDIDSync.ts
+++ b/src/api/handlers/xrpc/admin/triggerDIDSync.ts
@@ -11,6 +11,7 @@
  * @public
  */
 
+import { DIDResolver } from '../../../../auth/did/did-resolver.js';
 import type { DID } from '../../../../types/atproto.js';
 import {
   AuthorizationError,
@@ -21,45 +22,6 @@ import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 interface TriggerDIDSyncInput {
   readonly did: string;
-}
-
-/**
- * Resolves a DID to its PDS endpoint via PLC directory.
- *
- * @param did - the DID to resolve
- * @returns the PDS URL, or null if resolution fails
- */
-async function resolvePdsEndpoint(did: string): Promise<string | null> {
-  try {
-    if (did.startsWith('did:plc:')) {
-      const response = await fetch(`https://plc.directory/${did}`);
-      if (!response.ok) return null;
-      const doc = (await response.json()) as {
-        service?: { id: string; type: string; serviceEndpoint: string }[];
-      };
-      const pds = doc.service?.find(
-        (s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'
-      );
-      return pds?.serviceEndpoint ?? null;
-    }
-
-    if (did.startsWith('did:web:')) {
-      const domain = did.replace('did:web:', '').replace(/%3A/g, ':');
-      const response = await fetch(`https://${domain}/.well-known/did.json`);
-      if (!response.ok) return null;
-      const doc = (await response.json()) as {
-        service?: { id: string; type: string; serviceEndpoint: string }[];
-      };
-      const pds = doc.service?.find(
-        (s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'
-      );
-      return pds?.serviceEndpoint ?? null;
-    }
-
-    return null;
-  } catch {
-    return null;
-  }
 }
 
 export const triggerDIDSync: XRPCMethod<void, TriggerDIDSyncInput, unknown> = {
@@ -88,10 +50,19 @@ export const triggerDIDSync: XRPCMethod<void, TriggerDIDSyncInput, unknown> = {
 
     logger.info('DID sync triggered', { operationId: operation.id, did: input.did });
 
+    // One shared resolver rather than a hand-rolled fetch.
+    //
+    // This file and sync/indexRecord.ts each carried their own
+    // `resolvePdsEndpoint`, fetching plc.directory directly with no cache, no
+    // timeout and no did:web handling beyond a string replace, while
+    // DIDResolver — built on @atproto/identity, cached in Redis — was already
+    // used elsewhere for exactly this.
+    const didResolver = new DIDResolver({ redis: c.get('redis'), logger });
+
     // Fire-and-forget: resolve DID to PDS and scan all collections for that user
     void (async () => {
       try {
-        const pdsUrl = await resolvePdsEndpoint(input.did);
+        const pdsUrl = await didResolver.getPDSEndpoint(input.did as DID);
         if (!pdsUrl) {
           await backfillManager.failOperation(
             operation.id,

--- a/src/api/handlers/xrpc/sync/indexRecord.ts
+++ b/src/api/handlers/xrpc/sync/indexRecord.ts
@@ -29,6 +29,7 @@
  * @public
  */
 
+import { DIDResolver } from '../../../../auth/did/did-resolver.js';
 import type {
   InputSchema,
   OutputSchema,
@@ -61,48 +62,6 @@ function parseAtUri(uri: string): { did: DID; collection: string; rkey: string }
     collection: match[2],
     rkey: match[3],
   };
-}
-
-/**
- * Resolve DID to PDS endpoint using PLC directory.
- */
-async function resolvePdsEndpoint(did: DID): Promise<string | null> {
-  try {
-    // Handle did:plc DIDs via PLC directory
-    if (did.startsWith('did:plc:')) {
-      const response = await fetch(`https://plc.directory/${did}`);
-      if (!response.ok) {
-        return null;
-      }
-      const doc = (await response.json()) as {
-        service?: { id: string; type: string; serviceEndpoint: string }[];
-      };
-      const pdsService = doc.service?.find(
-        (s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'
-      );
-      return pdsService?.serviceEndpoint ?? null;
-    }
-
-    // Handle did:web DIDs
-    if (did.startsWith('did:web:')) {
-      const domain = did.replace('did:web:', '').replace(/%3A/g, ':');
-      const response = await fetch(`https://${domain}/.well-known/did.json`);
-      if (!response.ok) {
-        return null;
-      }
-      const doc = (await response.json()) as {
-        service?: { id: string; type: string; serviceEndpoint: string }[];
-      };
-      const pdsService = doc.service?.find(
-        (s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'
-      );
-      return pdsService?.serviceEndpoint ?? null;
-    }
-
-    return null;
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -184,8 +143,10 @@ export const indexRecord: XRPCMethod<void, InputSchema, OutputSchema> = {
     }
 
     try {
-      // Resolve PDS endpoint for the DID
-      const pdsUrl = await resolvePdsEndpoint(did);
+      // Resolve the PDS through the shared resolver; see the note in
+      // admin/triggerDIDSync.ts about the two hand-rolled copies this replaces.
+      const didResolver = new DIDResolver({ redis: c.get('redis'), logger });
+      const pdsUrl = await didResolver.getPDSEndpoint(did);
       if (!pdsUrl) {
         throw new NotFoundError('PDS endpoint', did);
       }

--- a/tests/unit/api/handlers/xrpc/sync.test.ts
+++ b/tests/unit/api/handlers/xrpc/sync.test.ts
@@ -14,6 +14,17 @@ import type { ChiveEnv } from '@/api/types/context.js';
 import type { AtUri, DID } from '@/types/atproto.js';
 import type { ILogger } from '@/types/interfaces/logger.interface.js';
 
+// The handler resolves the PDS through the shared DIDResolver rather than
+// fetching plc.directory itself, so the resolver is what these tests stub. The
+// `global.fetch` mock below still serves the getRecord call.
+vi.mock('@/auth/did/did-resolver.js', () => ({
+  DIDResolver: class {
+    getPDSEndpoint(): Promise<string> {
+      return Promise.resolve('https://user-pds.example.com');
+    }
+  },
+}));
+
 // The registerPDS handler runs every candidate URL through the SSRF guard,
 // which resolves the hostname before any fetch. Test hostnames do not exist in
 // DNS, so resolution is stubbed to a public address; the guard's own rejection

--- a/tests/unit/api/handlers/xrpc/sync/indexRecord-tags.test.ts
+++ b/tests/unit/api/handlers/xrpc/sync/indexRecord-tags.test.ts
@@ -15,6 +15,17 @@ import type { ChiveEnv } from '@/api/types/context.js';
 import type { AtUri, DID } from '@/types/atproto.js';
 import type { ILogger } from '@/types/interfaces/logger.interface.js';
 
+// The handler resolves the PDS through the shared DIDResolver rather than
+// fetching plc.directory itself, so the resolver is what these tests stub. The
+// `global.fetch` mock below still serves the getRecord call.
+vi.mock('@/auth/did/did-resolver.js', () => ({
+  DIDResolver: class {
+    getPDSEndpoint(): Promise<string> {
+      return Promise.resolve(TEST_PDS_URL);
+    }
+  },
+}));
+
 // =============================================================================
 // Mocks
 // =============================================================================

--- a/tests/unit/config/documented-health-paths.test.ts
+++ b/tests/unit/config/documented-health-paths.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import { HEALTH_PATHS } from '@/api/config.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function markdownFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'build' || entry.name === '.docusaurus') {
+      continue;
+    }
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) markdownFiles(full, out);
+    else if (entry.name.endsWith('.md') || entry.name.endsWith('.mdx')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * The docs described four health endpoints that do not exist —
+ * `/health/live`, `/health/ready`, `/health/liveness`, `/health/readiness` —
+ * while the service serves `/health` and `/ready`. One of them shipped inside a
+ * copy-pasteable Kubernetes probe snippet, so following the documentation
+ * produced pods that never pass their readiness gate.
+ */
+describe('documented health endpoints exist', () => {
+  const docs = markdownFiles(join(REPO_ROOT, 'docs'));
+
+  it('reads a non-trivial number of documents', () => {
+    expect(docs.length).toBeGreaterThan(10);
+  });
+
+  it('serves liveness at /health and readiness at /ready', () => {
+    expect(HEALTH_PATHS.liveness).toBe('/health');
+    expect(HEALTH_PATHS.readiness).toBe('/ready');
+  });
+
+  it('mentions no health path the service does not serve', () => {
+    const invalid = /\/health\/(live|ready|liveness|readiness)\b/;
+
+    for (const file of docs) {
+      const contents = readFileSync(file, 'utf8');
+      const match = invalid.exec(contents);
+      expect(
+        match?.[0],
+        `${file.slice(REPO_ROOT.length + 1)} documents ${match?.[0]}`
+      ).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
CFG-11 and API-18.

## Four documented health endpoints do not exist (CFG-11)

The docs describe `/health/live`, `/health/ready`, `/health/liveness` and `/health/readiness`. The service serves `/health` and `/ready` — `HEALTH_PATHS` in `src/api/config.ts` has said so all along.

The worst instance is in `docs/operations/deployment.md`, which ships a **copy-pasteable Kubernetes probe snippet** using two of the wrong paths. Following the documentation produces pods whose readiness probe can never pass.

Corrected across four files, and a test now walks every `.md`/`.mdx` under `docs/` and fails on any of the four non-existent paths, with the offending file named in the message. It also pins `HEALTH_PATHS` itself, so the documentation and the router cannot drift apart in either direction.

`.claude/skills/server-access/SKILL.md` said the staging deploy verifies `https://staging.chive.pub/health`. That path reaches Next.js and 404s; the workflow checks `/api/health` (`deploy-staging.yml:384`). Corrected, with the distinction spelled out — `/api/health` is a static 200 that cannot detect a dead datastore, while `/ready` is the only endpoint that touches all four stores and no workflow checks it.

## Two hand-rolled PDS resolvers (API-18)

`admin/triggerDIDSync.ts` and `sync/indexRecord.ts` each carried their own `resolvePdsEndpoint`, fetching `plc.directory` directly — no cache, no timeout, `did:web` handled by a string replace — while `DIDResolver`, built on `@atproto/identity` and cached in Redis, was already used elsewhere for exactly this and is what every other call site uses.

Both now use it. Roughly 70 lines of duplicated resolution logic removed, and the two paths that manually index or re-sync a repository stop hammering `plc.directory` uncached.

**Two test files stubbed `global.fetch` to fake the plc.directory response**, which is how they were coupled to the hand-rolled version. They now stub `DIDResolver` instead; the `fetch` mock still serves the `getRecord` call, which is a real fetch.

## Testing

- Unit: 211 files pass
- Integration: 32 passed, 1 skipped
- Compliance: 14/14
- `tsc --noEmit` clean, lint clean

## Compliance

Docs and a de-duplication. No data-flow change; the shared resolver reads the same DID documents the local copies did.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source