### PR TITLE
Honour the auth and rate-limit metadata REST endpoints declare and drop two dead plugin registries

### DIFF
--- a/src/api/handlers/xrpc/index.ts
+++ b/src/api/handlers/xrpc/index.ts
@@ -9,10 +9,12 @@
  * @public
  */
 
-import type { Hono } from 'hono';
+import type { Hono, MiddlewareHandler } from 'hono';
 
 import type { ValidationError as _ValidationError } from '../../../types/errors.js';
-import { XRPC_PATH_PREFIX } from '../../config.js';
+import { RATE_LIMITS, XRPC_PATH_PREFIX } from '../../config.js';
+import { requireAuth } from '../../middleware/auth.js';
+import { rateLimiter } from '../../middleware/rate-limit.js';
 import type { ChiveEnv } from '../../types/context.js';
 import { xrpcErrorHandler } from '../../xrpc/error-handler.js';
 import { createXRPCRouter } from '../../xrpc/index.js';
@@ -142,12 +144,59 @@ export function registerXRPCRoutes(app: Hono<ChiveEnv>): void {
   // Mount XRPC router at /xrpc prefix
   app.route(XRPC_PATH_PREFIX, xrpc.router);
 
-  // Register REST-style endpoints (binary/non-JSON responses) directly on app
+  // Register REST-style endpoints (binary/non-JSON responses) directly on app.
+  //
+  // Three things were wrong with the previous if/else over GET and POST:
+  //
+  //   - The `auth` and `rateLimit` fields on `RESTEndpoint` were declared and
+  //     then ignored. `fetchExternalPdf` says `auth: 'required'` and is only
+  //     protected because its handler happens to check `c.get('user')` itself;
+  //     the next endpoint to declare it and forget that check would be open.
+  //   - `RESTEndpoint` admits PUT, DELETE and PATCH. Any endpoint declaring one
+  //     matched neither branch and was registered nowhere — a 404 at runtime
+  //     with nothing said at startup.
+  //   - An unrecognised method was skipped in silence. It now throws while the
+  //     server is starting, which is the only point at which anyone would see it.
   for (const endpoint of claimingRestEndpoints) {
-    if (endpoint.method === 'GET') {
-      app.get(endpoint.path, endpoint.handler);
-    } else if (endpoint.method === 'POST') {
-      app.post(endpoint.path, endpoint.handler);
+    const middleware: MiddlewareHandler<ChiveEnv>[] = [];
+
+    if (endpoint.auth === 'required') {
+      middleware.push(requireAuth());
+    }
+
+    // The declared tier is a ceiling: an endpoint marked `anonymous` gets the
+    // anonymous allowance regardless of who is calling, which is the point of
+    // declaring it on a route that proxies fetches to third parties.
+    const ceiling = RATE_LIMITS[endpoint.rateLimit];
+    middleware.push(
+      rateLimiter({
+        anonymous: Math.min(RATE_LIMITS.anonymous, ceiling),
+        authenticated: Math.min(RATE_LIMITS.authenticated, ceiling),
+        premium: Math.min(RATE_LIMITS.premium, ceiling),
+        admin: Math.min(RATE_LIMITS.admin, ceiling),
+      })
+    );
+
+    switch (endpoint.method) {
+      case 'GET':
+        app.get(endpoint.path, ...middleware, endpoint.handler);
+        break;
+      case 'POST':
+        app.post(endpoint.path, ...middleware, endpoint.handler);
+        break;
+      case 'PUT':
+        app.put(endpoint.path, ...middleware, endpoint.handler);
+        break;
+      case 'DELETE':
+        app.delete(endpoint.path, ...middleware, endpoint.handler);
+        break;
+      case 'PATCH':
+        app.patch(endpoint.path, ...middleware, endpoint.handler);
+        break;
+      default: {
+        const unreachable: never = endpoint.method;
+        throw new Error(`Unsupported REST endpoint method: ${String(unreachable)}`);
+      }
     }
   }
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -124,82 +124,20 @@ export type { OpenReviewPaper } from './builtin/openreview.js';
 export { PsyArxivPlugin } from './builtin/psyarxiv.js';
 export type { PsyArxivPaper } from './builtin/psyarxiv.js';
 
-// =============================================================================
-// All Builtin Plugins (for convenience)
-// =============================================================================
-
-import { ArxivPlugin } from './builtin/arxiv.js';
-import { DoiRegistrationPlugin } from './builtin/doi-registration.js';
-import { GitHubIntegrationPlugin } from './builtin/github-integration.js';
-import { LingBuzzPlugin } from './builtin/lingbuzz.js';
-import { OpenAlexPlugin } from './builtin/openalex.js';
-import { OrcidLinkingPlugin } from './builtin/orcid-linking.js';
-import { SemanticScholarPlugin } from './builtin/semantic-scholar.js';
-import { SemanticsArchivePlugin } from './builtin/semantics-archive.js';
-
 /**
- * All builtin plugin classes.
+ * There is no exported builtin-plugin registry.
  *
  * @remarks
- * Use this to instantiate all builtin plugins at once.
+ * There used to be two — `BUILTIN_PLUGINS` and `createBuiltinPlugins()` — and
+ * neither was referenced anywhere. Each listed eight of the twenty-eight
+ * plugins in `builtin/`, and a different eight from the five that
+ * `src/index.ts` actually instantiates, so the codebase carried three disagreeing
+ * answers to "which plugins are built in" and the only correct one was the one
+ * that ran.
  *
- * @example
- * ```typescript
- * import { BUILTIN_PLUGINS, PluginManager } from './plugins';
- *
- * for (const PluginClass of BUILTIN_PLUGINS) {
- *   await manager.loadBuiltinPlugin(new PluginClass());
- * }
- * ```
- *
- * @public
+ * `src/index.ts` remains the registry, and deliberately so: the plugins do not
+ * share a shape. Search-based ones are loaded on demand, scraping ones are
+ * handed to the import scheduler, and each is wrapped in its own error handling
+ * so one failing to load does not take down startup. A flat array cannot
+ * express that, which is why the arrays drifted from it.
  */
-export const BUILTIN_PLUGINS = [
-  ArxivPlugin,
-  GitHubIntegrationPlugin,
-  OrcidLinkingPlugin,
-  DoiRegistrationPlugin,
-  SemanticsArchivePlugin,
-  LingBuzzPlugin,
-  SemanticScholarPlugin,
-  OpenAlexPlugin,
-] as const;
-
-/**
- * Creates instances of all builtin plugins.
- *
- * @returns Array of builtin plugin instances
- *
- * @example
- * ```typescript
- * import { createBuiltinPlugins, PluginManager } from './plugins';
- *
- * const plugins = createBuiltinPlugins();
- * for (const plugin of plugins) {
- *   await manager.loadBuiltinPlugin(plugin);
- * }
- * ```
- *
- * @public
- */
-export function createBuiltinPlugins(): readonly [
-  ArxivPlugin,
-  GitHubIntegrationPlugin,
-  OrcidLinkingPlugin,
-  DoiRegistrationPlugin,
-  SemanticsArchivePlugin,
-  LingBuzzPlugin,
-  SemanticScholarPlugin,
-  OpenAlexPlugin,
-] {
-  return [
-    new ArxivPlugin(),
-    new GitHubIntegrationPlugin(),
-    new OrcidLinkingPlugin(),
-    new DoiRegistrationPlugin(),
-    new SemanticsArchivePlugin(),
-    new LingBuzzPlugin(),
-    new SemanticScholarPlugin(),
-    new OpenAlexPlugin(),
-  ] as const;
-}

--- a/tests/unit/api/handlers/rest-endpoint-registration.test.ts
+++ b/tests/unit/api/handlers/rest-endpoint-registration.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import { claimingRestEndpoints } from '@/api/handlers/xrpc/claiming/index.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const registration = readFileSync(join(REPO_ROOT, 'src/api/handlers/xrpc/index.ts'), 'utf8');
+
+const block = registration.slice(
+  registration.indexOf('// Register REST-style endpoints'),
+  registration.length
+);
+
+/**
+ * `RESTEndpoint` declares `auth`, `rateLimit` and five HTTP methods. The
+ * registration loop honoured two of the methods and neither field, so the
+ * metadata was decorative: an endpoint declaring `auth: 'required'` was
+ * protected only if its handler remembered to check, and one declaring PUT,
+ * DELETE or PATCH was registered nowhere at all — a 404 with nothing said at
+ * startup.
+ */
+describe('REST endpoint registration honours declared metadata', () => {
+  it('registers every method the type admits', () => {
+    for (const verb of ['get', 'post', 'put', 'delete', 'patch']) {
+      expect(block, `app.${verb} missing`).toContain(`app.${verb}(endpoint.path`);
+    }
+  });
+
+  it('applies authentication when the endpoint requires it', () => {
+    expect(block).toContain("endpoint.auth === 'required'");
+    expect(block).toContain('requireAuth()');
+  });
+
+  it('applies the declared rate-limit tier', () => {
+    expect(block).toContain('RATE_LIMITS[endpoint.rateLimit]');
+    expect(block).toContain('rateLimiter(');
+  });
+
+  it('fails at startup on a method it cannot register', () => {
+    // Silently skipping produced an endpoint that 404s in production with no
+    // indication anywhere that it was never mounted.
+    expect(block).toContain('Unsupported REST endpoint method');
+    expect(block).toContain('const unreachable: never');
+  });
+
+  it('every declared endpoint names a method the loop handles', () => {
+    const handled = new Set(['GET', 'POST', 'PUT', 'DELETE', 'PATCH']);
+    for (const endpoint of claimingRestEndpoints) {
+      expect(handled, endpoint.path).toContain(endpoint.method);
+    }
+  });
+
+  it('every declared endpoint names a real rate-limit tier', () => {
+    const tiers = new Set(['anonymous', 'authenticated', 'admin']);
+    for (const endpoint of claimingRestEndpoints) {
+      expect(tiers, endpoint.path).toContain(endpoint.rateLimit);
+    }
+  });
+});


### PR DESCRIPTION
API-16 and DEAD-10.

## REST endpoint metadata was declared and then ignored (API-16)

`RESTEndpoint` declares `auth: 'required' | 'optional' | 'none'`, `rateLimit: 'anonymous' | 'authenticated' | 'admin'`, and five HTTP methods. The registration loop was an if/else over GET and POST that read neither field. Three consequences:

- **`auth` did nothing.** `fetchExternalPdf` declares `auth: 'required'` and is protected only because its handler happens to check `c.get('user')` itself. The next endpoint to declare it and rely on the declaration would be open. Declared auth now applies `requireAuth()`.
- **`rateLimit` did nothing.** Every REST endpoint got the global standard limiter regardless of the tier it asked for. The declared tier is now applied as a ceiling — an endpoint marked `anonymous` gets the anonymous allowance whoever is calling, which is the point of declaring it on a route that proxies fetches to third parties.
- **PUT, DELETE and PATCH were silently dropped.** An endpoint declaring one matched neither branch and was registered nowhere: a 404 in production with nothing said at startup. All five verbs are handled, and an unrecognised one now throws while the server is starting — the only moment anyone would notice.

To be accurate about scope: the endpoint did already get service-auth population, a standard rate limiter and error handling, because all three are mounted on `*` in `server.ts`. What was broken is that the *per-endpoint* declarations had no effect, so the type was describing a contract nothing enforced.

Six tests cover the registration, including that every currently declared endpoint names a method the loop handles and a tier that exists.

## Three disagreeing answers to "which plugins are built in" (DEAD-10)

`src/plugins/index.ts` exported `BUILTIN_PLUGINS` and `createBuiltinPlugins()`. Neither was referenced anywhere in the repository. Each listed eight of the twenty-eight plugins in `builtin/` — and a different eight from the five that `src/index.ts` actually instantiates.

Both are removed. `src/index.ts` stays the registry, and deliberately: the plugins do not share a shape. Search-based ones are loaded on demand, scraping ones are handed to the import scheduler, and each is wrapped in its own error handling so one failing to load does not take down startup. A flat array cannot express that, which is why the arrays drifted from it in the first place — the note now in `src/plugins/index.ts` says so, in place of the exports.

## Testing

- Unit: 211 files pass
- Integration: 32 passed, 1 skipped
- Compliance: 14/14
- `tsc --noEmit` clean, lint clean

## Compliance

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source