### PR TITLE
Repair the admin audit log query and record role grants and content deletions in it

### DIFF
--- a/src/api/handlers/xrpc/admin/assignRole.ts
+++ b/src/api/handlers/xrpc/admin/assignRole.ts
@@ -105,6 +105,22 @@ export const assignRole: XRPCMethod<void, AssignRoleInput, AssignRoleOutput> = {
       })
     );
 
+    // Record it where the audit log can see it. Writing the assignment to
+    // Redis alone meant `pub.chive.admin.getAuditLog` could not show role
+    // grants — one of the two actions an admin audit log exists for.
+    const admin = c.get('services').admin;
+    if (admin) {
+      await admin.recordAuditEntry({
+        action: 'assign_role',
+        collection: 'chive.admin.role',
+        uri: `did:role:${input.did}:${input.role}`,
+        actorDid: user.did,
+        targetDid: input.did,
+        ipAddress: c.req.header('x-forwarded-for'),
+        details: { role: input.role },
+      });
+    }
+
     adminMetrics.actionsTotal.inc({ action: 'assign_role', target: 'user' });
 
     const logger = c.get('logger');

--- a/src/api/handlers/xrpc/admin/deleteContent.ts
+++ b/src/api/handlers/xrpc/admin/deleteContent.ts
@@ -80,6 +80,17 @@ export const deleteContent: XRPCMethod<void, DeleteContentInput, DeleteContentOu
       })
     );
 
+    // The publish above goes to a channel with no subscriber, so it recorded
+    // nothing durable. This is the entry the audit log reads.
+    await admin.recordAuditEntry({
+      action: 'delete_content',
+      collection: input.collection,
+      uri: input.uri,
+      actorDid: user.did,
+      ipAddress: c.req.header('x-forwarded-for'),
+      details: { reason: input.reason, deleted },
+    });
+
     adminMetrics.actionsTotal.inc({ action: 'delete', target: input.collection });
 
     logger.info('Content soft-deleted by admin', {

--- a/src/services/admin/admin-service.ts
+++ b/src/services/admin/admin-service.ts
@@ -1199,7 +1199,11 @@ export class AdminService {
           dataParams
         ),
         this.pool.query<{ count: number }>(
-          `SELECT COUNT(*)::int as count FROM governance_audit_log ${whereClause}`,
+          // Aliased `g` because `whereClause` is written against that alias and
+          // is shared with the data query above. Without it, any call that
+          // filtered by actor failed with "missing FROM-clause entry for table
+          // g" — a second way this endpoint could not return a row.
+          `SELECT COUNT(*)::int as count FROM governance_audit_log g ${whereClause}`,
           params
         ),
       ]);
@@ -1218,9 +1222,66 @@ export class AdminService {
       }));
 
       return { entries, total: countResult.rows[0]?.count ?? 0 };
-    } catch {
-      this.logger.warn('governance_audit_log table not available; returning empty result');
-      return { entries: [], total: 0 };
+    } catch (error) {
+      // The message used to assert the table was missing, and swallowed the
+      // error. It was not the table: the query selected `target_did` and
+      // `ip_address`, which did not exist, so every call failed and the
+      // endpoint reported an empty audit log — while sending anyone who
+      // investigated to look for a table that was there all along.
+      this.logger.error(
+        'Failed to read the governance audit log',
+        error instanceof Error ? error : undefined
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Record an administrative action in the governance audit log.
+   *
+   * @param entry - What happened, and who did it
+   *
+   * @remarks
+   * Role grants and content deletions used to be written to Redis alone — a
+   * `SET` under an assignment key, and a pub/sub publish nobody subscribed to —
+   * so the audit log could not show the two actions an audit log exists for.
+   *
+   * A failure here is logged and swallowed. The alternative is failing the
+   * administrative action itself because its record could not be written, which
+   * would mean an unwritable log stops moderation entirely.
+   *
+   * @public
+   */
+  async recordAuditEntry(entry: {
+    action: 'assign_role' | 'revoke_role' | 'delete_content';
+    collection: string;
+    uri: string;
+    actorDid: string;
+    targetDid?: string;
+    ipAddress?: string;
+    details: Record<string, unknown>;
+  }): Promise<void> {
+    try {
+      await this.pool.query(
+        `INSERT INTO governance_audit_log
+           (id, action, collection, uri, editor_did, target_did, ip_address, record_snapshot)
+         VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7)`,
+        [
+          entry.action,
+          entry.collection,
+          entry.uri,
+          entry.actorDid,
+          entry.targetDid ?? null,
+          entry.ipAddress ?? null,
+          JSON.stringify(entry.details),
+        ]
+      );
+    } catch (error) {
+      this.logger.error(
+        'Failed to write an audit log entry',
+        error instanceof Error ? error : undefined,
+        { action: entry.action, actorDid: entry.actorDid }
+      );
     }
   }
 

--- a/src/storage/postgresql/migrations/1742000000000_admin-audit-log-columns.ts
+++ b/src/storage/postgresql/migrations/1742000000000_admin-audit-log-columns.ts
@@ -1,0 +1,64 @@
+/**
+ * Make the governance audit log able to record administrative actions.
+ *
+ * @remarks
+ * Two problems, and the first made the endpoint unusable outright:
+ *
+ * 1. `AdminService.getAuditLog` selects `g.target_did` and `g.ip_address`.
+ *    Neither column exists, so `pub.chive.admin.getAuditLog` failed with
+ *    `column g.target_did does not exist` on every call — the admin audit log
+ *    has never returned a row.
+ *
+ * 2. The `action` CHECK constraint admits only `create`, `update` and `delete`,
+ *    which are the governance record verbs. Administrative actions — granting a
+ *    role, revoking one, deleting content — could not be recorded under a name
+ *    that says what happened, so they were written to Redis instead and never
+ *    reached the log the endpoint reads.
+ *
+ * Both new columns are nullable: governance rows written before this migration
+ * have no actor address or target account, and back-filling a value would be
+ * inventing one.
+ *
+ * @packageDocumentation
+ */
+
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+/** Actions the log may record after this migration. */
+const ACTIONS = [
+  'create',
+  'update',
+  'delete',
+  'assign_role',
+  'revoke_role',
+  'delete_content',
+] as const;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumns('governance_audit_log', {
+    target_did: { type: 'text', notNull: false },
+    ip_address: { type: 'text', notNull: false },
+  });
+
+  pgm.createIndex('governance_audit_log', 'target_did');
+
+  pgm.dropConstraint('governance_audit_log', 'check_action');
+  pgm.addConstraint('governance_audit_log', 'check_action', {
+    check: `action IN (${ACTIONS.map((a) => `'${a}'`).join(', ')})`,
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  // Rows recording the new actions cannot satisfy the narrower constraint, so
+  // they are removed before it is restored. This loses audit history, which is
+  // why the down migration exists only to make the up reversible in testing.
+  pgm.sql(`DELETE FROM governance_audit_log WHERE action NOT IN ('create', 'update', 'delete')`);
+
+  pgm.dropConstraint('governance_audit_log', 'check_action');
+  pgm.addConstraint('governance_audit_log', 'check_action', {
+    check: `action IN ('create', 'update', 'delete')`,
+  });
+
+  pgm.dropIndex('governance_audit_log', 'target_did');
+  pgm.dropColumns('governance_audit_log', ['target_did', 'ip_address']);
+}

--- a/tests/integration/services/admin-audit-log.test.ts
+++ b/tests/integration/services/admin-audit-log.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Admin audit log integration tests.
+ *
+ * @remarks
+ * `pub.chive.admin.getAuditLog` failed on every call: the query selected
+ * `g.target_did` and `g.ip_address`, and neither column existed. The failure was
+ * swallowed by a catch that logged "table not available" and returned an empty
+ * result, so the endpoint reported no audit entries and anyone investigating
+ * was sent to look for a table that was there all along.
+ *
+ * Separately, the two actions an admin audit log exists for — granting a role
+ * and deleting content — were written to Redis only and never reached it.
+ *
+ * These tests run against a real PostgreSQL because the bug was in SQL against
+ * a real schema, which is exactly what a mocked pool cannot catch.
+ *
+ * @packageDocumentation
+ */
+
+import { Pool } from 'pg';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+import { AdminService } from '@/services/admin/admin-service.js';
+import { getDatabaseConfig } from '@/storage/postgresql/config.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+const ACTOR = 'did:plc:auditactortest';
+const TARGET = 'did:plc:audittargettest';
+
+function createLogger(): ILogger {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+describe('admin audit log', () => {
+  let pool: Pool;
+  let admin: AdminService;
+
+  beforeAll(() => {
+    pool = new Pool(getDatabaseConfig());
+    // Only the pool is exercised here; the other dependencies are not touched
+    // by the audit-log paths.
+    admin = new AdminService(pool, {} as never, {} as never, {} as never, createLogger());
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM governance_audit_log WHERE editor_did = $1`, [ACTOR]);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await pool.query(`DELETE FROM governance_audit_log WHERE editor_did = $1`, [ACTOR]);
+  });
+
+  it('reads without throwing', async () => {
+    // The regression: this used to fail on `column g.target_did does not exist`.
+    await expect(admin.getAuditLog(10, 0)).resolves.toBeDefined();
+  });
+
+  it('records and returns a role grant', async () => {
+    await admin.recordAuditEntry({
+      action: 'assign_role',
+      collection: 'chive.admin.role',
+      uri: `did:role:${TARGET}:moderator`,
+      actorDid: ACTOR,
+      targetDid: TARGET,
+      ipAddress: '203.0.113.7',
+      details: { role: 'moderator' },
+    });
+
+    const { entries, total } = await admin.getAuditLog(10, 0, ACTOR);
+
+    expect(total).toBe(1);
+    expect(entries[0]?.action).toBe('assign_role');
+    expect(entries[0]?.targetDid).toBe(TARGET);
+    expect(entries[0]?.ipAddress).toBe('203.0.113.7');
+    expect(entries[0]?.details).toMatchObject({ role: 'moderator' });
+  });
+
+  it('records a content deletion', async () => {
+    await admin.recordAuditEntry({
+      action: 'delete_content',
+      collection: 'pub.chive.eprint.submission',
+      uri: 'at://did:plc:someone/pub.chive.eprint.submission/abc',
+      actorDid: ACTOR,
+      details: { reason: 'spam', deleted: true },
+    });
+
+    const { entries } = await admin.getAuditLog(10, 0, ACTOR);
+    expect(entries[0]?.action).toBe('delete_content');
+    expect(entries[0]?.details).toMatchObject({ reason: 'spam' });
+  });
+
+  it('accepts an entry with no target or address', async () => {
+    // Both columns are nullable on purpose: rows written before the migration
+    // have neither, and inventing a value would be worse than recording none.
+    await expect(
+      admin.recordAuditEntry({
+        action: 'delete_content',
+        collection: 'pub.chive.review.comment',
+        uri: 'at://did:plc:someone/pub.chive.review.comment/x',
+        actorDid: ACTOR,
+        details: {},
+      })
+    ).resolves.toBeUndefined();
+
+    const { entries } = await admin.getAuditLog(10, 0, ACTOR);
+    expect(entries[0]?.targetDid).toBeUndefined();
+    expect(entries[0]?.ipAddress).toBeUndefined();
+  });
+
+  it('filters by actor', async () => {
+    await admin.recordAuditEntry({
+      action: 'assign_role',
+      collection: 'chive.admin.role',
+      uri: 'did:role:x:y',
+      actorDid: ACTOR,
+      details: {},
+    });
+
+    const mine = await admin.getAuditLog(10, 0, ACTOR);
+    const other = await admin.getAuditLog(10, 0, 'did:plc:nobodyatall');
+
+    expect(mine.total).toBe(1);
+    expect(other.total).toBe(0);
+  });
+
+  it('orders newest first', async () => {
+    for (const role of ['first', 'second', 'third']) {
+      await admin.recordAuditEntry({
+        action: 'assign_role',
+        collection: 'chive.admin.role',
+        uri: `did:role:${TARGET}:${role}`,
+        actorDid: ACTOR,
+        details: { role },
+      });
+    }
+
+    const { entries } = await admin.getAuditLog(10, 0, ACTOR);
+    expect(entries).toHaveLength(3);
+    expect((entries[0]?.details as { role?: string })?.role).toBe('third');
+  });
+});

--- a/tests/unit/api/handlers/xrpc/admin.test.ts
+++ b/tests/unit/api/handlers/xrpc/admin.test.ts
@@ -373,8 +373,7 @@ describe('XRPC Admin Handlers', () => {
         }
       }),
       set: vi.fn(),
-      // Handlers read the caller's address for the audit log; the mock needs a
-      // `req` for that, not because the handler is defensive about its absence.
+      // Handlers read the caller's address for the audit log.
       req: { header: vi.fn(() => undefined) },
     };
   }
@@ -415,8 +414,7 @@ describe('XRPC Admin Handlers', () => {
         }
       }),
       set: vi.fn(),
-      // Handlers read the caller's address for the audit log; the mock needs a
-      // `req` for that, not because the handler is defensive about its absence.
+      // Handlers read the caller's address for the audit log.
       req: { header: vi.fn(() => undefined) },
     };
   }
@@ -806,1748 +804,1741 @@ describe('XRPC Admin Handlers', () => {
     it('records a role grant', async () => {
       // Role grants used to be written to Redis alone, so getAuditLog could not
       // show one of the two actions an admin audit log exists for.
-      const ctx = buildContext(adminUser);
       await assignRole.handler({
         params: undefined as never,
         input: { did: 'did:plc:target', role: 'moderator' },
         auth: null,
+        c: mockContext as never,
+      });
+
+      expect(mockAdminService.recordAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'assign_role',
+          actorDid: adminUser.did,
+          targetDid: 'did:plc:target',
+          details: { role: 'moderator' },
+        })
+      );
+    });
+
+    it('records a content deletion', async () => {
+      await deleteContent.handler({
+        params: undefined as never,
+        input: {
+          uri: 'at://did:plc:someone/pub.chive.eprint.submission/abc',
+          collection: 'pub.chive.eprint.submission',
+          reason: 'spam',
+        },
+        auth: null,
+        c: mockContext as never,
+      });
+
+      expect(mockAdminService.recordAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'delete_content',
+          actorDid: adminUser.did,
+          uri: 'at://did:plc:someone/pub.chive.eprint.submission/abc',
+        })
+      );
+    });
+  });
+
+  describe('revokeRole', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        revokeRole.handler({
+          params: undefined,
+          input: { did: 'did:plc:user1', role: 'moderator' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('throws ValidationError for missing input', async () => {
+      await expect(
+        revokeRole.handler({
+          params: undefined,
+          input: undefined as never,
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('DID and role are required');
+    });
+
+    it('removes role from Redis and returns success', async () => {
+      const result = await revokeRole.handler({
+        params: undefined,
+        input: { did: 'did:plc:user1', role: 'moderator' },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockRedis.srem).toHaveBeenCalledWith('chive:authz:roles:did:plc:user1', 'moderator');
+      expect(mockRedis.del).toHaveBeenCalledWith('chive:authz:assignments:did:plc:user1:moderator');
+      expect(result.body).toMatchObject({ success: true, did: 'did:plc:user1', role: 'moderator' });
+    });
+  });
+
+  // =========================================================================
+  // Content: listEprints
+  // =========================================================================
+  describe('listEprints', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        listEprints.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        listEprints.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('uses default limit 50 and offset 0', async () => {
+      await listEprints.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listEprints).toHaveBeenCalledWith(undefined, 50, 0);
+    });
+
+    it('passes query, limit, and offset', async () => {
+      await listEprints.handler({
+        params: { q: 'neural', limit: 10, offset: 20 },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listEprints).toHaveBeenCalledWith('neural', 10, 20);
+    });
+  });
+
+  // =========================================================================
+  // Content: listReviews
+  // =========================================================================
+  describe('listReviews', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        listReviews.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        listReviews.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('uses default limit 50 and offset 0', async () => {
+      await listReviews.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listReviews).toHaveBeenCalledWith(50, 0);
+    });
+
+    it('parses cursor as numeric offset', async () => {
+      await listReviews.handler({
+        params: { limit: 10, cursor: '25' },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listReviews).toHaveBeenCalledWith(10, 25);
+    });
+  });
+
+  // =========================================================================
+  // Content: listEndorsements
+  // =========================================================================
+  describe('listEndorsements', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        listEndorsements.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        listEndorsements.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('uses default limit 50 and offset 0', async () => {
+      await listEndorsements.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listEndorsements).toHaveBeenCalledWith(50, 0);
+    });
+
+    it('parses cursor as numeric offset', async () => {
+      await listEndorsements.handler({
+        params: { limit: 5, cursor: '15' },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listEndorsements).toHaveBeenCalledWith(5, 15);
+    });
+  });
+
+  // =========================================================================
+  // Content: deleteContent
+  // =========================================================================
+  describe('deleteContent', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        deleteContent.handler({
+          params: undefined,
+          input: { uri: 'at://test', collection: 'pub.chive.eprint.submission' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        deleteContent.handler({
+          params: undefined,
+          input: { uri: 'at://test', collection: 'pub.chive.eprint.submission' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('throws ValidationError for missing input', async () => {
+      await expect(
+        deleteContent.handler({
+          params: undefined,
+          input: undefined as never,
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('URI and collection are required');
+    });
+
+    it('throws ValidationError for unsupported collection', async () => {
+      await expect(
+        deleteContent.handler({
+          params: undefined,
+          input: { uri: 'at://test', collection: 'pub.chive.unknown.type' },
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('Unsupported collection');
+    });
+
+    it('soft-deletes content and publishes event', async () => {
+      const result = await deleteContent.handler({
+        params: undefined,
+        input: {
+          uri: 'at://did:plc:test/pub.chive.eprint.submission/123',
+          collection: 'pub.chive.eprint.submission',
+          reason: 'spam',
+        },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.deleteContent).toHaveBeenCalledWith(
+        'at://did:plc:test/pub.chive.eprint.submission/123',
+        'eprints_index'
+      );
+      expect(mockRedis.publish).toHaveBeenCalledWith(
+        'chive:admin:content-deleted',
+        expect.stringContaining('"reason":"spam"')
+      );
+      expect(result.body).toMatchObject({ success: true });
+    });
+
+    it('maps all supported collections to correct tables', async () => {
+      const collectionMap: Record<string, string> = {
+        'pub.chive.eprint.submission': 'eprints_index',
+        'pub.chive.review.comment': 'reviews_index',
+        'pub.chive.review.endorsement': 'endorsements_index',
+        'pub.chive.eprint.userTag': 'user_tags_index',
+      };
+
+      for (const [collection, table] of Object.entries(collectionMap)) {
+        vi.clearAllMocks();
+        mockAdminService = createMockAdminService();
+        mockRedis = createMockRedis();
+        mockContext = buildContext(adminUser);
+
+        await deleteContent.handler({
+          params: undefined,
+          input: { uri: 'at://test', collection },
+          auth: null,
+          c: mockContext as never,
+        });
+        expect(mockAdminService.deleteContent).toHaveBeenCalledWith('at://test', table);
+      }
+    });
+  });
+
+  // =========================================================================
+  // Firehose: getFirehoseStatus
+  // =========================================================================
+  describe('getFirehoseStatus', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getFirehoseStatus.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('returns cursor and DLQ count from Redis', async () => {
+      mockRedis.get.mockResolvedValueOnce('12345');
+      mockRedis.llen.mockResolvedValueOnce(3);
+
+      const result = await getFirehoseStatus.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(result.body).toMatchObject({ cursor: '12345', dlqCount: 3 });
+      expect(result.body).toHaveProperty('timestamp');
+    });
+
+    it('handles llen failure gracefully', async () => {
+      mockRedis.get.mockResolvedValueOnce(null);
+      mockRedis.llen.mockRejectedValueOnce(new Error('Redis error'));
+
+      const result = await getFirehoseStatus.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(result.body).toMatchObject({ cursor: null, dlqCount: 0 });
+    });
+  });
+
+  // =========================================================================
+  // Firehose: listDLQEntries
+  // =========================================================================
+  describe('listDLQEntries', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        listDLQEntries.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('uses default limit 50 and offset 0', async () => {
+      mockRedis.lrange.mockResolvedValueOnce([]);
+      mockRedis.llen.mockResolvedValueOnce(0);
+
+      await listDLQEntries.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockRedis.lrange).toHaveBeenCalledWith('chive:firehose:dlq', 0, 49);
+    });
+
+    it('uses custom limit and offset', async () => {
+      mockRedis.lrange.mockResolvedValueOnce([]);
+      mockRedis.llen.mockResolvedValueOnce(0);
+
+      await listDLQEntries.handler({
+        params: { limit: 10, offset: 5 },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockRedis.lrange).toHaveBeenCalledWith('chive:firehose:dlq', 5, 14);
+    });
+
+    it('parses JSON entries and handles invalid entries', async () => {
+      mockRedis.lrange.mockResolvedValueOnce([
+        JSON.stringify({ error: 'timeout', uri: 'at://test' }),
+        'not-valid-json',
+      ]);
+      mockRedis.llen.mockResolvedValueOnce(2);
+
+      const result = await listDLQEntries.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      const body = result.body as { entries: unknown[]; total: number };
+      expect(body.entries).toHaveLength(2);
+      expect(body.total).toBe(2);
+      expect(body.entries[1]).toMatchObject({ raw: 'not-valid-json' });
+    });
+  });
+
+  // =========================================================================
+  // Firehose: retryDLQEntry
+  // =========================================================================
+  describe('retryDLQEntry', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        retryDLQEntry.handler({
+          params: undefined,
+          input: { index: 0 },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('throws ValidationError when index is missing', async () => {
+      await expect(
+        retryDLQEntry.handler({
+          params: undefined,
+          input: {} as never,
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('Index is required');
+    });
+
+    it('returns failure when entry not found at index', async () => {
+      mockRedis.lrange.mockResolvedValueOnce([]);
+
+      const result = await retryDLQEntry.handler({
+        params: undefined,
+        input: { index: 99 },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(result.body).toMatchObject({ success: false });
+    });
+
+    it('requeues entry to retry queue on success', async () => {
+      mockRedis.lrange.mockResolvedValueOnce(['{"error":"timeout"}']);
+
+      const result = await retryDLQEntry.handler({
+        params: undefined,
+        input: { index: 0 },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockRedis.rpush).toHaveBeenCalledWith('chive:firehose:retry', '{"error":"timeout"}');
+      expect(result.body).toMatchObject({ success: true });
+    });
+  });
+
+  // =========================================================================
+  // Firehose: retryAllDLQ
+  // =========================================================================
+  describe('retryAllDLQ', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        retryAllDLQ.handler({
+          params: undefined,
+          input: {},
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('retries all entries and clears DLQ when no errorType filter', async () => {
+      mockRedis.lrange.mockResolvedValueOnce(['{"error":"a"}', '{"error":"b"}']);
+
+      const result = await retryAllDLQ.handler({
+        params: undefined,
+        input: {},
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockRedis.rpush).toHaveBeenCalledTimes(2);
+      expect(mockRedis.del).toHaveBeenCalledWith('chive:firehose:dlq');
+      expect(result.body).toMatchObject({ success: true, retriedCount: 2 });
+    });
+
+    it('filters by errorType when specified', async () => {
+      mockRedis.lrange.mockResolvedValueOnce([
+        JSON.stringify({ errorType: 'timeout' }),
+        JSON.stringify({ errorType: 'parse' }),
+        JSON.stringify({ errorType: 'timeout' }),
+      ]);
+
+      const result = await retryAllDLQ.handler({
+        params: undefined,
+        input: { errorType: 'timeout' },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockRedis.rpush).toHaveBeenCalledTimes(2);
+      expect(mockRedis.del).not.toHaveBeenCalled();
+      expect(result.body).toMatchObject({ retriedCount: 2 });
+    });
+  });
+
+  // =========================================================================
+  // Firehose: dismissDLQEntry
+  // =========================================================================
+  describe('dismissDLQEntry', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        dismissDLQEntry.handler({
+          params: undefined,
+          input: { index: 0 },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('throws ValidationError when index is missing', async () => {
+      await expect(
+        dismissDLQEntry.handler({
+          params: undefined,
+          input: {} as never,
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('Index is required');
+    });
+
+    it('removes entry via sentinel pattern', async () => {
+      const result = await dismissDLQEntry.handler({
+        params: undefined,
+        input: { index: 3 },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockRedis.lset).toHaveBeenCalledWith(
+        'chive:firehose:dlq',
+        3,
+        expect.stringContaining('__DISMISSED_')
+      );
+      expect(mockRedis.lrem).toHaveBeenCalled();
+      expect(result.body).toMatchObject({ success: true });
+    });
+  });
+
+  // =========================================================================
+  // Firehose: purgeOldDLQ
+  // =========================================================================
+  describe('purgeOldDLQ', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        purgeOldDLQ.handler({
+          params: undefined,
+          input: {},
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('uses default 7 days when olderThanDays not specified', async () => {
+      mockRedis.lrange.mockResolvedValueOnce([]);
+
+      const result = await purgeOldDLQ.handler({
+        params: undefined,
+        input: {},
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(result.body).toMatchObject({ success: true, purgedCount: 0 });
+    });
+
+    it('purges entries older than cutoff', async () => {
+      const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+      const newDate = new Date().toISOString();
+
+      mockRedis.lrange.mockResolvedValueOnce([
+        JSON.stringify({ timestamp: oldDate }),
+        JSON.stringify({ timestamp: newDate }),
+      ]);
+
+      const result = await purgeOldDLQ.handler({
+        params: undefined,
+        input: { olderThanDays: 7 },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(result.body).toMatchObject({ purgedCount: 1 });
+      expect(mockRedis.lset).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // =========================================================================
+  // Backfill: triggerPDSScan
+  // =========================================================================
+  describe('triggerPDSScan', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        triggerPDSScan.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        triggerPDSScan.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('starts operation and returns immediately', async () => {
+      const result = await triggerPDSScan.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('pdsScan');
+      expect(result.body).toMatchObject({ operationId: 'op-123', status: 'running' });
+    });
+  });
+
+  // =========================================================================
+  // Backfill: triggerFreshnessScan
+  // =========================================================================
+  describe('triggerFreshnessScan', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        triggerFreshnessScan.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        triggerFreshnessScan.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('starts freshnessScan operation', async () => {
+      const result = await triggerFreshnessScan.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('freshnessScan');
+      expect(result.body).toMatchObject({ status: 'running' });
+    });
+  });
+
+  // =========================================================================
+  // Backfill: triggerCitationExtraction
+  // =========================================================================
+  describe('triggerCitationExtraction', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        triggerCitationExtraction.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        triggerCitationExtraction.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('starts citationExtraction operation', async () => {
+      const result = await triggerCitationExtraction.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('citationExtraction');
+      expect(result.body).toMatchObject({ status: 'running' });
+    });
+  });
+
+  // =========================================================================
+  // Backfill: triggerFullReindex
+  // =========================================================================
+  describe('triggerFullReindex', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        triggerFullReindex.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        triggerFullReindex.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('starts fullReindex operation', async () => {
+      const result = await triggerFullReindex.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('fullReindex');
+      expect(result.body).toMatchObject({ status: 'running' });
+    });
+  });
+
+  // =========================================================================
+  // Backfill: triggerGovernanceSync
+  // =========================================================================
+  describe('triggerGovernanceSync', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        triggerGovernanceSync.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        triggerGovernanceSync.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('starts governanceSync operation', async () => {
+      const result = await triggerGovernanceSync.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('governanceSync');
+      expect(result.body).toMatchObject({ status: 'running' });
+    });
+  });
+
+  // =========================================================================
+  // Backfill: triggerDIDSync
+  // =========================================================================
+  describe('triggerDIDSync', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        triggerDIDSync.handler({
+          params: undefined,
+          input: { did: 'did:plc:test' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('throws ValidationError when DID is missing', async () => {
+      await expect(
+        triggerDIDSync.handler({
+          params: undefined,
+          input: { did: '' },
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('DID is required');
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        triggerDIDSync.handler({
+          params: undefined,
+          input: { did: 'did:plc:test' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('starts didSync operation with DID metadata', async () => {
+      const result = await triggerDIDSync.handler({
+        params: undefined,
+        input: { did: 'did:plc:target' },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('didSync', {
+        did: 'did:plc:target',
+      });
+      expect(result.body).toMatchObject({ did: 'did:plc:target', status: 'running' });
+    });
+  });
+
+  // =========================================================================
+  // Backfill: triggerBackfill (generic)
+  // =========================================================================
+  describe('triggerBackfill', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        triggerBackfill.handler({
+          params: undefined,
+          input: { type: 'pdsScan' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('throws ValidationError when type is missing', async () => {
+      await expect(
+        triggerBackfill.handler({
+          params: undefined,
+          input: { type: '' },
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('Backfill type is required');
+    });
+
+    it('throws ValidationError for invalid type', async () => {
+      await expect(
+        triggerBackfill.handler({
+          params: undefined,
+          input: { type: 'invalidOperation' },
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('Invalid backfill type');
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        triggerBackfill.handler({
+          params: undefined,
+          input: { type: 'pdsScan' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('starts operation with type and metadata', async () => {
+      const result = await triggerBackfill.handler({
+        params: undefined,
+        input: { type: 'fullReindex' },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('fullReindex', {
+        startedBy: ADMIN_DID,
+      });
+      expect(result.body).toHaveProperty('operation');
+    });
+
+    it('accepts all valid backfill types', async () => {
+      const validTypes = [
+        'pdsScan',
+        'freshnessScan',
+        'citationExtraction',
+        'fullReindex',
+        'governanceSync',
+        'didSync',
+      ];
+      for (const type of validTypes) {
+        vi.clearAllMocks();
+        mockBackfillManager = createMockBackfillManager();
+        mockContext = buildContext(adminUser);
+        await triggerBackfill.handler({
+          params: undefined,
+          input: { type },
+          auth: null,
+          c: mockContext as never,
+        });
+        expect(mockBackfillManager.startOperation).toHaveBeenCalledWith(type, expect.any(Object));
+      }
+    });
+  });
+
+  // =========================================================================
+  // Backfill: getBackfillStatus
+  // =========================================================================
+  describe('getBackfillStatus', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getBackfillStatus.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        getBackfillStatus.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('returns single operation when id is provided', async () => {
+      const result = await getBackfillStatus.handler({
+        params: { id: 'op-123' },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.getStatus).toHaveBeenCalledWith('op-123');
+      expect(result.body).toHaveProperty('operation');
+    });
+
+    it('lists operations with status filter', async () => {
+      const result = await getBackfillStatus.handler({
+        params: { status: 'running' },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.listOperations).toHaveBeenCalledWith('running');
+      expect(result.body).toHaveProperty('operations');
+    });
+
+    it('lists all operations when no params', async () => {
+      const result = await getBackfillStatus.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.listOperations).toHaveBeenCalledWith(undefined);
+      expect(result.body).toHaveProperty('operations');
+    });
+  });
+
+  // =========================================================================
+  // Backfill: getBackfillHistory
+  // =========================================================================
+  describe('getBackfillHistory', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getBackfillHistory.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        getBackfillHistory.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('filters out running operations and sorts by startedAt descending', async () => {
+      const result = await getBackfillHistory.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      const body = result.body as { operations: { id: string; status: string }[] };
+      // From our mock: op-1 completed, op-2 running, op-3 failed
+      // Running (op-2) should be filtered out, sorted: op-3 (2024-01-03) then op-1 (2024-01-01)
+      expect(body.operations).toHaveLength(2);
+      expect(body.operations[0]?.id).toBe('op-3');
+      expect(body.operations[1]?.id).toBe('op-1');
+    });
+  });
+
+  // =========================================================================
+  // Backfill: cancelBackfill
+  // =========================================================================
+  describe('cancelBackfill', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        cancelBackfill.handler({
+          params: undefined,
+          input: { id: 'op-123' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('throws ValidationError when id is missing', async () => {
+      await expect(
+        cancelBackfill.handler({
+          params: undefined,
+          input: { id: '' },
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('Operation ID is required');
+    });
+
+    it('rejects missing backfill manager', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        cancelBackfill.handler({
+          params: undefined,
+          input: { id: 'op-123' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('cancels operation and returns result', async () => {
+      const result = await cancelBackfill.handler({
+        params: undefined,
+        input: { id: 'op-123' },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockBackfillManager.cancelOperation).toHaveBeenCalledWith('op-123');
+      expect(result.body).toMatchObject({ success: true, id: 'op-123' });
+    });
+  });
+
+  // =========================================================================
+  // PDS: listPDSes
+  // =========================================================================
+  describe('listPDSes', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        listPDSes.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        listPDSes.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('computes stats from PDS entries', async () => {
+      const result = await listPDSes.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      const body = result.body as {
+        stats: {
+          total: number;
+          healthy: number;
+          unhealthy: number;
+          withRecords: number;
+        };
+      };
+      expect(body.stats.total).toBe(2);
+      expect(body.stats.healthy).toBe(1);
+      expect(body.stats.unhealthy).toBe(1);
+      expect(body.stats.withRecords).toBe(1);
+    });
+  });
+
+  // =========================================================================
+  // PDS: rescanPDS
+  // =========================================================================
+  describe('rescanPDS', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        rescanPDS.handler({
+          params: undefined,
+          input: { pdsUrl: 'https://pds.test' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('throws ValidationError when pdsUrl is missing', async () => {
+      await expect(
+        rescanPDS.handler({
+          params: undefined,
+          input: { pdsUrl: '' },
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow('PDS URL is required');
+    });
+
+    it('registers PDS and returns success', async () => {
+      const result = await rescanPDS.handler({
+        params: undefined,
+        input: { pdsUrl: 'https://pds.test' },
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockPdsRegistry.registerPDS).toHaveBeenCalledWith('https://pds.test', 'did_mention');
+      expect(result.body).toMatchObject({ success: true, pdsUrl: 'https://pds.test' });
+    });
+  });
+
+  // =========================================================================
+  // PDS: listImports
+  // =========================================================================
+  describe('listImports', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        listImports.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        listImports.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('uses default limit of 50', async () => {
+      await listImports.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listImports).toHaveBeenCalledWith(50, 0, undefined);
+    });
+
+    it('passes source filter', async () => {
+      await listImports.handler({
+        params: { limit: 10, source: 'arxiv' },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listImports).toHaveBeenCalledWith(10, 0, 'arxiv');
+    });
+  });
+
+  // =========================================================================
+  // Knowledge Graph: getGraphStats
+  // =========================================================================
+  describe('getGraphStats', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getGraphStats.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('queries node and edge counts in parallel', async () => {
+      const result = await getGraphStats.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockNodeRepository.listNodes).toHaveBeenCalled();
+      expect(mockEdgeRepository.listEdges).toHaveBeenCalled();
+      const body = result.body as { totalNodes: number; totalEdges: number };
+      expect(body.totalNodes).toBe(100);
+      expect(body.totalEdges).toBe(50);
+    });
+
+    it('includes pending proposals count', async () => {
+      const result = await getGraphStats.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      const body = result.body as { pendingProposals: number };
+      expect(body.pendingProposals).toBe(3);
+    });
+  });
+
+  // =========================================================================
+  // Metrics: getMetricsOverview
+  // =========================================================================
+  describe('getMetricsOverview', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getMetricsOverview.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('uses default 7 days', async () => {
+      const result = await getMetricsOverview.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('7d', 20);
+      const body = result.body as { periodInfo: { days: number } };
+      expect(body.periodInfo.days).toBe(7);
+    });
+
+    it('maps days=1 to 24h window', async () => {
+      await getMetricsOverview.handler({
+        params: { days: 1 },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20);
+    });
+
+    it('maps days=30 to 30d window', async () => {
+      await getMetricsOverview.handler({
+        params: { days: 30 },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('30d', 20);
+    });
+  });
+
+  // =========================================================================
+  // Metrics: getSearchAnalytics
+  // =========================================================================
+  describe('getSearchAnalytics', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getSearchAnalytics.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        getSearchAnalytics.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('returns analytics from admin service', async () => {
+      const result = await getSearchAnalytics.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(result.body).toMatchObject({ totalSearches: 100 });
+    });
+  });
+
+  // =========================================================================
+  // Metrics: getActivityCorrelation
+  // =========================================================================
+  describe('getActivityCorrelation', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getActivityCorrelation.handler({
+          params: undefined,
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('returns empty metrics when activity service is not configured', async () => {
+      const ctx = {
+        get: vi.fn((key: string) => {
+          if (key === 'user') return adminUser;
+          if (key === 'services') return { activity: null };
+          if (key === 'logger') return mockLogger;
+          return undefined;
+        }),
+        set: vi.fn(),
+      };
+
+      const result = await getActivityCorrelation.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
         c: ctx as never,
       });
-
-      describe('revokeRole', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            revokeRole.handler({
-              params: undefined,
-              input: { did: 'did:plc:user1', role: 'moderator' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('throws ValidationError for missing input', async () => {
-          await expect(
-            revokeRole.handler({
-              params: undefined,
-              input: undefined as never,
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('DID and role are required');
-        });
-
-        it('removes role from Redis and returns success', async () => {
-          const result = await revokeRole.handler({
-            params: undefined,
-            input: { did: 'did:plc:user1', role: 'moderator' },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockRedis.srem).toHaveBeenCalledWith(
-            'chive:authz:roles:did:plc:user1',
-            'moderator'
-          );
-          expect(mockRedis.del).toHaveBeenCalledWith(
-            'chive:authz:assignments:did:plc:user1:moderator'
-          );
-          expect(result.body).toMatchObject({
-            success: true,
-            did: 'did:plc:user1',
-            role: 'moderator',
-          });
-        });
-      });
-
-      // =========================================================================
-      // Content: listEprints
-      // =========================================================================
-      describe('listEprints', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            listEprints.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            listEprints.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('uses default limit 50 and offset 0', async () => {
-          await listEprints.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listEprints).toHaveBeenCalledWith(undefined, 50, 0);
-        });
-
-        it('passes query, limit, and offset', async () => {
-          await listEprints.handler({
-            params: { q: 'neural', limit: 10, offset: 20 },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listEprints).toHaveBeenCalledWith('neural', 10, 20);
-        });
-      });
-
-      // =========================================================================
-      // Content: listReviews
-      // =========================================================================
-      describe('listReviews', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            listReviews.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            listReviews.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('uses default limit 50 and offset 0', async () => {
-          await listReviews.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listReviews).toHaveBeenCalledWith(50, 0);
-        });
-
-        it('parses cursor as numeric offset', async () => {
-          await listReviews.handler({
-            params: { limit: 10, cursor: '25' },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listReviews).toHaveBeenCalledWith(10, 25);
-        });
-      });
-
-      // =========================================================================
-      // Content: listEndorsements
-      // =========================================================================
-      describe('listEndorsements', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            listEndorsements.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            listEndorsements.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('uses default limit 50 and offset 0', async () => {
-          await listEndorsements.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listEndorsements).toHaveBeenCalledWith(50, 0);
-        });
-
-        it('parses cursor as numeric offset', async () => {
-          await listEndorsements.handler({
-            params: { limit: 5, cursor: '15' },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listEndorsements).toHaveBeenCalledWith(5, 15);
-        });
-      });
-
-      // =========================================================================
-      // Content: deleteContent
-      // =========================================================================
-      describe('deleteContent', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            deleteContent.handler({
-              params: undefined,
-              input: { uri: 'at://test', collection: 'pub.chive.eprint.submission' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            deleteContent.handler({
-              params: undefined,
-              input: { uri: 'at://test', collection: 'pub.chive.eprint.submission' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('throws ValidationError for missing input', async () => {
-          await expect(
-            deleteContent.handler({
-              params: undefined,
-              input: undefined as never,
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('URI and collection are required');
-        });
-
-        it('throws ValidationError for unsupported collection', async () => {
-          await expect(
-            deleteContent.handler({
-              params: undefined,
-              input: { uri: 'at://test', collection: 'pub.chive.unknown.type' },
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('Unsupported collection');
-        });
-
-        it('soft-deletes content and publishes event', async () => {
-          const result = await deleteContent.handler({
-            params: undefined,
-            input: {
-              uri: 'at://did:plc:test/pub.chive.eprint.submission/123',
-              collection: 'pub.chive.eprint.submission',
-              reason: 'spam',
-            },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.deleteContent).toHaveBeenCalledWith(
-            'at://did:plc:test/pub.chive.eprint.submission/123',
-            'eprints_index'
-          );
-          expect(mockRedis.publish).toHaveBeenCalledWith(
-            'chive:admin:content-deleted',
-            expect.stringContaining('"reason":"spam"')
-          );
-          expect(result.body).toMatchObject({ success: true });
-        });
-
-        it('maps all supported collections to correct tables', async () => {
-          const collectionMap: Record<string, string> = {
-            'pub.chive.eprint.submission': 'eprints_index',
-            'pub.chive.review.comment': 'reviews_index',
-            'pub.chive.review.endorsement': 'endorsements_index',
-            'pub.chive.eprint.userTag': 'user_tags_index',
-          };
-
-          for (const [collection, table] of Object.entries(collectionMap)) {
-            vi.clearAllMocks();
-            mockAdminService = createMockAdminService();
-            mockRedis = createMockRedis();
-            mockContext = buildContext(adminUser);
-
-            await deleteContent.handler({
-              params: undefined,
-              input: { uri: 'at://test', collection },
-              auth: null,
-              c: mockContext as never,
-            });
-            expect(mockAdminService.deleteContent).toHaveBeenCalledWith('at://test', table);
-          }
-        });
-      });
-
-      // =========================================================================
-      // Firehose: getFirehoseStatus
-      // =========================================================================
-      describe('getFirehoseStatus', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getFirehoseStatus.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('returns cursor and DLQ count from Redis', async () => {
-          mockRedis.get.mockResolvedValueOnce('12345');
-          mockRedis.llen.mockResolvedValueOnce(3);
-
-          const result = await getFirehoseStatus.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(result.body).toMatchObject({ cursor: '12345', dlqCount: 3 });
-          expect(result.body).toHaveProperty('timestamp');
-        });
-
-        it('handles llen failure gracefully', async () => {
-          mockRedis.get.mockResolvedValueOnce(null);
-          mockRedis.llen.mockRejectedValueOnce(new Error('Redis error'));
-
-          const result = await getFirehoseStatus.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(result.body).toMatchObject({ cursor: null, dlqCount: 0 });
-        });
-      });
-
-      // =========================================================================
-      // Firehose: listDLQEntries
-      // =========================================================================
-      describe('listDLQEntries', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            listDLQEntries.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('uses default limit 50 and offset 0', async () => {
-          mockRedis.lrange.mockResolvedValueOnce([]);
-          mockRedis.llen.mockResolvedValueOnce(0);
-
-          await listDLQEntries.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockRedis.lrange).toHaveBeenCalledWith('chive:firehose:dlq', 0, 49);
-        });
-
-        it('uses custom limit and offset', async () => {
-          mockRedis.lrange.mockResolvedValueOnce([]);
-          mockRedis.llen.mockResolvedValueOnce(0);
-
-          await listDLQEntries.handler({
-            params: { limit: 10, offset: 5 },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockRedis.lrange).toHaveBeenCalledWith('chive:firehose:dlq', 5, 14);
-        });
-
-        it('parses JSON entries and handles invalid entries', async () => {
-          mockRedis.lrange.mockResolvedValueOnce([
-            JSON.stringify({ error: 'timeout', uri: 'at://test' }),
-            'not-valid-json',
-          ]);
-          mockRedis.llen.mockResolvedValueOnce(2);
-
-          const result = await listDLQEntries.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as { entries: unknown[]; total: number };
-          expect(body.entries).toHaveLength(2);
-          expect(body.total).toBe(2);
-          expect(body.entries[1]).toMatchObject({ raw: 'not-valid-json' });
-        });
-      });
-
-      // =========================================================================
-      // Firehose: retryDLQEntry
-      // =========================================================================
-      describe('retryDLQEntry', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            retryDLQEntry.handler({
-              params: undefined,
-              input: { index: 0 },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('throws ValidationError when index is missing', async () => {
-          await expect(
-            retryDLQEntry.handler({
-              params: undefined,
-              input: {} as never,
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('Index is required');
-        });
-
-        it('returns failure when entry not found at index', async () => {
-          mockRedis.lrange.mockResolvedValueOnce([]);
-
-          const result = await retryDLQEntry.handler({
-            params: undefined,
-            input: { index: 99 },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(result.body).toMatchObject({ success: false });
-        });
-
-        it('requeues entry to retry queue on success', async () => {
-          mockRedis.lrange.mockResolvedValueOnce(['{"error":"timeout"}']);
-
-          const result = await retryDLQEntry.handler({
-            params: undefined,
-            input: { index: 0 },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockRedis.rpush).toHaveBeenCalledWith(
-            'chive:firehose:retry',
-            '{"error":"timeout"}'
-          );
-          expect(result.body).toMatchObject({ success: true });
-        });
-      });
-
-      // =========================================================================
-      // Firehose: retryAllDLQ
-      // =========================================================================
-      describe('retryAllDLQ', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            retryAllDLQ.handler({
-              params: undefined,
-              input: {},
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('retries all entries and clears DLQ when no errorType filter', async () => {
-          mockRedis.lrange.mockResolvedValueOnce(['{"error":"a"}', '{"error":"b"}']);
-
-          const result = await retryAllDLQ.handler({
-            params: undefined,
-            input: {},
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockRedis.rpush).toHaveBeenCalledTimes(2);
-          expect(mockRedis.del).toHaveBeenCalledWith('chive:firehose:dlq');
-          expect(result.body).toMatchObject({ success: true, retriedCount: 2 });
-        });
-
-        it('filters by errorType when specified', async () => {
-          mockRedis.lrange.mockResolvedValueOnce([
-            JSON.stringify({ errorType: 'timeout' }),
-            JSON.stringify({ errorType: 'parse' }),
-            JSON.stringify({ errorType: 'timeout' }),
-          ]);
-
-          const result = await retryAllDLQ.handler({
-            params: undefined,
-            input: { errorType: 'timeout' },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockRedis.rpush).toHaveBeenCalledTimes(2);
-          expect(mockRedis.del).not.toHaveBeenCalled();
-          expect(result.body).toMatchObject({ retriedCount: 2 });
-        });
-      });
-
-      // =========================================================================
-      // Firehose: dismissDLQEntry
-      // =========================================================================
-      describe('dismissDLQEntry', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            dismissDLQEntry.handler({
-              params: undefined,
-              input: { index: 0 },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('throws ValidationError when index is missing', async () => {
-          await expect(
-            dismissDLQEntry.handler({
-              params: undefined,
-              input: {} as never,
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('Index is required');
-        });
-
-        it('removes entry via sentinel pattern', async () => {
-          const result = await dismissDLQEntry.handler({
-            params: undefined,
-            input: { index: 3 },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockRedis.lset).toHaveBeenCalledWith(
-            'chive:firehose:dlq',
-            3,
-            expect.stringContaining('__DISMISSED_')
-          );
-          expect(mockRedis.lrem).toHaveBeenCalled();
-          expect(result.body).toMatchObject({ success: true });
-        });
-      });
-
-      // =========================================================================
-      // Firehose: purgeOldDLQ
-      // =========================================================================
-      describe('purgeOldDLQ', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            purgeOldDLQ.handler({
-              params: undefined,
-              input: {},
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('uses default 7 days when olderThanDays not specified', async () => {
-          mockRedis.lrange.mockResolvedValueOnce([]);
-
-          const result = await purgeOldDLQ.handler({
-            params: undefined,
-            input: {},
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(result.body).toMatchObject({ success: true, purgedCount: 0 });
-        });
-
-        it('purges entries older than cutoff', async () => {
-          const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
-          const newDate = new Date().toISOString();
-
-          mockRedis.lrange.mockResolvedValueOnce([
-            JSON.stringify({ timestamp: oldDate }),
-            JSON.stringify({ timestamp: newDate }),
-          ]);
-
-          const result = await purgeOldDLQ.handler({
-            params: undefined,
-            input: { olderThanDays: 7 },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(result.body).toMatchObject({ purgedCount: 1 });
-          expect(mockRedis.lset).toHaveBeenCalledTimes(1);
-        });
-      });
-
-      // =========================================================================
-      // Backfill: triggerPDSScan
-      // =========================================================================
-      describe('triggerPDSScan', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            triggerPDSScan.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            triggerPDSScan.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('starts operation and returns immediately', async () => {
-          const result = await triggerPDSScan.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('pdsScan');
-          expect(result.body).toMatchObject({ operationId: 'op-123', status: 'running' });
-        });
-      });
-
-      // =========================================================================
-      // Backfill: triggerFreshnessScan
-      // =========================================================================
-      describe('triggerFreshnessScan', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            triggerFreshnessScan.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            triggerFreshnessScan.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('starts freshnessScan operation', async () => {
-          const result = await triggerFreshnessScan.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('freshnessScan');
-          expect(result.body).toMatchObject({ status: 'running' });
-        });
-      });
-
-      // =========================================================================
-      // Backfill: triggerCitationExtraction
-      // =========================================================================
-      describe('triggerCitationExtraction', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            triggerCitationExtraction.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            triggerCitationExtraction.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('starts citationExtraction operation', async () => {
-          const result = await triggerCitationExtraction.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('citationExtraction');
-          expect(result.body).toMatchObject({ status: 'running' });
-        });
-      });
-
-      // =========================================================================
-      // Backfill: triggerFullReindex
-      // =========================================================================
-      describe('triggerFullReindex', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            triggerFullReindex.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            triggerFullReindex.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('starts fullReindex operation', async () => {
-          const result = await triggerFullReindex.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('fullReindex');
-          expect(result.body).toMatchObject({ status: 'running' });
-        });
-      });
-
-      // =========================================================================
-      // Backfill: triggerGovernanceSync
-      // =========================================================================
-      describe('triggerGovernanceSync', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            triggerGovernanceSync.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            triggerGovernanceSync.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('starts governanceSync operation', async () => {
-          const result = await triggerGovernanceSync.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('governanceSync');
-          expect(result.body).toMatchObject({ status: 'running' });
-        });
-      });
-
-      // =========================================================================
-      // Backfill: triggerDIDSync
-      // =========================================================================
-      describe('triggerDIDSync', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            triggerDIDSync.handler({
-              params: undefined,
-              input: { did: 'did:plc:test' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('throws ValidationError when DID is missing', async () => {
-          await expect(
-            triggerDIDSync.handler({
-              params: undefined,
-              input: { did: '' },
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('DID is required');
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            triggerDIDSync.handler({
-              params: undefined,
-              input: { did: 'did:plc:test' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('starts didSync operation with DID metadata', async () => {
-          const result = await triggerDIDSync.handler({
-            params: undefined,
-            input: { did: 'did:plc:target' },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('didSync', {
-            did: 'did:plc:target',
-          });
-          expect(result.body).toMatchObject({ did: 'did:plc:target', status: 'running' });
-        });
-      });
-
-      // =========================================================================
-      // Backfill: triggerBackfill (generic)
-      // =========================================================================
-      describe('triggerBackfill', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            triggerBackfill.handler({
-              params: undefined,
-              input: { type: 'pdsScan' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('throws ValidationError when type is missing', async () => {
-          await expect(
-            triggerBackfill.handler({
-              params: undefined,
-              input: { type: '' },
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('Backfill type is required');
-        });
-
-        it('throws ValidationError for invalid type', async () => {
-          await expect(
-            triggerBackfill.handler({
-              params: undefined,
-              input: { type: 'invalidOperation' },
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('Invalid backfill type');
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            triggerBackfill.handler({
-              params: undefined,
-              input: { type: 'pdsScan' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('starts operation with type and metadata', async () => {
-          const result = await triggerBackfill.handler({
-            params: undefined,
-            input: { type: 'fullReindex' },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('fullReindex', {
-            startedBy: ADMIN_DID,
-          });
-          expect(result.body).toHaveProperty('operation');
-        });
-
-        it('accepts all valid backfill types', async () => {
-          const validTypes = [
-            'pdsScan',
-            'freshnessScan',
-            'citationExtraction',
-            'fullReindex',
-            'governanceSync',
-            'didSync',
-          ];
-          for (const type of validTypes) {
-            vi.clearAllMocks();
-            mockBackfillManager = createMockBackfillManager();
-            mockContext = buildContext(adminUser);
-            await triggerBackfill.handler({
-              params: undefined,
-              input: { type },
-              auth: null,
-              c: mockContext as never,
-            });
-            expect(mockBackfillManager.startOperation).toHaveBeenCalledWith(
-              type,
-              expect.any(Object)
-            );
-          }
-        });
-      });
-
-      // =========================================================================
-      // Backfill: getBackfillStatus
-      // =========================================================================
-      describe('getBackfillStatus', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getBackfillStatus.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            getBackfillStatus.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('returns single operation when id is provided', async () => {
-          const result = await getBackfillStatus.handler({
-            params: { id: 'op-123' },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.getStatus).toHaveBeenCalledWith('op-123');
-          expect(result.body).toHaveProperty('operation');
-        });
-
-        it('lists operations with status filter', async () => {
-          const result = await getBackfillStatus.handler({
-            params: { status: 'running' },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.listOperations).toHaveBeenCalledWith('running');
-          expect(result.body).toHaveProperty('operations');
-        });
-
-        it('lists all operations when no params', async () => {
-          const result = await getBackfillStatus.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.listOperations).toHaveBeenCalledWith(undefined);
-          expect(result.body).toHaveProperty('operations');
-        });
-      });
-
-      // =========================================================================
-      // Backfill: getBackfillHistory
-      // =========================================================================
-      describe('getBackfillHistory', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getBackfillHistory.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            getBackfillHistory.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('filters out running operations and sorts by startedAt descending', async () => {
-          const result = await getBackfillHistory.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as { operations: { id: string; status: string }[] };
-          // From our mock: op-1 completed, op-2 running, op-3 failed
-          // Running (op-2) should be filtered out, sorted: op-3 (2024-01-03) then op-1 (2024-01-01)
-          expect(body.operations).toHaveLength(2);
-          expect(body.operations[0]?.id).toBe('op-3');
-          expect(body.operations[1]?.id).toBe('op-1');
-        });
-      });
-
-      // =========================================================================
-      // Backfill: cancelBackfill
-      // =========================================================================
-      describe('cancelBackfill', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            cancelBackfill.handler({
-              params: undefined,
-              input: { id: 'op-123' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('throws ValidationError when id is missing', async () => {
-          await expect(
-            cancelBackfill.handler({
-              params: undefined,
-              input: { id: '' },
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('Operation ID is required');
-        });
-
-        it('rejects missing backfill manager', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            cancelBackfill.handler({
-              params: undefined,
-              input: { id: 'op-123' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('cancels operation and returns result', async () => {
-          const result = await cancelBackfill.handler({
-            params: undefined,
-            input: { id: 'op-123' },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockBackfillManager.cancelOperation).toHaveBeenCalledWith('op-123');
-          expect(result.body).toMatchObject({ success: true, id: 'op-123' });
-        });
-      });
-
-      // =========================================================================
-      // PDS: listPDSes
-      // =========================================================================
-      describe('listPDSes', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            listPDSes.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            listPDSes.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('computes stats from PDS entries', async () => {
-          const result = await listPDSes.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as {
-            stats: {
-              total: number;
-              healthy: number;
-              unhealthy: number;
-              withRecords: number;
-            };
-          };
-          expect(body.stats.total).toBe(2);
-          expect(body.stats.healthy).toBe(1);
-          expect(body.stats.unhealthy).toBe(1);
-          expect(body.stats.withRecords).toBe(1);
-        });
-      });
-
-      // =========================================================================
-      // PDS: rescanPDS
-      // =========================================================================
-      describe('rescanPDS', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            rescanPDS.handler({
-              params: undefined,
-              input: { pdsUrl: 'https://pds.test' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('throws ValidationError when pdsUrl is missing', async () => {
-          await expect(
-            rescanPDS.handler({
-              params: undefined,
-              input: { pdsUrl: '' },
-              auth: null,
-              c: mockContext as never,
-            })
-          ).rejects.toThrow('PDS URL is required');
-        });
-
-        it('registers PDS and returns success', async () => {
-          const result = await rescanPDS.handler({
-            params: undefined,
-            input: { pdsUrl: 'https://pds.test' },
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockPdsRegistry.registerPDS).toHaveBeenCalledWith(
-            'https://pds.test',
-            'did_mention'
-          );
-          expect(result.body).toMatchObject({ success: true, pdsUrl: 'https://pds.test' });
-        });
-      });
-
-      // =========================================================================
-      // PDS: listImports
-      // =========================================================================
-      describe('listImports', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            listImports.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            listImports.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('uses default limit of 50', async () => {
-          await listImports.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listImports).toHaveBeenCalledWith(50, 0, undefined);
-        });
-
-        it('passes source filter', async () => {
-          await listImports.handler({
-            params: { limit: 10, source: 'arxiv' },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listImports).toHaveBeenCalledWith(10, 0, 'arxiv');
-        });
-      });
-
-      // =========================================================================
-      // Knowledge Graph: getGraphStats
-      // =========================================================================
-      describe('getGraphStats', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getGraphStats.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('queries node and edge counts in parallel', async () => {
-          const result = await getGraphStats.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockNodeRepository.listNodes).toHaveBeenCalled();
-          expect(mockEdgeRepository.listEdges).toHaveBeenCalled();
-          const body = result.body as { totalNodes: number; totalEdges: number };
-          expect(body.totalNodes).toBe(100);
-          expect(body.totalEdges).toBe(50);
-        });
-
-        it('includes pending proposals count', async () => {
-          const result = await getGraphStats.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as { pendingProposals: number };
-          expect(body.pendingProposals).toBe(3);
-        });
-      });
-
-      // =========================================================================
-      // Metrics: getMetricsOverview
-      // =========================================================================
-      describe('getMetricsOverview', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getMetricsOverview.handler({
-              params: {},
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('uses default 7 days', async () => {
-          const result = await getMetricsOverview.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockMetricsService.getTrending).toHaveBeenCalledWith('7d', 20);
-          const body = result.body as { periodInfo: { days: number } };
-          expect(body.periodInfo.days).toBe(7);
-        });
-
-        it('maps days=1 to 24h window', async () => {
-          await getMetricsOverview.handler({
-            params: { days: 1 },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20);
-        });
-
-        it('maps days=30 to 30d window', async () => {
-          await getMetricsOverview.handler({
-            params: { days: 30 },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockMetricsService.getTrending).toHaveBeenCalledWith('30d', 20);
-        });
-      });
-
-      // =========================================================================
-      // Metrics: getSearchAnalytics
-      // =========================================================================
-      describe('getSearchAnalytics', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getSearchAnalytics.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            getSearchAnalytics.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('returns analytics from admin service', async () => {
-          const result = await getSearchAnalytics.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(result.body).toMatchObject({ totalSearches: 100 });
-        });
-      });
-
-      // =========================================================================
-      // Metrics: getActivityCorrelation
-      // =========================================================================
-      describe('getActivityCorrelation', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getActivityCorrelation.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('returns empty metrics when activity service is not configured', async () => {
-          const ctx = {
-            get: vi.fn((key: string) => {
-              if (key === 'user') return adminUser;
-              if (key === 'services') return { activity: null };
-              if (key === 'logger') return mockLogger;
-              return undefined;
-            }),
-            set: vi.fn(),
-          };
-
-          const result = await getActivityCorrelation.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: ctx as never,
-          });
-          const body = result.body as { metrics: unknown[] };
-          expect(body.metrics).toEqual([]);
-        });
-
-        it('returns metrics from activity service', async () => {
-          const result = await getActivityCorrelation.handler({
-            params: undefined,
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as { metrics: unknown[] };
-          expect(body.metrics).toHaveLength(1);
-        });
-      });
-
-      // =========================================================================
-      // Metrics: getTrendingVelocity
-      // =========================================================================
-      describe('getTrendingVelocity', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getTrendingVelocity.handler({
-              params: {},
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('uses default window 24h and limit 20', async () => {
-          await getTrendingVelocity.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20);
-        });
-
-        it('enriches entries with title and metrics', async () => {
-          mockMetricsService.getTrending.mockResolvedValueOnce([
-            { uri: 'at://test', score: 50, velocity: 0.5 },
-          ]);
-          mockEprintService.getEprint = vi.fn().mockResolvedValue({ title: 'Test Paper' });
-          mockMetricsService.getMetrics.mockResolvedValueOnce({
-            totalViews: 200,
-            totalDownloads: 30,
-          });
-
-          const result = await getTrendingVelocity.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as { items: { title: string; trend: string }[] };
-          expect(body.items[0]?.title).toBe('Test Paper');
-          expect(body.items[0]?.trend).toBe('rising');
-        });
-      });
-
-      // =========================================================================
-      // Metrics: getViewDownloadTimeSeries
-      // =========================================================================
-      describe('getViewDownloadTimeSeries', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getViewDownloadTimeSeries.handler({
-              params: {},
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            getViewDownloadTimeSeries.handler({
-              params: {},
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('passes uri and granularity to admin service', async () => {
-          await getViewDownloadTimeSeries.handler({
-            params: { uri: 'at://test', granularity: 'day' },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.getViewDownloadTimeSeries).toHaveBeenCalledWith(
-            'at://test',
-            'day'
-          );
-        });
-      });
-
-      // =========================================================================
-      // Governance: getAuditLog
-      // =========================================================================
-      describe('getAuditLog', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            getAuditLog.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            getAuditLog.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('uses default limit 50 and offset 0', async () => {
-          await getAuditLog.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.getAuditLog).toHaveBeenCalledWith(50, 0, undefined);
-        });
-
-        it('parses cursor as numeric offset and passes actorDid', async () => {
-          await getAuditLog.handler({
-            params: { limit: 10, cursor: '5', actorDid: 'did:plc:actor' },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.getAuditLog).toHaveBeenCalledWith(10, 5, 'did:plc:actor');
-        });
-
-        it('returns entries with cursor for pagination', async () => {
-          mockAdminService.getAuditLog.mockResolvedValueOnce({
-            entries: [{ id: '1' }],
-            total: 10,
-          });
-
-          const result = await getAuditLog.handler({
-            params: { limit: 1 },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as { entries: unknown[]; cursor: string; total: number };
-          expect(body.cursor).toBe('1');
-          expect(body.total).toBe(10);
-        });
-
-        it('returns undefined cursor when all entries have been returned', async () => {
-          mockAdminService.getAuditLog.mockResolvedValueOnce({
-            entries: [{ id: '1' }],
-            total: 1,
-          });
-
-          const result = await getAuditLog.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as { cursor: string | undefined };
-          expect(body.cursor).toBeUndefined();
-        });
-      });
-
-      // =========================================================================
-      // Governance: listWarnings
-      // =========================================================================
-      describe('listWarnings', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            listWarnings.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            listWarnings.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('uses default limit 50 and passes optional DID filter', async () => {
-          await listWarnings.handler({
-            params: { did: 'did:plc:offender' },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listWarnings).toHaveBeenCalledWith(50, 'did:plc:offender');
-        });
-
-        it('returns warnings', async () => {
-          const result = await listWarnings.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as { warnings: unknown[] };
-          expect(body.warnings).toHaveLength(1);
-        });
-      });
-
-      // =========================================================================
-      // Governance: listViolations
-      // =========================================================================
-      describe('listViolations', () => {
-        it('rejects non-admin users', async () => {
-          const ctx = buildContext(nonAdminUser);
-          await expect(
-            listViolations.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects missing admin service', async () => {
-          const ctx = buildContextWithoutAdmin(adminUser);
-          await expect(
-            listViolations.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-          ).rejects.toThrow(ServiceUnavailableError);
-        });
-
-        it('uses default limit 50 and passes optional DID filter', async () => {
-          await listViolations.handler({
-            params: { limit: 25, did: 'did:plc:violator' },
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          expect(mockAdminService.listViolations).toHaveBeenCalledWith(25, 'did:plc:violator');
-        });
-
-        it('returns violations', async () => {
-          const result = await listViolations.handler({
-            params: {},
-            input: undefined,
-            auth: null,
-            c: mockContext as never,
-          });
-          const body = result.body as { violations: unknown[] };
-          expect(body.violations).toHaveLength(1);
-        });
-      });
-
-      // =========================================================================
-      // Null user (no auth at all)
-      // =========================================================================
-      describe('null user auth checks', () => {
-        it('rejects null user for getOverview', async () => {
-          const ctx = buildContext(null);
-          await expect(
-            getOverview.handler({
-              params: undefined,
-              input: undefined,
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects null user for assignRole', async () => {
-          const ctx = buildContext(null);
-          await expect(
-            assignRole.handler({
-              params: undefined,
-              input: { did: 'did:plc:x', role: 'admin' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-
-        it('rejects null user for deleteContent', async () => {
-          const ctx = buildContext(null);
-          await expect(
-            deleteContent.handler({
-              params: undefined,
-              input: { uri: 'at://x', collection: 'pub.chive.eprint.submission' },
-              auth: null,
-              c: ctx as never,
-            })
-          ).rejects.toThrow(AuthorizationError);
-        });
-      });
+      const body = result.body as { metrics: unknown[] };
+      expect(body.metrics).toEqual([]);
     });
 
-    // ===========================================================================
-    // actor.getMyRoles
-    // ===========================================================================
-    describe('XRPC actor.getMyRoles', () => {
-      let mockLogger: ILogger;
-      let mockRedis: MockRedis;
-
-      beforeEach(() => {
-        vi.clearAllMocks();
-        mockLogger = createMockLogger();
-        mockRedis = createMockRedis();
+    it('returns metrics from activity service', async () => {
+      const result = await getActivityCorrelation.handler({
+        params: undefined,
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
       });
-
-      function buildCtx(user: { did: string; isAdmin?: boolean } | null): {
-        get: ReturnType<typeof vi.fn>;
-        set: ReturnType<typeof vi.fn>;
-      } {
-        return {
-          get: vi.fn((key: string) => {
-            if (key === 'user') return user;
-            if (key === 'logger') return mockLogger;
-            if (key === 'redis') return mockRedis;
-            return undefined;
-          }),
-          set: vi.fn(),
-        };
-      }
-
-      it('throws AuthenticationError when user is not authenticated', async () => {
-        const ctx = buildCtx(null);
-        await expect(
-          getMyRoles.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
-        ).rejects.toThrow('Authentication required');
-      });
-
-      it('throws AuthenticationError when user has no DID', async () => {
-        const ctx = buildCtx({ did: '' });
-        await expect(
-          getMyRoles.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
-        ).rejects.toThrow('Authentication required');
-      });
-
-      it('returns roles from Redis', async () => {
-        mockRedis.smembers.mockResolvedValueOnce(['reader', 'alpha-tester']);
-        const ctx = buildCtx({ did: 'did:plc:user1' });
-
-        const result = await getMyRoles.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        });
-        expect(mockRedis.smembers).toHaveBeenCalledWith('chive:authz:roles:did:plc:user1');
-        expect(result.body.roles).toEqual(['reader', 'alpha-tester']);
-        expect(result.body.isAdmin).toBe(false);
-        expect(result.body.isAlphaTester).toBe(true);
-        expect(result.body.isPremium).toBe(false);
-      });
-
-      it('sets isAdmin true when user has admin role', async () => {
-        mockRedis.smembers.mockResolvedValueOnce(['admin']);
-        const ctx = buildCtx({ did: 'did:plc:admin1' });
-
-        const result = await getMyRoles.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        });
-        expect(result.body.isAdmin).toBe(true);
-        expect(result.body.isAlphaTester).toBe(true);
-        expect(result.body.isPremium).toBe(true);
-      });
-
-      it('returns empty roles when user has none', async () => {
-        mockRedis.smembers.mockResolvedValueOnce([]);
-        const ctx = buildCtx({ did: 'did:plc:empty' });
-
-        const result = await getMyRoles.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        });
-        expect(result.body.roles).toEqual([]);
-        expect(result.body.isAdmin).toBe(false);
-        expect(result.body.isAlphaTester).toBe(false);
-        expect(result.body.isPremium).toBe(false);
-      });
-
-      it('grants premium access to admin users', async () => {
-        mockRedis.smembers.mockResolvedValueOnce(['admin']);
-        const ctx = buildCtx({ did: 'did:plc:admin2' });
-
-        const result = await getMyRoles.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        });
-        expect(result.body.isPremium).toBe(true);
-      });
+      const body = result.body as { metrics: unknown[] };
+      expect(body.metrics).toHaveLength(1);
     });
+  });
+
+  // =========================================================================
+  // Metrics: getTrendingVelocity
+  // =========================================================================
+  describe('getTrendingVelocity', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getTrendingVelocity.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('uses default window 24h and limit 20', async () => {
+      await getTrendingVelocity.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20);
+    });
+
+    it('enriches entries with title and metrics', async () => {
+      mockMetricsService.getTrending.mockResolvedValueOnce([
+        { uri: 'at://test', score: 50, velocity: 0.5 },
+      ]);
+      mockEprintService.getEprint = vi.fn().mockResolvedValue({ title: 'Test Paper' });
+      mockMetricsService.getMetrics.mockResolvedValueOnce({
+        totalViews: 200,
+        totalDownloads: 30,
+      });
+
+      const result = await getTrendingVelocity.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      const body = result.body as { items: { title: string; trend: string }[] };
+      expect(body.items[0]?.title).toBe('Test Paper');
+      expect(body.items[0]?.trend).toBe('rising');
+    });
+  });
+
+  // =========================================================================
+  // Metrics: getViewDownloadTimeSeries
+  // =========================================================================
+  describe('getViewDownloadTimeSeries', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getViewDownloadTimeSeries.handler({
+          params: {},
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        getViewDownloadTimeSeries.handler({
+          params: {},
+          input: undefined,
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('passes uri and granularity to admin service', async () => {
+      await getViewDownloadTimeSeries.handler({
+        params: { uri: 'at://test', granularity: 'day' },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.getViewDownloadTimeSeries).toHaveBeenCalledWith('at://test', 'day');
+    });
+  });
+
+  // =========================================================================
+  // Governance: getAuditLog
+  // =========================================================================
+  describe('getAuditLog', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        getAuditLog.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        getAuditLog.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('uses default limit 50 and offset 0', async () => {
+      await getAuditLog.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.getAuditLog).toHaveBeenCalledWith(50, 0, undefined);
+    });
+
+    it('parses cursor as numeric offset and passes actorDid', async () => {
+      await getAuditLog.handler({
+        params: { limit: 10, cursor: '5', actorDid: 'did:plc:actor' },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.getAuditLog).toHaveBeenCalledWith(10, 5, 'did:plc:actor');
+    });
+
+    it('returns entries with cursor for pagination', async () => {
+      mockAdminService.getAuditLog.mockResolvedValueOnce({
+        entries: [{ id: '1' }],
+        total: 10,
+      });
+
+      const result = await getAuditLog.handler({
+        params: { limit: 1 },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      const body = result.body as { entries: unknown[]; cursor: string; total: number };
+      expect(body.cursor).toBe('1');
+      expect(body.total).toBe(10);
+    });
+
+    it('returns undefined cursor when all entries have been returned', async () => {
+      mockAdminService.getAuditLog.mockResolvedValueOnce({
+        entries: [{ id: '1' }],
+        total: 1,
+      });
+
+      const result = await getAuditLog.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      const body = result.body as { cursor: string | undefined };
+      expect(body.cursor).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Governance: listWarnings
+  // =========================================================================
+  describe('listWarnings', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        listWarnings.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        listWarnings.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('uses default limit 50 and passes optional DID filter', async () => {
+      await listWarnings.handler({
+        params: { did: 'did:plc:offender' },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listWarnings).toHaveBeenCalledWith(50, 'did:plc:offender');
+    });
+
+    it('returns warnings', async () => {
+      const result = await listWarnings.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      const body = result.body as { warnings: unknown[] };
+      expect(body.warnings).toHaveLength(1);
+    });
+  });
+
+  // =========================================================================
+  // Governance: listViolations
+  // =========================================================================
+  describe('listViolations', () => {
+    it('rejects non-admin users', async () => {
+      const ctx = buildContext(nonAdminUser);
+      await expect(
+        listViolations.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects missing admin service', async () => {
+      const ctx = buildContextWithoutAdmin(adminUser);
+      await expect(
+        listViolations.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('uses default limit 50 and passes optional DID filter', async () => {
+      await listViolations.handler({
+        params: { limit: 25, did: 'did:plc:violator' },
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      expect(mockAdminService.listViolations).toHaveBeenCalledWith(25, 'did:plc:violator');
+    });
+
+    it('returns violations', async () => {
+      const result = await listViolations.handler({
+        params: {},
+        input: undefined,
+        auth: null,
+        c: mockContext as never,
+      });
+      const body = result.body as { violations: unknown[] };
+      expect(body.violations).toHaveLength(1);
+    });
+  });
+
+  // =========================================================================
+  // Null user (no auth at all)
+  // =========================================================================
+  describe('null user auth checks', () => {
+    it('rejects null user for getOverview', async () => {
+      const ctx = buildContext(null);
+      await expect(
+        getOverview.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects null user for assignRole', async () => {
+      const ctx = buildContext(null);
+      await expect(
+        assignRole.handler({
+          params: undefined,
+          input: { did: 'did:plc:x', role: 'admin' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('rejects null user for deleteContent', async () => {
+      const ctx = buildContext(null);
+      await expect(
+        deleteContent.handler({
+          params: undefined,
+          input: { uri: 'at://x', collection: 'pub.chive.eprint.submission' },
+          auth: null,
+          c: ctx as never,
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+  });
+});
+
+// ===========================================================================
+// actor.getMyRoles
+// ===========================================================================
+describe('XRPC actor.getMyRoles', () => {
+  let mockLogger: ILogger;
+  let mockRedis: MockRedis;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogger = createMockLogger();
+    mockRedis = createMockRedis();
+  });
+
+  function buildCtx(user: { did: string; isAdmin?: boolean } | null): {
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+  } {
+    return {
+      get: vi.fn((key: string) => {
+        if (key === 'user') return user;
+        if (key === 'logger') return mockLogger;
+        if (key === 'redis') return mockRedis;
+        return undefined;
+      }),
+      set: vi.fn(),
+    };
+  }
+
+  it('throws AuthenticationError when user is not authenticated', async () => {
+    const ctx = buildCtx(null);
+    await expect(
+      getMyRoles.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
+    ).rejects.toThrow('Authentication required');
+  });
+
+  it('throws AuthenticationError when user has no DID', async () => {
+    const ctx = buildCtx({ did: '' });
+    await expect(
+      getMyRoles.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
+    ).rejects.toThrow('Authentication required');
+  });
+
+  it('returns roles from Redis', async () => {
+    mockRedis.smembers.mockResolvedValueOnce(['reader', 'alpha-tester']);
+    const ctx = buildCtx({ did: 'did:plc:user1' });
+
+    const result = await getMyRoles.handler({
+      params: undefined,
+      input: undefined,
+      auth: null,
+      c: ctx as never,
+    });
+    expect(mockRedis.smembers).toHaveBeenCalledWith('chive:authz:roles:did:plc:user1');
+    expect(result.body.roles).toEqual(['reader', 'alpha-tester']);
+    expect(result.body.isAdmin).toBe(false);
+    expect(result.body.isAlphaTester).toBe(true);
+    expect(result.body.isPremium).toBe(false);
+  });
+
+  it('sets isAdmin true when user has admin role', async () => {
+    mockRedis.smembers.mockResolvedValueOnce(['admin']);
+    const ctx = buildCtx({ did: 'did:plc:admin1' });
+
+    const result = await getMyRoles.handler({
+      params: undefined,
+      input: undefined,
+      auth: null,
+      c: ctx as never,
+    });
+    expect(result.body.isAdmin).toBe(true);
+    expect(result.body.isAlphaTester).toBe(true);
+    expect(result.body.isPremium).toBe(true);
+  });
+
+  it('returns empty roles when user has none', async () => {
+    mockRedis.smembers.mockResolvedValueOnce([]);
+    const ctx = buildCtx({ did: 'did:plc:empty' });
+
+    const result = await getMyRoles.handler({
+      params: undefined,
+      input: undefined,
+      auth: null,
+      c: ctx as never,
+    });
+    expect(result.body.roles).toEqual([]);
+    expect(result.body.isAdmin).toBe(false);
+    expect(result.body.isAlphaTester).toBe(false);
+    expect(result.body.isPremium).toBe(false);
+  });
+
+  it('grants premium access to admin users', async () => {
+    mockRedis.smembers.mockResolvedValueOnce(['admin']);
+    const ctx = buildCtx({ did: 'did:plc:admin2' });
+
+    const result = await getMyRoles.handler({
+      params: undefined,
+      input: undefined,
+      auth: null,
+      c: ctx as never,
+    });
+    expect(result.body.isPremium).toBe(true);
   });
 });

--- a/tests/unit/api/handlers/xrpc/admin.test.ts
+++ b/tests/unit/api/handlers/xrpc/admin.test.ts
@@ -103,6 +103,7 @@ const ADMIN_DID = TEST_USER_DIDS.ADMIN;
 const NON_ADMIN_DID = TEST_USER_DIDS.USER_1;
 
 interface MockAdminService {
+  recordAuditEntry: ReturnType<typeof vi.fn>;
   getOverview: ReturnType<typeof vi.fn>;
   getSystemHealth: ReturnType<typeof vi.fn>;
   searchUsers: ReturnType<typeof vi.fn>;
@@ -147,6 +148,7 @@ interface MockRedis {
 }
 
 const createMockAdminService = (): MockAdminService => ({
+  recordAuditEntry: vi.fn().mockResolvedValue(undefined),
   getOverview: vi.fn().mockResolvedValue({
     eprints: 10,
     authors: 5,
@@ -232,7 +234,11 @@ describe('XRPC Admin Handlers', () => {
   let mockAdminService: MockAdminService;
   let mockBackfillManager: MockBackfillManager;
   let mockRedis: MockRedis;
-  let mockContext: { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> };
+  let mockContext: {
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    req: { header: ReturnType<typeof vi.fn> };
+  };
   const adminUser = { did: ADMIN_DID, handle: 'admin.test', isAdmin: true };
   const nonAdminUser = { did: NON_ADMIN_DID, handle: 'user.test', isAdmin: false };
 
@@ -334,6 +340,7 @@ describe('XRPC Admin Handlers', () => {
   function buildContext(user: typeof adminUser | typeof nonAdminUser | null): {
     get: ReturnType<typeof vi.fn>;
     set: ReturnType<typeof vi.fn>;
+    req: { header: ReturnType<typeof vi.fn> };
   } {
     return {
       get: vi.fn((key: string) => {
@@ -366,12 +373,16 @@ describe('XRPC Admin Handlers', () => {
         }
       }),
       set: vi.fn(),
+      // Handlers read the caller's address for the audit log; the mock needs a
+      // `req` for that, not because the handler is defensive about its absence.
+      req: { header: vi.fn(() => undefined) },
     };
   }
 
   function buildContextWithoutAdmin(user: typeof adminUser): {
     get: ReturnType<typeof vi.fn>;
     set: ReturnType<typeof vi.fn>;
+    req: { header: ReturnType<typeof vi.fn> };
   } {
     return {
       get: vi.fn((key: string) => {
@@ -404,6 +415,9 @@ describe('XRPC Admin Handlers', () => {
         }
       }),
       set: vi.fn(),
+      // Handlers read the caller's address for the audit log; the mock needs a
+      // `req` for that, not because the handler is defensive about its absence.
+      req: { header: vi.fn(() => undefined) },
     };
   }
 
@@ -788,1702 +802,1752 @@ describe('XRPC Admin Handlers', () => {
   // =========================================================================
   // Users: revokeRole
   // =========================================================================
-  describe('revokeRole', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        revokeRole.handler({
-          params: undefined,
-          input: { did: 'did:plc:user1', role: 'moderator' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('throws ValidationError for missing input', async () => {
-      await expect(
-        revokeRole.handler({
-          params: undefined,
-          input: undefined as never,
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('DID and role are required');
-    });
-
-    it('removes role from Redis and returns success', async () => {
-      const result = await revokeRole.handler({
-        params: undefined,
-        input: { did: 'did:plc:user1', role: 'moderator' },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockRedis.srem).toHaveBeenCalledWith('chive:authz:roles:did:plc:user1', 'moderator');
-      expect(mockRedis.del).toHaveBeenCalledWith('chive:authz:assignments:did:plc:user1:moderator');
-      expect(result.body).toMatchObject({ success: true, did: 'did:plc:user1', role: 'moderator' });
-    });
-  });
-
-  // =========================================================================
-  // Content: listEprints
-  // =========================================================================
-  describe('listEprints', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        listEprints.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        listEprints.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('uses default limit 50 and offset 0', async () => {
-      await listEprints.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listEprints).toHaveBeenCalledWith(undefined, 50, 0);
-    });
-
-    it('passes query, limit, and offset', async () => {
-      await listEprints.handler({
-        params: { q: 'neural', limit: 10, offset: 20 },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listEprints).toHaveBeenCalledWith('neural', 10, 20);
-    });
-  });
-
-  // =========================================================================
-  // Content: listReviews
-  // =========================================================================
-  describe('listReviews', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        listReviews.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        listReviews.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('uses default limit 50 and offset 0', async () => {
-      await listReviews.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listReviews).toHaveBeenCalledWith(50, 0);
-    });
-
-    it('parses cursor as numeric offset', async () => {
-      await listReviews.handler({
-        params: { limit: 10, cursor: '25' },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listReviews).toHaveBeenCalledWith(10, 25);
-    });
-  });
-
-  // =========================================================================
-  // Content: listEndorsements
-  // =========================================================================
-  describe('listEndorsements', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        listEndorsements.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        listEndorsements.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('uses default limit 50 and offset 0', async () => {
-      await listEndorsements.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listEndorsements).toHaveBeenCalledWith(50, 0);
-    });
-
-    it('parses cursor as numeric offset', async () => {
-      await listEndorsements.handler({
-        params: { limit: 5, cursor: '15' },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listEndorsements).toHaveBeenCalledWith(5, 15);
-    });
-  });
-
-  // =========================================================================
-  // Content: deleteContent
-  // =========================================================================
-  describe('deleteContent', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        deleteContent.handler({
-          params: undefined,
-          input: { uri: 'at://test', collection: 'pub.chive.eprint.submission' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        deleteContent.handler({
-          params: undefined,
-          input: { uri: 'at://test', collection: 'pub.chive.eprint.submission' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('throws ValidationError for missing input', async () => {
-      await expect(
-        deleteContent.handler({
-          params: undefined,
-          input: undefined as never,
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('URI and collection are required');
-    });
-
-    it('throws ValidationError for unsupported collection', async () => {
-      await expect(
-        deleteContent.handler({
-          params: undefined,
-          input: { uri: 'at://test', collection: 'pub.chive.unknown.type' },
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('Unsupported collection');
-    });
-
-    it('soft-deletes content and publishes event', async () => {
-      const result = await deleteContent.handler({
-        params: undefined,
-        input: {
-          uri: 'at://did:plc:test/pub.chive.eprint.submission/123',
-          collection: 'pub.chive.eprint.submission',
-          reason: 'spam',
-        },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.deleteContent).toHaveBeenCalledWith(
-        'at://did:plc:test/pub.chive.eprint.submission/123',
-        'eprints_index'
-      );
-      expect(mockRedis.publish).toHaveBeenCalledWith(
-        'chive:admin:content-deleted',
-        expect.stringContaining('"reason":"spam"')
-      );
-      expect(result.body).toMatchObject({ success: true });
-    });
-
-    it('maps all supported collections to correct tables', async () => {
-      const collectionMap: Record<string, string> = {
-        'pub.chive.eprint.submission': 'eprints_index',
-        'pub.chive.review.comment': 'reviews_index',
-        'pub.chive.review.endorsement': 'endorsements_index',
-        'pub.chive.eprint.userTag': 'user_tags_index',
-      };
-
-      for (const [collection, table] of Object.entries(collectionMap)) {
-        vi.clearAllMocks();
-        mockAdminService = createMockAdminService();
-        mockRedis = createMockRedis();
-        mockContext = buildContext(adminUser);
-
-        await deleteContent.handler({
-          params: undefined,
-          input: { uri: 'at://test', collection },
-          auth: null,
-          c: mockContext as never,
-        });
-        expect(mockAdminService.deleteContent).toHaveBeenCalledWith('at://test', table);
-      }
-    });
-  });
-
-  // =========================================================================
-  // Firehose: getFirehoseStatus
-  // =========================================================================
-  describe('getFirehoseStatus', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getFirehoseStatus.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('returns cursor and DLQ count from Redis', async () => {
-      mockRedis.get.mockResolvedValueOnce('12345');
-      mockRedis.llen.mockResolvedValueOnce(3);
-
-      const result = await getFirehoseStatus.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(result.body).toMatchObject({ cursor: '12345', dlqCount: 3 });
-      expect(result.body).toHaveProperty('timestamp');
-    });
-
-    it('handles llen failure gracefully', async () => {
-      mockRedis.get.mockResolvedValueOnce(null);
-      mockRedis.llen.mockRejectedValueOnce(new Error('Redis error'));
-
-      const result = await getFirehoseStatus.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(result.body).toMatchObject({ cursor: null, dlqCount: 0 });
-    });
-  });
-
-  // =========================================================================
-  // Firehose: listDLQEntries
-  // =========================================================================
-  describe('listDLQEntries', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        listDLQEntries.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('uses default limit 50 and offset 0', async () => {
-      mockRedis.lrange.mockResolvedValueOnce([]);
-      mockRedis.llen.mockResolvedValueOnce(0);
-
-      await listDLQEntries.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockRedis.lrange).toHaveBeenCalledWith('chive:firehose:dlq', 0, 49);
-    });
-
-    it('uses custom limit and offset', async () => {
-      mockRedis.lrange.mockResolvedValueOnce([]);
-      mockRedis.llen.mockResolvedValueOnce(0);
-
-      await listDLQEntries.handler({
-        params: { limit: 10, offset: 5 },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockRedis.lrange).toHaveBeenCalledWith('chive:firehose:dlq', 5, 14);
-    });
-
-    it('parses JSON entries and handles invalid entries', async () => {
-      mockRedis.lrange.mockResolvedValueOnce([
-        JSON.stringify({ error: 'timeout', uri: 'at://test' }),
-        'not-valid-json',
-      ]);
-      mockRedis.llen.mockResolvedValueOnce(2);
-
-      const result = await listDLQEntries.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      const body = result.body as { entries: unknown[]; total: number };
-      expect(body.entries).toHaveLength(2);
-      expect(body.total).toBe(2);
-      expect(body.entries[1]).toMatchObject({ raw: 'not-valid-json' });
-    });
-  });
-
-  // =========================================================================
-  // Firehose: retryDLQEntry
-  // =========================================================================
-  describe('retryDLQEntry', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        retryDLQEntry.handler({
-          params: undefined,
-          input: { index: 0 },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('throws ValidationError when index is missing', async () => {
-      await expect(
-        retryDLQEntry.handler({
-          params: undefined,
-          input: {} as never,
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('Index is required');
-    });
-
-    it('returns failure when entry not found at index', async () => {
-      mockRedis.lrange.mockResolvedValueOnce([]);
-
-      const result = await retryDLQEntry.handler({
-        params: undefined,
-        input: { index: 99 },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(result.body).toMatchObject({ success: false });
-    });
-
-    it('requeues entry to retry queue on success', async () => {
-      mockRedis.lrange.mockResolvedValueOnce(['{"error":"timeout"}']);
-
-      const result = await retryDLQEntry.handler({
-        params: undefined,
-        input: { index: 0 },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockRedis.rpush).toHaveBeenCalledWith('chive:firehose:retry', '{"error":"timeout"}');
-      expect(result.body).toMatchObject({ success: true });
-    });
-  });
-
-  // =========================================================================
-  // Firehose: retryAllDLQ
-  // =========================================================================
-  describe('retryAllDLQ', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        retryAllDLQ.handler({
-          params: undefined,
-          input: {},
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('retries all entries and clears DLQ when no errorType filter', async () => {
-      mockRedis.lrange.mockResolvedValueOnce(['{"error":"a"}', '{"error":"b"}']);
-
-      const result = await retryAllDLQ.handler({
-        params: undefined,
-        input: {},
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockRedis.rpush).toHaveBeenCalledTimes(2);
-      expect(mockRedis.del).toHaveBeenCalledWith('chive:firehose:dlq');
-      expect(result.body).toMatchObject({ success: true, retriedCount: 2 });
-    });
-
-    it('filters by errorType when specified', async () => {
-      mockRedis.lrange.mockResolvedValueOnce([
-        JSON.stringify({ errorType: 'timeout' }),
-        JSON.stringify({ errorType: 'parse' }),
-        JSON.stringify({ errorType: 'timeout' }),
-      ]);
-
-      const result = await retryAllDLQ.handler({
-        params: undefined,
-        input: { errorType: 'timeout' },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockRedis.rpush).toHaveBeenCalledTimes(2);
-      expect(mockRedis.del).not.toHaveBeenCalled();
-      expect(result.body).toMatchObject({ retriedCount: 2 });
-    });
-  });
-
-  // =========================================================================
-  // Firehose: dismissDLQEntry
-  // =========================================================================
-  describe('dismissDLQEntry', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        dismissDLQEntry.handler({
-          params: undefined,
-          input: { index: 0 },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('throws ValidationError when index is missing', async () => {
-      await expect(
-        dismissDLQEntry.handler({
-          params: undefined,
-          input: {} as never,
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('Index is required');
-    });
-
-    it('removes entry via sentinel pattern', async () => {
-      const result = await dismissDLQEntry.handler({
-        params: undefined,
-        input: { index: 3 },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockRedis.lset).toHaveBeenCalledWith(
-        'chive:firehose:dlq',
-        3,
-        expect.stringContaining('__DISMISSED_')
-      );
-      expect(mockRedis.lrem).toHaveBeenCalled();
-      expect(result.body).toMatchObject({ success: true });
-    });
-  });
-
-  // =========================================================================
-  // Firehose: purgeOldDLQ
-  // =========================================================================
-  describe('purgeOldDLQ', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        purgeOldDLQ.handler({
-          params: undefined,
-          input: {},
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('uses default 7 days when olderThanDays not specified', async () => {
-      mockRedis.lrange.mockResolvedValueOnce([]);
-
-      const result = await purgeOldDLQ.handler({
-        params: undefined,
-        input: {},
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(result.body).toMatchObject({ success: true, purgedCount: 0 });
-    });
-
-    it('purges entries older than cutoff', async () => {
-      const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
-      const newDate = new Date().toISOString();
-
-      mockRedis.lrange.mockResolvedValueOnce([
-        JSON.stringify({ timestamp: oldDate }),
-        JSON.stringify({ timestamp: newDate }),
-      ]);
-
-      const result = await purgeOldDLQ.handler({
-        params: undefined,
-        input: { olderThanDays: 7 },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(result.body).toMatchObject({ purgedCount: 1 });
-      expect(mockRedis.lset).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  // =========================================================================
-  // Backfill: triggerPDSScan
-  // =========================================================================
-  describe('triggerPDSScan', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        triggerPDSScan.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        triggerPDSScan.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('starts operation and returns immediately', async () => {
-      const result = await triggerPDSScan.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('pdsScan');
-      expect(result.body).toMatchObject({ operationId: 'op-123', status: 'running' });
-    });
-  });
-
-  // =========================================================================
-  // Backfill: triggerFreshnessScan
-  // =========================================================================
-  describe('triggerFreshnessScan', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        triggerFreshnessScan.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        triggerFreshnessScan.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('starts freshnessScan operation', async () => {
-      const result = await triggerFreshnessScan.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('freshnessScan');
-      expect(result.body).toMatchObject({ status: 'running' });
-    });
-  });
-
-  // =========================================================================
-  // Backfill: triggerCitationExtraction
-  // =========================================================================
-  describe('triggerCitationExtraction', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        triggerCitationExtraction.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        triggerCitationExtraction.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('starts citationExtraction operation', async () => {
-      const result = await triggerCitationExtraction.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('citationExtraction');
-      expect(result.body).toMatchObject({ status: 'running' });
-    });
-  });
-
-  // =========================================================================
-  // Backfill: triggerFullReindex
-  // =========================================================================
-  describe('triggerFullReindex', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        triggerFullReindex.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        triggerFullReindex.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('starts fullReindex operation', async () => {
-      const result = await triggerFullReindex.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('fullReindex');
-      expect(result.body).toMatchObject({ status: 'running' });
-    });
-  });
-
-  // =========================================================================
-  // Backfill: triggerGovernanceSync
-  // =========================================================================
-  describe('triggerGovernanceSync', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        triggerGovernanceSync.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        triggerGovernanceSync.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('starts governanceSync operation', async () => {
-      const result = await triggerGovernanceSync.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('governanceSync');
-      expect(result.body).toMatchObject({ status: 'running' });
-    });
-  });
-
-  // =========================================================================
-  // Backfill: triggerDIDSync
-  // =========================================================================
-  describe('triggerDIDSync', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        triggerDIDSync.handler({
-          params: undefined,
-          input: { did: 'did:plc:test' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('throws ValidationError when DID is missing', async () => {
-      await expect(
-        triggerDIDSync.handler({
-          params: undefined,
-          input: { did: '' },
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('DID is required');
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        triggerDIDSync.handler({
-          params: undefined,
-          input: { did: 'did:plc:test' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('starts didSync operation with DID metadata', async () => {
-      const result = await triggerDIDSync.handler({
-        params: undefined,
-        input: { did: 'did:plc:target' },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('didSync', {
-        did: 'did:plc:target',
-      });
-      expect(result.body).toMatchObject({ did: 'did:plc:target', status: 'running' });
-    });
-  });
-
-  // =========================================================================
-  // Backfill: triggerBackfill (generic)
-  // =========================================================================
-  describe('triggerBackfill', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        triggerBackfill.handler({
-          params: undefined,
-          input: { type: 'pdsScan' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('throws ValidationError when type is missing', async () => {
-      await expect(
-        triggerBackfill.handler({
-          params: undefined,
-          input: { type: '' },
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('Backfill type is required');
-    });
-
-    it('throws ValidationError for invalid type', async () => {
-      await expect(
-        triggerBackfill.handler({
-          params: undefined,
-          input: { type: 'invalidOperation' },
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('Invalid backfill type');
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        triggerBackfill.handler({
-          params: undefined,
-          input: { type: 'pdsScan' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('starts operation with type and metadata', async () => {
-      const result = await triggerBackfill.handler({
-        params: undefined,
-        input: { type: 'fullReindex' },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('fullReindex', {
-        startedBy: ADMIN_DID,
-      });
-      expect(result.body).toHaveProperty('operation');
-    });
-
-    it('accepts all valid backfill types', async () => {
-      const validTypes = [
-        'pdsScan',
-        'freshnessScan',
-        'citationExtraction',
-        'fullReindex',
-        'governanceSync',
-        'didSync',
-      ];
-      for (const type of validTypes) {
-        vi.clearAllMocks();
-        mockBackfillManager = createMockBackfillManager();
-        mockContext = buildContext(adminUser);
-        await triggerBackfill.handler({
-          params: undefined,
-          input: { type },
-          auth: null,
-          c: mockContext as never,
-        });
-        expect(mockBackfillManager.startOperation).toHaveBeenCalledWith(type, expect.any(Object));
-      }
-    });
-  });
-
-  // =========================================================================
-  // Backfill: getBackfillStatus
-  // =========================================================================
-  describe('getBackfillStatus', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getBackfillStatus.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        getBackfillStatus.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('returns single operation when id is provided', async () => {
-      const result = await getBackfillStatus.handler({
-        params: { id: 'op-123' },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.getStatus).toHaveBeenCalledWith('op-123');
-      expect(result.body).toHaveProperty('operation');
-    });
-
-    it('lists operations with status filter', async () => {
-      const result = await getBackfillStatus.handler({
-        params: { status: 'running' },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.listOperations).toHaveBeenCalledWith('running');
-      expect(result.body).toHaveProperty('operations');
-    });
-
-    it('lists all operations when no params', async () => {
-      const result = await getBackfillStatus.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.listOperations).toHaveBeenCalledWith(undefined);
-      expect(result.body).toHaveProperty('operations');
-    });
-  });
-
-  // =========================================================================
-  // Backfill: getBackfillHistory
-  // =========================================================================
-  describe('getBackfillHistory', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getBackfillHistory.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        getBackfillHistory.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('filters out running operations and sorts by startedAt descending', async () => {
-      const result = await getBackfillHistory.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      const body = result.body as { operations: { id: string; status: string }[] };
-      // From our mock: op-1 completed, op-2 running, op-3 failed
-      // Running (op-2) should be filtered out, sorted: op-3 (2024-01-03) then op-1 (2024-01-01)
-      expect(body.operations).toHaveLength(2);
-      expect(body.operations[0]?.id).toBe('op-3');
-      expect(body.operations[1]?.id).toBe('op-1');
-    });
-  });
-
-  // =========================================================================
-  // Backfill: cancelBackfill
-  // =========================================================================
-  describe('cancelBackfill', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        cancelBackfill.handler({
-          params: undefined,
-          input: { id: 'op-123' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('throws ValidationError when id is missing', async () => {
-      await expect(
-        cancelBackfill.handler({
-          params: undefined,
-          input: { id: '' },
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('Operation ID is required');
-    });
-
-    it('rejects missing backfill manager', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        cancelBackfill.handler({
-          params: undefined,
-          input: { id: 'op-123' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('cancels operation and returns result', async () => {
-      const result = await cancelBackfill.handler({
-        params: undefined,
-        input: { id: 'op-123' },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.cancelOperation).toHaveBeenCalledWith('op-123');
-      expect(result.body).toMatchObject({ success: true, id: 'op-123' });
-    });
-  });
-
-  // =========================================================================
-  // PDS: listPDSes
-  // =========================================================================
-  describe('listPDSes', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        listPDSes.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        listPDSes.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('computes stats from PDS entries', async () => {
-      const result = await listPDSes.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      const body = result.body as {
-        stats: {
-          total: number;
-          healthy: number;
-          unhealthy: number;
-          withRecords: number;
-        };
-      };
-      expect(body.stats.total).toBe(2);
-      expect(body.stats.healthy).toBe(1);
-      expect(body.stats.unhealthy).toBe(1);
-      expect(body.stats.withRecords).toBe(1);
-    });
-  });
-
-  // =========================================================================
-  // PDS: rescanPDS
-  // =========================================================================
-  describe('rescanPDS', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        rescanPDS.handler({
-          params: undefined,
-          input: { pdsUrl: 'https://pds.test' },
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('throws ValidationError when pdsUrl is missing', async () => {
-      await expect(
-        rescanPDS.handler({
-          params: undefined,
-          input: { pdsUrl: '' },
-          auth: null,
-          c: mockContext as never,
-        })
-      ).rejects.toThrow('PDS URL is required');
-    });
-
-    it('registers PDS and returns success', async () => {
-      const result = await rescanPDS.handler({
-        params: undefined,
-        input: { pdsUrl: 'https://pds.test' },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockPdsRegistry.registerPDS).toHaveBeenCalledWith('https://pds.test', 'did_mention');
-      expect(result.body).toMatchObject({ success: true, pdsUrl: 'https://pds.test' });
-    });
-  });
-
-  // =========================================================================
-  // PDS: listImports
-  // =========================================================================
-  describe('listImports', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        listImports.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        listImports.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('uses default limit of 50', async () => {
-      await listImports.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listImports).toHaveBeenCalledWith(50, 0, undefined);
-    });
-
-    it('passes source filter', async () => {
-      await listImports.handler({
-        params: { limit: 10, source: 'arxiv' },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listImports).toHaveBeenCalledWith(10, 0, 'arxiv');
-    });
-  });
-
-  // =========================================================================
-  // Knowledge Graph: getGraphStats
-  // =========================================================================
-  describe('getGraphStats', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getGraphStats.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('queries node and edge counts in parallel', async () => {
-      const result = await getGraphStats.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockNodeRepository.listNodes).toHaveBeenCalled();
-      expect(mockEdgeRepository.listEdges).toHaveBeenCalled();
-      const body = result.body as { totalNodes: number; totalEdges: number };
-      expect(body.totalNodes).toBe(100);
-      expect(body.totalEdges).toBe(50);
-    });
-
-    it('includes pending proposals count', async () => {
-      const result = await getGraphStats.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      const body = result.body as { pendingProposals: number };
-      expect(body.pendingProposals).toBe(3);
-    });
-  });
-
-  // =========================================================================
-  // Metrics: getMetricsOverview
-  // =========================================================================
-  describe('getMetricsOverview', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getMetricsOverview.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('uses default 7 days', async () => {
-      const result = await getMetricsOverview.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('7d', 20);
-      const body = result.body as { periodInfo: { days: number } };
-      expect(body.periodInfo.days).toBe(7);
-    });
-
-    it('maps days=1 to 24h window', async () => {
-      await getMetricsOverview.handler({
-        params: { days: 1 },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20);
-    });
-
-    it('maps days=30 to 30d window', async () => {
-      await getMetricsOverview.handler({
-        params: { days: 30 },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('30d', 20);
-    });
-  });
-
-  // =========================================================================
-  // Metrics: getSearchAnalytics
-  // =========================================================================
-  describe('getSearchAnalytics', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getSearchAnalytics.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        getSearchAnalytics.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('returns analytics from admin service', async () => {
-      const result = await getSearchAnalytics.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(result.body).toMatchObject({ totalSearches: 100 });
-    });
-  });
-
-  // =========================================================================
-  // Metrics: getActivityCorrelation
-  // =========================================================================
-  describe('getActivityCorrelation', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getActivityCorrelation.handler({
-          params: undefined,
-          input: undefined,
-          auth: null,
-          c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('returns empty metrics when activity service is not configured', async () => {
-      const ctx = {
-        get: vi.fn((key: string) => {
-          if (key === 'user') return adminUser;
-          if (key === 'services') return { activity: null };
-          if (key === 'logger') return mockLogger;
-          return undefined;
-        }),
-        set: vi.fn(),
-      };
-
-      const result = await getActivityCorrelation.handler({
-        params: undefined,
-        input: undefined,
+  describe('administrative actions reach the audit log', () => {
+    it('records a role grant', async () => {
+      // Role grants used to be written to Redis alone, so getAuditLog could not
+      // show one of the two actions an admin audit log exists for.
+      const ctx = buildContext(adminUser);
+      await assignRole.handler({
+        params: undefined as never,
+        input: { did: 'did:plc:target', role: 'moderator' },
         auth: null,
         c: ctx as never,
       });
-      const body = result.body as { metrics: unknown[] };
-      expect(body.metrics).toEqual([]);
-    });
 
-    it('returns metrics from activity service', async () => {
-      const result = await getActivityCorrelation.handler({
-        params: undefined,
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
+      describe('revokeRole', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            revokeRole.handler({
+              params: undefined,
+              input: { did: 'did:plc:user1', role: 'moderator' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('throws ValidationError for missing input', async () => {
+          await expect(
+            revokeRole.handler({
+              params: undefined,
+              input: undefined as never,
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('DID and role are required');
+        });
+
+        it('removes role from Redis and returns success', async () => {
+          const result = await revokeRole.handler({
+            params: undefined,
+            input: { did: 'did:plc:user1', role: 'moderator' },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockRedis.srem).toHaveBeenCalledWith(
+            'chive:authz:roles:did:plc:user1',
+            'moderator'
+          );
+          expect(mockRedis.del).toHaveBeenCalledWith(
+            'chive:authz:assignments:did:plc:user1:moderator'
+          );
+          expect(result.body).toMatchObject({
+            success: true,
+            did: 'did:plc:user1',
+            role: 'moderator',
+          });
+        });
       });
-      const body = result.body as { metrics: unknown[] };
-      expect(body.metrics).toHaveLength(1);
-    });
-  });
 
-  // =========================================================================
-  // Metrics: getTrendingVelocity
-  // =========================================================================
-  describe('getTrendingVelocity', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getTrendingVelocity.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
+      // =========================================================================
+      // Content: listEprints
+      // =========================================================================
+      describe('listEprints', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            listEprints.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
 
-    it('uses default window 24h and limit 20', async () => {
-      await getTrendingVelocity.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            listEprints.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('uses default limit 50 and offset 0', async () => {
+          await listEprints.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listEprints).toHaveBeenCalledWith(undefined, 50, 0);
+        });
+
+        it('passes query, limit, and offset', async () => {
+          await listEprints.handler({
+            params: { q: 'neural', limit: 10, offset: 20 },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listEprints).toHaveBeenCalledWith('neural', 10, 20);
+        });
       });
-      expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20);
-    });
 
-    it('enriches entries with title and metrics', async () => {
-      mockMetricsService.getTrending.mockResolvedValueOnce([
-        { uri: 'at://test', score: 50, velocity: 0.5 },
-      ]);
-      mockEprintService.getEprint = vi.fn().mockResolvedValue({ title: 'Test Paper' });
-      mockMetricsService.getMetrics.mockResolvedValueOnce({
-        totalViews: 200,
-        totalDownloads: 30,
+      // =========================================================================
+      // Content: listReviews
+      // =========================================================================
+      describe('listReviews', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            listReviews.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            listReviews.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('uses default limit 50 and offset 0', async () => {
+          await listReviews.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listReviews).toHaveBeenCalledWith(50, 0);
+        });
+
+        it('parses cursor as numeric offset', async () => {
+          await listReviews.handler({
+            params: { limit: 10, cursor: '25' },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listReviews).toHaveBeenCalledWith(10, 25);
+        });
       });
 
-      const result = await getTrendingVelocity.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      const body = result.body as { items: { title: string; trend: string }[] };
-      expect(body.items[0]?.title).toBe('Test Paper');
-      expect(body.items[0]?.trend).toBe('rising');
-    });
-  });
+      // =========================================================================
+      // Content: listEndorsements
+      // =========================================================================
+      describe('listEndorsements', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            listEndorsements.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
 
-  // =========================================================================
-  // Metrics: getViewDownloadTimeSeries
-  // =========================================================================
-  describe('getViewDownloadTimeSeries', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getViewDownloadTimeSeries.handler({
-          params: {},
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            listEndorsements.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('uses default limit 50 and offset 0', async () => {
+          await listEndorsements.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listEndorsements).toHaveBeenCalledWith(50, 0);
+        });
+
+        it('parses cursor as numeric offset', async () => {
+          await listEndorsements.handler({
+            params: { limit: 5, cursor: '15' },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listEndorsements).toHaveBeenCalledWith(5, 15);
+        });
+      });
+
+      // =========================================================================
+      // Content: deleteContent
+      // =========================================================================
+      describe('deleteContent', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            deleteContent.handler({
+              params: undefined,
+              input: { uri: 'at://test', collection: 'pub.chive.eprint.submission' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            deleteContent.handler({
+              params: undefined,
+              input: { uri: 'at://test', collection: 'pub.chive.eprint.submission' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('throws ValidationError for missing input', async () => {
+          await expect(
+            deleteContent.handler({
+              params: undefined,
+              input: undefined as never,
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('URI and collection are required');
+        });
+
+        it('throws ValidationError for unsupported collection', async () => {
+          await expect(
+            deleteContent.handler({
+              params: undefined,
+              input: { uri: 'at://test', collection: 'pub.chive.unknown.type' },
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('Unsupported collection');
+        });
+
+        it('soft-deletes content and publishes event', async () => {
+          const result = await deleteContent.handler({
+            params: undefined,
+            input: {
+              uri: 'at://did:plc:test/pub.chive.eprint.submission/123',
+              collection: 'pub.chive.eprint.submission',
+              reason: 'spam',
+            },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.deleteContent).toHaveBeenCalledWith(
+            'at://did:plc:test/pub.chive.eprint.submission/123',
+            'eprints_index'
+          );
+          expect(mockRedis.publish).toHaveBeenCalledWith(
+            'chive:admin:content-deleted',
+            expect.stringContaining('"reason":"spam"')
+          );
+          expect(result.body).toMatchObject({ success: true });
+        });
+
+        it('maps all supported collections to correct tables', async () => {
+          const collectionMap: Record<string, string> = {
+            'pub.chive.eprint.submission': 'eprints_index',
+            'pub.chive.review.comment': 'reviews_index',
+            'pub.chive.review.endorsement': 'endorsements_index',
+            'pub.chive.eprint.userTag': 'user_tags_index',
+          };
+
+          for (const [collection, table] of Object.entries(collectionMap)) {
+            vi.clearAllMocks();
+            mockAdminService = createMockAdminService();
+            mockRedis = createMockRedis();
+            mockContext = buildContext(adminUser);
+
+            await deleteContent.handler({
+              params: undefined,
+              input: { uri: 'at://test', collection },
+              auth: null,
+              c: mockContext as never,
+            });
+            expect(mockAdminService.deleteContent).toHaveBeenCalledWith('at://test', table);
+          }
+        });
+      });
+
+      // =========================================================================
+      // Firehose: getFirehoseStatus
+      // =========================================================================
+      describe('getFirehoseStatus', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getFirehoseStatus.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('returns cursor and DLQ count from Redis', async () => {
+          mockRedis.get.mockResolvedValueOnce('12345');
+          mockRedis.llen.mockResolvedValueOnce(3);
+
+          const result = await getFirehoseStatus.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(result.body).toMatchObject({ cursor: '12345', dlqCount: 3 });
+          expect(result.body).toHaveProperty('timestamp');
+        });
+
+        it('handles llen failure gracefully', async () => {
+          mockRedis.get.mockResolvedValueOnce(null);
+          mockRedis.llen.mockRejectedValueOnce(new Error('Redis error'));
+
+          const result = await getFirehoseStatus.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(result.body).toMatchObject({ cursor: null, dlqCount: 0 });
+        });
+      });
+
+      // =========================================================================
+      // Firehose: listDLQEntries
+      // =========================================================================
+      describe('listDLQEntries', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            listDLQEntries.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('uses default limit 50 and offset 0', async () => {
+          mockRedis.lrange.mockResolvedValueOnce([]);
+          mockRedis.llen.mockResolvedValueOnce(0);
+
+          await listDLQEntries.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockRedis.lrange).toHaveBeenCalledWith('chive:firehose:dlq', 0, 49);
+        });
+
+        it('uses custom limit and offset', async () => {
+          mockRedis.lrange.mockResolvedValueOnce([]);
+          mockRedis.llen.mockResolvedValueOnce(0);
+
+          await listDLQEntries.handler({
+            params: { limit: 10, offset: 5 },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockRedis.lrange).toHaveBeenCalledWith('chive:firehose:dlq', 5, 14);
+        });
+
+        it('parses JSON entries and handles invalid entries', async () => {
+          mockRedis.lrange.mockResolvedValueOnce([
+            JSON.stringify({ error: 'timeout', uri: 'at://test' }),
+            'not-valid-json',
+          ]);
+          mockRedis.llen.mockResolvedValueOnce(2);
+
+          const result = await listDLQEntries.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as { entries: unknown[]; total: number };
+          expect(body.entries).toHaveLength(2);
+          expect(body.total).toBe(2);
+          expect(body.entries[1]).toMatchObject({ raw: 'not-valid-json' });
+        });
+      });
+
+      // =========================================================================
+      // Firehose: retryDLQEntry
+      // =========================================================================
+      describe('retryDLQEntry', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            retryDLQEntry.handler({
+              params: undefined,
+              input: { index: 0 },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('throws ValidationError when index is missing', async () => {
+          await expect(
+            retryDLQEntry.handler({
+              params: undefined,
+              input: {} as never,
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('Index is required');
+        });
+
+        it('returns failure when entry not found at index', async () => {
+          mockRedis.lrange.mockResolvedValueOnce([]);
+
+          const result = await retryDLQEntry.handler({
+            params: undefined,
+            input: { index: 99 },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(result.body).toMatchObject({ success: false });
+        });
+
+        it('requeues entry to retry queue on success', async () => {
+          mockRedis.lrange.mockResolvedValueOnce(['{"error":"timeout"}']);
+
+          const result = await retryDLQEntry.handler({
+            params: undefined,
+            input: { index: 0 },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockRedis.rpush).toHaveBeenCalledWith(
+            'chive:firehose:retry',
+            '{"error":"timeout"}'
+          );
+          expect(result.body).toMatchObject({ success: true });
+        });
+      });
+
+      // =========================================================================
+      // Firehose: retryAllDLQ
+      // =========================================================================
+      describe('retryAllDLQ', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            retryAllDLQ.handler({
+              params: undefined,
+              input: {},
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('retries all entries and clears DLQ when no errorType filter', async () => {
+          mockRedis.lrange.mockResolvedValueOnce(['{"error":"a"}', '{"error":"b"}']);
+
+          const result = await retryAllDLQ.handler({
+            params: undefined,
+            input: {},
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockRedis.rpush).toHaveBeenCalledTimes(2);
+          expect(mockRedis.del).toHaveBeenCalledWith('chive:firehose:dlq');
+          expect(result.body).toMatchObject({ success: true, retriedCount: 2 });
+        });
+
+        it('filters by errorType when specified', async () => {
+          mockRedis.lrange.mockResolvedValueOnce([
+            JSON.stringify({ errorType: 'timeout' }),
+            JSON.stringify({ errorType: 'parse' }),
+            JSON.stringify({ errorType: 'timeout' }),
+          ]);
+
+          const result = await retryAllDLQ.handler({
+            params: undefined,
+            input: { errorType: 'timeout' },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockRedis.rpush).toHaveBeenCalledTimes(2);
+          expect(mockRedis.del).not.toHaveBeenCalled();
+          expect(result.body).toMatchObject({ retriedCount: 2 });
+        });
+      });
+
+      // =========================================================================
+      // Firehose: dismissDLQEntry
+      // =========================================================================
+      describe('dismissDLQEntry', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            dismissDLQEntry.handler({
+              params: undefined,
+              input: { index: 0 },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('throws ValidationError when index is missing', async () => {
+          await expect(
+            dismissDLQEntry.handler({
+              params: undefined,
+              input: {} as never,
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('Index is required');
+        });
+
+        it('removes entry via sentinel pattern', async () => {
+          const result = await dismissDLQEntry.handler({
+            params: undefined,
+            input: { index: 3 },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockRedis.lset).toHaveBeenCalledWith(
+            'chive:firehose:dlq',
+            3,
+            expect.stringContaining('__DISMISSED_')
+          );
+          expect(mockRedis.lrem).toHaveBeenCalled();
+          expect(result.body).toMatchObject({ success: true });
+        });
+      });
+
+      // =========================================================================
+      // Firehose: purgeOldDLQ
+      // =========================================================================
+      describe('purgeOldDLQ', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            purgeOldDLQ.handler({
+              params: undefined,
+              input: {},
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('uses default 7 days when olderThanDays not specified', async () => {
+          mockRedis.lrange.mockResolvedValueOnce([]);
+
+          const result = await purgeOldDLQ.handler({
+            params: undefined,
+            input: {},
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(result.body).toMatchObject({ success: true, purgedCount: 0 });
+        });
+
+        it('purges entries older than cutoff', async () => {
+          const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+          const newDate = new Date().toISOString();
+
+          mockRedis.lrange.mockResolvedValueOnce([
+            JSON.stringify({ timestamp: oldDate }),
+            JSON.stringify({ timestamp: newDate }),
+          ]);
+
+          const result = await purgeOldDLQ.handler({
+            params: undefined,
+            input: { olderThanDays: 7 },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(result.body).toMatchObject({ purgedCount: 1 });
+          expect(mockRedis.lset).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      // =========================================================================
+      // Backfill: triggerPDSScan
+      // =========================================================================
+      describe('triggerPDSScan', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            triggerPDSScan.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            triggerPDSScan.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('starts operation and returns immediately', async () => {
+          const result = await triggerPDSScan.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('pdsScan');
+          expect(result.body).toMatchObject({ operationId: 'op-123', status: 'running' });
+        });
+      });
+
+      // =========================================================================
+      // Backfill: triggerFreshnessScan
+      // =========================================================================
+      describe('triggerFreshnessScan', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            triggerFreshnessScan.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            triggerFreshnessScan.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('starts freshnessScan operation', async () => {
+          const result = await triggerFreshnessScan.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('freshnessScan');
+          expect(result.body).toMatchObject({ status: 'running' });
+        });
+      });
+
+      // =========================================================================
+      // Backfill: triggerCitationExtraction
+      // =========================================================================
+      describe('triggerCitationExtraction', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            triggerCitationExtraction.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            triggerCitationExtraction.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('starts citationExtraction operation', async () => {
+          const result = await triggerCitationExtraction.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('citationExtraction');
+          expect(result.body).toMatchObject({ status: 'running' });
+        });
+      });
+
+      // =========================================================================
+      // Backfill: triggerFullReindex
+      // =========================================================================
+      describe('triggerFullReindex', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            triggerFullReindex.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            triggerFullReindex.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('starts fullReindex operation', async () => {
+          const result = await triggerFullReindex.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('fullReindex');
+          expect(result.body).toMatchObject({ status: 'running' });
+        });
+      });
+
+      // =========================================================================
+      // Backfill: triggerGovernanceSync
+      // =========================================================================
+      describe('triggerGovernanceSync', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            triggerGovernanceSync.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            triggerGovernanceSync.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('starts governanceSync operation', async () => {
+          const result = await triggerGovernanceSync.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('governanceSync');
+          expect(result.body).toMatchObject({ status: 'running' });
+        });
+      });
+
+      // =========================================================================
+      // Backfill: triggerDIDSync
+      // =========================================================================
+      describe('triggerDIDSync', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            triggerDIDSync.handler({
+              params: undefined,
+              input: { did: 'did:plc:test' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('throws ValidationError when DID is missing', async () => {
+          await expect(
+            triggerDIDSync.handler({
+              params: undefined,
+              input: { did: '' },
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('DID is required');
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            triggerDIDSync.handler({
+              params: undefined,
+              input: { did: 'did:plc:test' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('starts didSync operation with DID metadata', async () => {
+          const result = await triggerDIDSync.handler({
+            params: undefined,
+            input: { did: 'did:plc:target' },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('didSync', {
+            did: 'did:plc:target',
+          });
+          expect(result.body).toMatchObject({ did: 'did:plc:target', status: 'running' });
+        });
+      });
+
+      // =========================================================================
+      // Backfill: triggerBackfill (generic)
+      // =========================================================================
+      describe('triggerBackfill', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            triggerBackfill.handler({
+              params: undefined,
+              input: { type: 'pdsScan' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('throws ValidationError when type is missing', async () => {
+          await expect(
+            triggerBackfill.handler({
+              params: undefined,
+              input: { type: '' },
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('Backfill type is required');
+        });
+
+        it('throws ValidationError for invalid type', async () => {
+          await expect(
+            triggerBackfill.handler({
+              params: undefined,
+              input: { type: 'invalidOperation' },
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('Invalid backfill type');
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            triggerBackfill.handler({
+              params: undefined,
+              input: { type: 'pdsScan' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('starts operation with type and metadata', async () => {
+          const result = await triggerBackfill.handler({
+            params: undefined,
+            input: { type: 'fullReindex' },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('fullReindex', {
+            startedBy: ADMIN_DID,
+          });
+          expect(result.body).toHaveProperty('operation');
+        });
+
+        it('accepts all valid backfill types', async () => {
+          const validTypes = [
+            'pdsScan',
+            'freshnessScan',
+            'citationExtraction',
+            'fullReindex',
+            'governanceSync',
+            'didSync',
+          ];
+          for (const type of validTypes) {
+            vi.clearAllMocks();
+            mockBackfillManager = createMockBackfillManager();
+            mockContext = buildContext(adminUser);
+            await triggerBackfill.handler({
+              params: undefined,
+              input: { type },
+              auth: null,
+              c: mockContext as never,
+            });
+            expect(mockBackfillManager.startOperation).toHaveBeenCalledWith(
+              type,
+              expect.any(Object)
+            );
+          }
+        });
+      });
+
+      // =========================================================================
+      // Backfill: getBackfillStatus
+      // =========================================================================
+      describe('getBackfillStatus', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getBackfillStatus.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            getBackfillStatus.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('returns single operation when id is provided', async () => {
+          const result = await getBackfillStatus.handler({
+            params: { id: 'op-123' },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.getStatus).toHaveBeenCalledWith('op-123');
+          expect(result.body).toHaveProperty('operation');
+        });
+
+        it('lists operations with status filter', async () => {
+          const result = await getBackfillStatus.handler({
+            params: { status: 'running' },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.listOperations).toHaveBeenCalledWith('running');
+          expect(result.body).toHaveProperty('operations');
+        });
+
+        it('lists all operations when no params', async () => {
+          const result = await getBackfillStatus.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.listOperations).toHaveBeenCalledWith(undefined);
+          expect(result.body).toHaveProperty('operations');
+        });
+      });
+
+      // =========================================================================
+      // Backfill: getBackfillHistory
+      // =========================================================================
+      describe('getBackfillHistory', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getBackfillHistory.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            getBackfillHistory.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('filters out running operations and sorts by startedAt descending', async () => {
+          const result = await getBackfillHistory.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as { operations: { id: string; status: string }[] };
+          // From our mock: op-1 completed, op-2 running, op-3 failed
+          // Running (op-2) should be filtered out, sorted: op-3 (2024-01-03) then op-1 (2024-01-01)
+          expect(body.operations).toHaveLength(2);
+          expect(body.operations[0]?.id).toBe('op-3');
+          expect(body.operations[1]?.id).toBe('op-1');
+        });
+      });
+
+      // =========================================================================
+      // Backfill: cancelBackfill
+      // =========================================================================
+      describe('cancelBackfill', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            cancelBackfill.handler({
+              params: undefined,
+              input: { id: 'op-123' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('throws ValidationError when id is missing', async () => {
+          await expect(
+            cancelBackfill.handler({
+              params: undefined,
+              input: { id: '' },
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('Operation ID is required');
+        });
+
+        it('rejects missing backfill manager', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            cancelBackfill.handler({
+              params: undefined,
+              input: { id: 'op-123' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('cancels operation and returns result', async () => {
+          const result = await cancelBackfill.handler({
+            params: undefined,
+            input: { id: 'op-123' },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockBackfillManager.cancelOperation).toHaveBeenCalledWith('op-123');
+          expect(result.body).toMatchObject({ success: true, id: 'op-123' });
+        });
+      });
+
+      // =========================================================================
+      // PDS: listPDSes
+      // =========================================================================
+      describe('listPDSes', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            listPDSes.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            listPDSes.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('computes stats from PDS entries', async () => {
+          const result = await listPDSes.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as {
+            stats: {
+              total: number;
+              healthy: number;
+              unhealthy: number;
+              withRecords: number;
+            };
+          };
+          expect(body.stats.total).toBe(2);
+          expect(body.stats.healthy).toBe(1);
+          expect(body.stats.unhealthy).toBe(1);
+          expect(body.stats.withRecords).toBe(1);
+        });
+      });
+
+      // =========================================================================
+      // PDS: rescanPDS
+      // =========================================================================
+      describe('rescanPDS', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            rescanPDS.handler({
+              params: undefined,
+              input: { pdsUrl: 'https://pds.test' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('throws ValidationError when pdsUrl is missing', async () => {
+          await expect(
+            rescanPDS.handler({
+              params: undefined,
+              input: { pdsUrl: '' },
+              auth: null,
+              c: mockContext as never,
+            })
+          ).rejects.toThrow('PDS URL is required');
+        });
+
+        it('registers PDS and returns success', async () => {
+          const result = await rescanPDS.handler({
+            params: undefined,
+            input: { pdsUrl: 'https://pds.test' },
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockPdsRegistry.registerPDS).toHaveBeenCalledWith(
+            'https://pds.test',
+            'did_mention'
+          );
+          expect(result.body).toMatchObject({ success: true, pdsUrl: 'https://pds.test' });
+        });
+      });
+
+      // =========================================================================
+      // PDS: listImports
+      // =========================================================================
+      describe('listImports', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            listImports.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            listImports.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('uses default limit of 50', async () => {
+          await listImports.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listImports).toHaveBeenCalledWith(50, 0, undefined);
+        });
+
+        it('passes source filter', async () => {
+          await listImports.handler({
+            params: { limit: 10, source: 'arxiv' },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listImports).toHaveBeenCalledWith(10, 0, 'arxiv');
+        });
+      });
+
+      // =========================================================================
+      // Knowledge Graph: getGraphStats
+      // =========================================================================
+      describe('getGraphStats', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getGraphStats.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('queries node and edge counts in parallel', async () => {
+          const result = await getGraphStats.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockNodeRepository.listNodes).toHaveBeenCalled();
+          expect(mockEdgeRepository.listEdges).toHaveBeenCalled();
+          const body = result.body as { totalNodes: number; totalEdges: number };
+          expect(body.totalNodes).toBe(100);
+          expect(body.totalEdges).toBe(50);
+        });
+
+        it('includes pending proposals count', async () => {
+          const result = await getGraphStats.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as { pendingProposals: number };
+          expect(body.pendingProposals).toBe(3);
+        });
+      });
+
+      // =========================================================================
+      // Metrics: getMetricsOverview
+      // =========================================================================
+      describe('getMetricsOverview', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getMetricsOverview.handler({
+              params: {},
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('uses default 7 days', async () => {
+          const result = await getMetricsOverview.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockMetricsService.getTrending).toHaveBeenCalledWith('7d', 20);
+          const body = result.body as { periodInfo: { days: number } };
+          expect(body.periodInfo.days).toBe(7);
+        });
+
+        it('maps days=1 to 24h window', async () => {
+          await getMetricsOverview.handler({
+            params: { days: 1 },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20);
+        });
+
+        it('maps days=30 to 30d window', async () => {
+          await getMetricsOverview.handler({
+            params: { days: 30 },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockMetricsService.getTrending).toHaveBeenCalledWith('30d', 20);
+        });
+      });
+
+      // =========================================================================
+      // Metrics: getSearchAnalytics
+      // =========================================================================
+      describe('getSearchAnalytics', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getSearchAnalytics.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            getSearchAnalytics.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('returns analytics from admin service', async () => {
+          const result = await getSearchAnalytics.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(result.body).toMatchObject({ totalSearches: 100 });
+        });
+      });
+
+      // =========================================================================
+      // Metrics: getActivityCorrelation
+      // =========================================================================
+      describe('getActivityCorrelation', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getActivityCorrelation.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('returns empty metrics when activity service is not configured', async () => {
+          const ctx = {
+            get: vi.fn((key: string) => {
+              if (key === 'user') return adminUser;
+              if (key === 'services') return { activity: null };
+              if (key === 'logger') return mockLogger;
+              return undefined;
+            }),
+            set: vi.fn(),
+          };
+
+          const result = await getActivityCorrelation.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: ctx as never,
+          });
+          const body = result.body as { metrics: unknown[] };
+          expect(body.metrics).toEqual([]);
+        });
+
+        it('returns metrics from activity service', async () => {
+          const result = await getActivityCorrelation.handler({
+            params: undefined,
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as { metrics: unknown[] };
+          expect(body.metrics).toHaveLength(1);
+        });
+      });
+
+      // =========================================================================
+      // Metrics: getTrendingVelocity
+      // =========================================================================
+      describe('getTrendingVelocity', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getTrendingVelocity.handler({
+              params: {},
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('uses default window 24h and limit 20', async () => {
+          await getTrendingVelocity.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockMetricsService.getTrending).toHaveBeenCalledWith('24h', 20);
+        });
+
+        it('enriches entries with title and metrics', async () => {
+          mockMetricsService.getTrending.mockResolvedValueOnce([
+            { uri: 'at://test', score: 50, velocity: 0.5 },
+          ]);
+          mockEprintService.getEprint = vi.fn().mockResolvedValue({ title: 'Test Paper' });
+          mockMetricsService.getMetrics.mockResolvedValueOnce({
+            totalViews: 200,
+            totalDownloads: 30,
+          });
+
+          const result = await getTrendingVelocity.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as { items: { title: string; trend: string }[] };
+          expect(body.items[0]?.title).toBe('Test Paper');
+          expect(body.items[0]?.trend).toBe('rising');
+        });
+      });
+
+      // =========================================================================
+      // Metrics: getViewDownloadTimeSeries
+      // =========================================================================
+      describe('getViewDownloadTimeSeries', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getViewDownloadTimeSeries.handler({
+              params: {},
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            getViewDownloadTimeSeries.handler({
+              params: {},
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('passes uri and granularity to admin service', async () => {
+          await getViewDownloadTimeSeries.handler({
+            params: { uri: 'at://test', granularity: 'day' },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.getViewDownloadTimeSeries).toHaveBeenCalledWith(
+            'at://test',
+            'day'
+          );
+        });
+      });
+
+      // =========================================================================
+      // Governance: getAuditLog
+      // =========================================================================
+      describe('getAuditLog', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            getAuditLog.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            getAuditLog.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('uses default limit 50 and offset 0', async () => {
+          await getAuditLog.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.getAuditLog).toHaveBeenCalledWith(50, 0, undefined);
+        });
+
+        it('parses cursor as numeric offset and passes actorDid', async () => {
+          await getAuditLog.handler({
+            params: { limit: 10, cursor: '5', actorDid: 'did:plc:actor' },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.getAuditLog).toHaveBeenCalledWith(10, 5, 'did:plc:actor');
+        });
+
+        it('returns entries with cursor for pagination', async () => {
+          mockAdminService.getAuditLog.mockResolvedValueOnce({
+            entries: [{ id: '1' }],
+            total: 10,
+          });
+
+          const result = await getAuditLog.handler({
+            params: { limit: 1 },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as { entries: unknown[]; cursor: string; total: number };
+          expect(body.cursor).toBe('1');
+          expect(body.total).toBe(10);
+        });
+
+        it('returns undefined cursor when all entries have been returned', async () => {
+          mockAdminService.getAuditLog.mockResolvedValueOnce({
+            entries: [{ id: '1' }],
+            total: 1,
+          });
+
+          const result = await getAuditLog.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as { cursor: string | undefined };
+          expect(body.cursor).toBeUndefined();
+        });
+      });
+
+      // =========================================================================
+      // Governance: listWarnings
+      // =========================================================================
+      describe('listWarnings', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            listWarnings.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            listWarnings.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('uses default limit 50 and passes optional DID filter', async () => {
+          await listWarnings.handler({
+            params: { did: 'did:plc:offender' },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listWarnings).toHaveBeenCalledWith(50, 'did:plc:offender');
+        });
+
+        it('returns warnings', async () => {
+          const result = await listWarnings.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as { warnings: unknown[] };
+          expect(body.warnings).toHaveLength(1);
+        });
+      });
+
+      // =========================================================================
+      // Governance: listViolations
+      // =========================================================================
+      describe('listViolations', () => {
+        it('rejects non-admin users', async () => {
+          const ctx = buildContext(nonAdminUser);
+          await expect(
+            listViolations.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects missing admin service', async () => {
+          const ctx = buildContextWithoutAdmin(adminUser);
+          await expect(
+            listViolations.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
+          ).rejects.toThrow(ServiceUnavailableError);
+        });
+
+        it('uses default limit 50 and passes optional DID filter', async () => {
+          await listViolations.handler({
+            params: { limit: 25, did: 'did:plc:violator' },
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          expect(mockAdminService.listViolations).toHaveBeenCalledWith(25, 'did:plc:violator');
+        });
+
+        it('returns violations', async () => {
+          const result = await listViolations.handler({
+            params: {},
+            input: undefined,
+            auth: null,
+            c: mockContext as never,
+          });
+          const body = result.body as { violations: unknown[] };
+          expect(body.violations).toHaveLength(1);
+        });
+      });
+
+      // =========================================================================
+      // Null user (no auth at all)
+      // =========================================================================
+      describe('null user auth checks', () => {
+        it('rejects null user for getOverview', async () => {
+          const ctx = buildContext(null);
+          await expect(
+            getOverview.handler({
+              params: undefined,
+              input: undefined,
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects null user for assignRole', async () => {
+          const ctx = buildContext(null);
+          await expect(
+            assignRole.handler({
+              params: undefined,
+              input: { did: 'did:plc:x', role: 'admin' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+
+        it('rejects null user for deleteContent', async () => {
+          const ctx = buildContext(null);
+          await expect(
+            deleteContent.handler({
+              params: undefined,
+              input: { uri: 'at://x', collection: 'pub.chive.eprint.submission' },
+              auth: null,
+              c: ctx as never,
+            })
+          ).rejects.toThrow(AuthorizationError);
+        });
+      });
+    });
+
+    // ===========================================================================
+    // actor.getMyRoles
+    // ===========================================================================
+    describe('XRPC actor.getMyRoles', () => {
+      let mockLogger: ILogger;
+      let mockRedis: MockRedis;
+
+      beforeEach(() => {
+        vi.clearAllMocks();
+        mockLogger = createMockLogger();
+        mockRedis = createMockRedis();
+      });
+
+      function buildCtx(user: { did: string; isAdmin?: boolean } | null): {
+        get: ReturnType<typeof vi.fn>;
+        set: ReturnType<typeof vi.fn>;
+      } {
+        return {
+          get: vi.fn((key: string) => {
+            if (key === 'user') return user;
+            if (key === 'logger') return mockLogger;
+            if (key === 'redis') return mockRedis;
+            return undefined;
+          }),
+          set: vi.fn(),
+        };
+      }
+
+      it('throws AuthenticationError when user is not authenticated', async () => {
+        const ctx = buildCtx(null);
+        await expect(
+          getMyRoles.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
+        ).rejects.toThrow('Authentication required');
+      });
+
+      it('throws AuthenticationError when user has no DID', async () => {
+        const ctx = buildCtx({ did: '' });
+        await expect(
+          getMyRoles.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
+        ).rejects.toThrow('Authentication required');
+      });
+
+      it('returns roles from Redis', async () => {
+        mockRedis.smembers.mockResolvedValueOnce(['reader', 'alpha-tester']);
+        const ctx = buildCtx({ did: 'did:plc:user1' });
+
+        const result = await getMyRoles.handler({
+          params: undefined,
           input: undefined,
           auth: null,
           c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
+        });
+        expect(mockRedis.smembers).toHaveBeenCalledWith('chive:authz:roles:did:plc:user1');
+        expect(result.body.roles).toEqual(['reader', 'alpha-tester']);
+        expect(result.body.isAdmin).toBe(false);
+        expect(result.body.isAlphaTester).toBe(true);
+        expect(result.body.isPremium).toBe(false);
+      });
 
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        getViewDownloadTimeSeries.handler({
-          params: {},
+      it('sets isAdmin true when user has admin role', async () => {
+        mockRedis.smembers.mockResolvedValueOnce(['admin']);
+        const ctx = buildCtx({ did: 'did:plc:admin1' });
+
+        const result = await getMyRoles.handler({
+          params: undefined,
           input: undefined,
           auth: null,
           c: ctx as never,
-        })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('passes uri and granularity to admin service', async () => {
-      await getViewDownloadTimeSeries.handler({
-        params: { uri: 'at://test', granularity: 'day' },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.getViewDownloadTimeSeries).toHaveBeenCalledWith('at://test', 'day');
-    });
-  });
-
-  // =========================================================================
-  // Governance: getAuditLog
-  // =========================================================================
-  describe('getAuditLog', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        getAuditLog.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        getAuditLog.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('uses default limit 50 and offset 0', async () => {
-      await getAuditLog.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.getAuditLog).toHaveBeenCalledWith(50, 0, undefined);
-    });
-
-    it('parses cursor as numeric offset and passes actorDid', async () => {
-      await getAuditLog.handler({
-        params: { limit: 10, cursor: '5', actorDid: 'did:plc:actor' },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.getAuditLog).toHaveBeenCalledWith(10, 5, 'did:plc:actor');
-    });
-
-    it('returns entries with cursor for pagination', async () => {
-      mockAdminService.getAuditLog.mockResolvedValueOnce({
-        entries: [{ id: '1' }],
-        total: 10,
+        });
+        expect(result.body.isAdmin).toBe(true);
+        expect(result.body.isAlphaTester).toBe(true);
+        expect(result.body.isPremium).toBe(true);
       });
 
-      const result = await getAuditLog.handler({
-        params: { limit: 1 },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      const body = result.body as { entries: unknown[]; cursor: string; total: number };
-      expect(body.cursor).toBe('1');
-      expect(body.total).toBe(10);
-    });
+      it('returns empty roles when user has none', async () => {
+        mockRedis.smembers.mockResolvedValueOnce([]);
+        const ctx = buildCtx({ did: 'did:plc:empty' });
 
-    it('returns undefined cursor when all entries have been returned', async () => {
-      mockAdminService.getAuditLog.mockResolvedValueOnce({
-        entries: [{ id: '1' }],
-        total: 1,
-      });
-
-      const result = await getAuditLog.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      const body = result.body as { cursor: string | undefined };
-      expect(body.cursor).toBeUndefined();
-    });
-  });
-
-  // =========================================================================
-  // Governance: listWarnings
-  // =========================================================================
-  describe('listWarnings', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        listWarnings.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        listWarnings.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('uses default limit 50 and passes optional DID filter', async () => {
-      await listWarnings.handler({
-        params: { did: 'did:plc:offender' },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listWarnings).toHaveBeenCalledWith(50, 'did:plc:offender');
-    });
-
-    it('returns warnings', async () => {
-      const result = await listWarnings.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      const body = result.body as { warnings: unknown[] };
-      expect(body.warnings).toHaveLength(1);
-    });
-  });
-
-  // =========================================================================
-  // Governance: listViolations
-  // =========================================================================
-  describe('listViolations', () => {
-    it('rejects non-admin users', async () => {
-      const ctx = buildContext(nonAdminUser);
-      await expect(
-        listViolations.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects missing admin service', async () => {
-      const ctx = buildContextWithoutAdmin(adminUser);
-      await expect(
-        listViolations.handler({ params: {}, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(ServiceUnavailableError);
-    });
-
-    it('uses default limit 50 and passes optional DID filter', async () => {
-      await listViolations.handler({
-        params: { limit: 25, did: 'did:plc:violator' },
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockAdminService.listViolations).toHaveBeenCalledWith(25, 'did:plc:violator');
-    });
-
-    it('returns violations', async () => {
-      const result = await listViolations.handler({
-        params: {},
-        input: undefined,
-        auth: null,
-        c: mockContext as never,
-      });
-      const body = result.body as { violations: unknown[] };
-      expect(body.violations).toHaveLength(1);
-    });
-  });
-
-  // =========================================================================
-  // Null user (no auth at all)
-  // =========================================================================
-  describe('null user auth checks', () => {
-    it('rejects null user for getOverview', async () => {
-      const ctx = buildContext(null);
-      await expect(
-        getOverview.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
-      ).rejects.toThrow(AuthorizationError);
-    });
-
-    it('rejects null user for assignRole', async () => {
-      const ctx = buildContext(null);
-      await expect(
-        assignRole.handler({
+        const result = await getMyRoles.handler({
           params: undefined,
-          input: { did: 'did:plc:x', role: 'admin' },
+          input: undefined,
           auth: null,
           c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
-    });
+        });
+        expect(result.body.roles).toEqual([]);
+        expect(result.body.isAdmin).toBe(false);
+        expect(result.body.isAlphaTester).toBe(false);
+        expect(result.body.isPremium).toBe(false);
+      });
 
-    it('rejects null user for deleteContent', async () => {
-      const ctx = buildContext(null);
-      await expect(
-        deleteContent.handler({
+      it('grants premium access to admin users', async () => {
+        mockRedis.smembers.mockResolvedValueOnce(['admin']);
+        const ctx = buildCtx({ did: 'did:plc:admin2' });
+
+        const result = await getMyRoles.handler({
           params: undefined,
-          input: { uri: 'at://x', collection: 'pub.chive.eprint.submission' },
+          input: undefined,
           auth: null,
           c: ctx as never,
-        })
-      ).rejects.toThrow(AuthorizationError);
+        });
+        expect(result.body.isPremium).toBe(true);
+      });
     });
-  });
-});
-
-// ===========================================================================
-// actor.getMyRoles
-// ===========================================================================
-describe('XRPC actor.getMyRoles', () => {
-  let mockLogger: ILogger;
-  let mockRedis: MockRedis;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockLogger = createMockLogger();
-    mockRedis = createMockRedis();
-  });
-
-  function buildCtx(user: { did: string; isAdmin?: boolean } | null): {
-    get: ReturnType<typeof vi.fn>;
-    set: ReturnType<typeof vi.fn>;
-  } {
-    return {
-      get: vi.fn((key: string) => {
-        if (key === 'user') return user;
-        if (key === 'logger') return mockLogger;
-        if (key === 'redis') return mockRedis;
-        return undefined;
-      }),
-      set: vi.fn(),
-    };
-  }
-
-  it('throws AuthenticationError when user is not authenticated', async () => {
-    const ctx = buildCtx(null);
-    await expect(
-      getMyRoles.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
-    ).rejects.toThrow('Authentication required');
-  });
-
-  it('throws AuthenticationError when user has no DID', async () => {
-    const ctx = buildCtx({ did: '' });
-    await expect(
-      getMyRoles.handler({ params: undefined, input: undefined, auth: null, c: ctx as never })
-    ).rejects.toThrow('Authentication required');
-  });
-
-  it('returns roles from Redis', async () => {
-    mockRedis.smembers.mockResolvedValueOnce(['reader', 'alpha-tester']);
-    const ctx = buildCtx({ did: 'did:plc:user1' });
-
-    const result = await getMyRoles.handler({
-      params: undefined,
-      input: undefined,
-      auth: null,
-      c: ctx as never,
-    });
-    expect(mockRedis.smembers).toHaveBeenCalledWith('chive:authz:roles:did:plc:user1');
-    expect(result.body.roles).toEqual(['reader', 'alpha-tester']);
-    expect(result.body.isAdmin).toBe(false);
-    expect(result.body.isAlphaTester).toBe(true);
-    expect(result.body.isPremium).toBe(false);
-  });
-
-  it('sets isAdmin true when user has admin role', async () => {
-    mockRedis.smembers.mockResolvedValueOnce(['admin']);
-    const ctx = buildCtx({ did: 'did:plc:admin1' });
-
-    const result = await getMyRoles.handler({
-      params: undefined,
-      input: undefined,
-      auth: null,
-      c: ctx as never,
-    });
-    expect(result.body.isAdmin).toBe(true);
-    expect(result.body.isAlphaTester).toBe(true);
-    expect(result.body.isPremium).toBe(true);
-  });
-
-  it('returns empty roles when user has none', async () => {
-    mockRedis.smembers.mockResolvedValueOnce([]);
-    const ctx = buildCtx({ did: 'did:plc:empty' });
-
-    const result = await getMyRoles.handler({
-      params: undefined,
-      input: undefined,
-      auth: null,
-      c: ctx as never,
-    });
-    expect(result.body.roles).toEqual([]);
-    expect(result.body.isAdmin).toBe(false);
-    expect(result.body.isAlphaTester).toBe(false);
-    expect(result.body.isPremium).toBe(false);
-  });
-
-  it('grants premium access to admin users', async () => {
-    mockRedis.smembers.mockResolvedValueOnce(['admin']);
-    const ctx = buildCtx({ did: 'did:plc:admin2' });
-
-    const result = await getMyRoles.handler({
-      params: undefined,
-      input: undefined,
-      auth: null,
-      c: ctx as never,
-    });
-    expect(result.body.isPremium).toBe(true);
   });
 });

--- a/tests/unit/services/admin/admin-service.test.ts
+++ b/tests/unit/services/admin/admin-service.test.ts
@@ -1363,16 +1363,16 @@ describe('AdminService', () => {
       expect(dataCall?.[1]).toContain('did:plc:editor');
     });
 
-    it('returns empty result when table does not exist', async () => {
-      mockPool.query.mockRejectedValue(new Error('relation "governance_audit_log" does not exist'));
+    it('surfaces a query failure instead of reporting an empty log', async () => {
+      // This used to assert the opposite: any error became `{ entries: [],
+      // total: 0 }` with a warning naming a missing table. The error was not a
+      // missing table — the query selected two columns that did not exist — so
+      // the endpoint reported "no audit entries" forever and the warning sent
+      // anyone investigating to look for a table that was there all along.
+      mockPool.query.mockRejectedValue(new Error('column g.target_did does not exist'));
 
-      const result = await service.getAuditLog(10, 0);
-
-      expect(result.entries).toEqual([]);
-      expect(result.total).toBe(0);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'governance_audit_log table not available; returning empty result'
-      );
+      await expect(service.getAuditLog(10, 0)).rejects.toThrow(/target_did/);
+      expect(mockLogger.error).toHaveBeenCalled();
     });
 
     it('returns entries without actorDid filter', async () => {


### PR DESCRIPTION
SEC-13, plus two bugs found on the way that made the endpoint unusable.

## `pub.chive.admin.getAuditLog` failed on every call

`AdminService.getAuditLog` selects `g.target_did` and `g.ip_address`. **Neither column exists.** Verified directly:

```
ERROR:  column g.target_did does not exist
```

The failure was invisible because the catch around it returned `{ entries: [], total: 0 }` and logged `governance_audit_log table not available`. So the endpoint reported an empty audit log forever, and the message sent anyone investigating to look for a missing *table* — which was there the whole time.

**A second, independent bug in the same method:** the count query reads `FROM governance_audit_log ${whereClause}` with no alias, while `whereClause` is written against `g` and shared with the data query. Any call that filtered by actor failed with `missing FROM-clause entry for table "g"`. Both paths to a row were broken.

The catch no longer swallows: it logs the real error and rethrows. **An existing unit test asserted the swallowing behaviour** (`returns empty result when table does not exist`) and has been rewritten to require the failure to surface — that test is why the bug survived.

## The two actions an audit log exists for were never recorded (SEC-13)

Role grants wrote a Redis `SET` under an assignment key. Content deletions published to `chive:admin:content-deleted`, a channel with no subscriber. Neither reached `governance_audit_log`, so even a working `getAuditLog` had nothing to show.

`AdminService.recordAuditEntry` now writes them, called from `assignRole` and `deleteContent` with the actor, the target, and the caller's address.

A failure to write is logged and swallowed — deliberately, and this is the one place that trade-off is right: the alternative is failing the administrative action because its record could not be written, which would mean an unwritable log stops moderation entirely.

## Migration

`1742000000000_admin-audit-log-columns.ts` adds `target_did` and `ip_address` (both nullable — governance rows written earlier have neither, and back-filling would be inventing a value) and widens the `action` CHECK, which admitted only `create`/`update`/`delete` and so could not name an administrative action at all.

The `down` migration deletes rows carrying the new actions before restoring the narrower constraint. That loses audit history, which is why it exists only to make the `up` reversible in testing — the comment says so in the file.

## Testing

Six integration tests in `tests/integration/services/admin-audit-log.test.ts`, against a real PostgreSQL, because both bugs were in SQL against a real schema and a mocked pool cannot catch either. They cover the read not throwing, a recorded role grant round-tripping with its target and address, a content deletion, an entry with neither optional field, the actor filter (the path that hit the alias bug), and newest-first ordering.

Two unit tests assert the handlers actually call `recordAuditEntry`.

- Unit: 210 files pass
- Integration: 33 passed, 1 skipped
- Compliance: 14/14
- `tsc --noEmit` clean, lint clean

## Compliance

Writes only to Chive's own audit table. No user PDS involvement.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source