### PR TITLE
Add unit tests for the cursor, the queue, the dead letter queue, and the service auth verifier

### DIFF
--- a/tests/unit/auth/service-auth/service-auth-verifier.test.ts
+++ b/tests/unit/auth/service-auth/service-auth-verifier.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for ServiceAuthVerifier.
+ *
+ * @remarks
+ * This is the trust boundary: whatever this returns becomes the caller's
+ * identity for the rest of the request. It had no unit test at all, which is
+ * the same gap that let SEC-3 — a token minted for one lexicon method being
+ * accepted for any other — go unnoticed until 0.8.0.
+ *
+ * `verifyJwt` from `@atproto/xrpc-server` is mocked: what is under test is what
+ * Chive asks it to check and what Chive does with the answer, not the ATProto
+ * library's cryptography.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const verifyJwt = vi.fn();
+
+vi.mock('@atproto/xrpc-server', () => ({
+  verifyJwt: (...args: unknown[]): unknown => verifyJwt(...args) as unknown,
+  cryptoVerifySignatureWithKey: vi.fn(),
+}));
+
+vi.mock('@atproto/identity', () => ({
+  IdResolver: class {
+    did = { resolveAtprotoKey: vi.fn().mockResolvedValue('did:key:zTestSigningKey') };
+  },
+}));
+
+const { ServiceAuthVerifier } = await import('@/auth/service-auth/service-auth-verifier.js');
+
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+function createLogger(): ILogger {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+const SERVICE_DID = 'did:web:api.chive.pub';
+
+function build(): InstanceType<typeof ServiceAuthVerifier> {
+  return new ServiceAuthVerifier({
+    logger: createLogger(),
+    config: { serviceDid: SERVICE_DID },
+  } as never);
+}
+
+describe('ServiceAuthVerifier', () => {
+  beforeEach(() => {
+    verifyJwt.mockReset();
+  });
+
+  it('returns the issuing DID as the caller identity', async () => {
+    verifyJwt.mockResolvedValue({
+      iss: 'did:plc:caller',
+      aud: SERVICE_DID,
+      lxm: 'pub.chive.eprint.getSubmission',
+      exp: 1893456000,
+    });
+
+    const result = await build().verify('a.jwt.string');
+
+    expect(result).toEqual({
+      did: 'did:plc:caller',
+      lxm: 'pub.chive.eprint.getSubmission',
+      exp: 1893456000,
+    });
+  });
+
+  it('checks the audience against this service', async () => {
+    // A token minted for a different service must not be accepted here. The
+    // audience is passed to verifyJwt rather than checked afterwards, so the
+    // test asserts on the argument.
+    verifyJwt.mockResolvedValue({ iss: 'did:plc:caller', aud: SERVICE_DID, exp: 1 });
+
+    await build().verify('a.jwt.string');
+
+    expect(verifyJwt).toHaveBeenCalledWith(
+      'a.jwt.string',
+      SERVICE_DID,
+      null,
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it('checks the lexicon method when one is given', async () => {
+    // This is SEC-3: without the lxm argument, a token minted for a read is
+    // accepted for a write.
+    verifyJwt.mockResolvedValue({ iss: 'did:plc:caller', aud: SERVICE_DID, exp: 1 });
+
+    await build().verify('a.jwt.string', 'pub.chive.eprint.deleteSubmission');
+
+    expect(verifyJwt).toHaveBeenCalledWith(
+      'a.jwt.string',
+      SERVICE_DID,
+      'pub.chive.eprint.deleteSubmission',
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it('returns null rather than throwing when verification fails', async () => {
+    // The middleware treats null as "unauthenticated". An exception escaping
+    // here would surface as a 500 and tell a caller their token broke the
+    // server rather than that it was rejected.
+    verifyJwt.mockRejectedValue(new Error('bad signature'));
+
+    expect(await build().verify('a.jwt.string')).toBeNull();
+  });
+
+  it('returns null for an expired token', async () => {
+    verifyJwt.mockRejectedValue(new Error('jwt expired'));
+
+    expect(await build().verify('a.jwt.string')).toBeNull();
+  });
+
+  it('returns null when the signing key cannot be resolved', async () => {
+    verifyJwt.mockRejectedValue(new Error('could not resolve did'));
+
+    expect(await build().verify('a.jwt.string')).toBeNull();
+  });
+
+  it('never returns a partially verified identity', async () => {
+    // Any failure path must yield null, not an object with the DID filled in
+    // from an unverified token.
+    for (const failure of ['bad signature', 'jwt expired', 'wrong audience', 'bad lxm']) {
+      verifyJwt.mockRejectedValueOnce(new Error(failure));
+      expect(await build().verify('a.jwt.string'), failure).toBeNull();
+    }
+  });
+});

--- a/tests/unit/services/indexing/cursor-manager.test.ts
+++ b/tests/unit/services/indexing/cursor-manager.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Unit tests for CursorManager.
+ *
+ * @remarks
+ * The cursor decides where the firehose resumes after a restart. Losing it
+ * means replaying from the beginning; advancing it past unprocessed events
+ * means never seeing them again. It had no unit test at all.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+import { CursorManager } from '@/services/indexing/cursor-manager.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+function createLogger(): ILogger {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+function createDb(rows: Record<string, unknown>[] = []): {
+  query: ReturnType<typeof vi.fn>;
+} {
+  return { query: vi.fn().mockResolvedValue({ rows }) };
+}
+
+function createRedis(cached: string | null = null): {
+  get: ReturnType<typeof vi.fn>;
+  setex: ReturnType<typeof vi.fn>;
+} {
+  return {
+    get: vi.fn().mockResolvedValue(cached),
+    setex: vi.fn().mockResolvedValue('OK'),
+  };
+}
+
+function build(
+  db: ReturnType<typeof createDb>,
+  redis: ReturnType<typeof createRedis>,
+  overrides: Record<string, unknown> = {}
+): CursorManager {
+  return new CursorManager({
+    db: db as never,
+    redis: redis as never,
+    serviceName: 'indexer',
+    logger: createLogger(),
+    ...overrides,
+  });
+}
+
+describe('CursorManager', () => {
+  let managers: CursorManager[];
+
+  beforeEach(() => {
+    managers = [];
+  });
+
+  afterEach(async () => {
+    // Every instance starts a periodic timer in its constructor; leaving them
+    // running leaks handles across the suite.
+    for (const m of managers) {
+      await m.close().catch(() => {
+        // A test that made a flush fail leaves the cursor pending; teardown
+        // only needs the timer stopped.
+      });
+    }
+  });
+
+  function track(m: CursorManager): CursorManager {
+    managers.push(m);
+    return m;
+  }
+
+  describe('getCurrentCursor', () => {
+    it('returns null on a first run, rather than a zero the caller might resume from', async () => {
+      const db = createDb([]);
+      const manager = track(build(db, createRedis(null)));
+
+      expect(await manager.getCurrentCursor()).toBeNull();
+    });
+
+    it('reads the cache without touching the database', async () => {
+      const db = createDb([]);
+      const manager = track(build(db, createRedis('4200')));
+
+      const cursor = await manager.getCurrentCursor();
+
+      expect(cursor?.seq).toBe(4200);
+      expect(cursor?.fromCache).toBe(true);
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it('falls back to PostgreSQL, which is authoritative', async () => {
+      const updated = new Date('2026-01-01T00:00:00Z');
+      const db = createDb([{ cursor_seq: 99, last_updated: updated }]);
+      const redis = createRedis(null);
+      const manager = track(build(db, redis));
+
+      const cursor = await manager.getCurrentCursor();
+
+      expect(cursor).toMatchObject({ seq: 99, fromCache: false, lastUpdated: updated });
+      expect(redis.setex).toHaveBeenCalledWith(expect.stringContaining('indexer'), 3600, '99');
+    });
+
+    it('ignores a cache entry that is not a number', async () => {
+      // A corrupt cache value must not become a cursor position; resuming from
+      // NaN would either replay everything or skip everything.
+      const db = createDb([{ cursor_seq: 7, last_updated: new Date() }]);
+      const manager = track(build(db, createRedis('not-a-number')));
+
+      const cursor = await manager.getCurrentCursor();
+
+      expect(cursor?.seq).toBe(7);
+      expect(cursor?.fromCache).toBe(false);
+    });
+
+    it('scopes the cache key to the service', async () => {
+      const redis = createRedis(null);
+      const manager = track(
+        build(createDb([{ cursor_seq: 1, last_updated: new Date() }]), redis, {
+          serviceName: 'other-consumer',
+        })
+      );
+
+      await manager.getCurrentCursor();
+
+      expect(redis.setex).toHaveBeenCalledWith(
+        expect.stringContaining('other-consumer'),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('updateCursor', () => {
+    it('batches rather than writing on every event', async () => {
+      const db = createDb();
+      const manager = track(build(db, createRedis(), { batchSize: 10 }));
+
+      for (let i = 1; i <= 5; i += 1) await manager.updateCursor(i);
+
+      expect(db.query).not.toHaveBeenCalled();
+      expect(manager.getPendingCursor()).toBe(5);
+      expect(manager.getEventCount()).toBe(5);
+    });
+
+    it('flushes once the batch size is reached', async () => {
+      const db = createDb();
+      const manager = track(build(db, createRedis(), { batchSize: 3 }));
+
+      await manager.updateCursor(1);
+      await manager.updateCursor(2);
+      expect(db.query).not.toHaveBeenCalled();
+
+      await manager.updateCursor(3);
+      expect(db.query).toHaveBeenCalledTimes(1);
+      expect(manager.getEventCount()).toBe(0);
+    });
+  });
+
+  describe('flush', () => {
+    it('does nothing when there is no pending cursor', async () => {
+      const db = createDb();
+      const manager = track(build(db, createRedis()));
+
+      await manager.flush();
+
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it('does not rewrite an unchanged cursor', async () => {
+      const db = createDb();
+      const manager = track(build(db, createRedis(), { batchSize: 1000 }));
+
+      await manager.updateCursor(42);
+      await manager.flush();
+      await manager.flush();
+
+      expect(db.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('upserts, so a restart cannot duplicate the row', async () => {
+      const db = createDb();
+      const manager = track(build(db, createRedis(), { batchSize: 1000 }));
+
+      await manager.updateCursor(77);
+      await manager.flush();
+
+      const [sql, params] = db.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('ON CONFLICT');
+      expect(params).toEqual(['indexer', 77]);
+    });
+
+    it('writes the database before the cache', async () => {
+      // PostgreSQL is authoritative. Caching a position that failed to persist
+      // would let a restart resume past events that were never recorded.
+      const order: string[] = [];
+      const db = {
+        query: vi.fn(() => {
+          order.push('db');
+          return Promise.resolve({ rows: [] });
+        }),
+      };
+      const redis = {
+        get: vi.fn().mockResolvedValue(null),
+        setex: vi.fn(() => {
+          order.push('redis');
+          return Promise.resolve('OK');
+        }),
+      };
+      const manager = track(build(db as never, redis as never, { batchSize: 1000 }));
+
+      await manager.updateCursor(5);
+      await manager.flush();
+
+      expect(order).toEqual(['db', 'redis']);
+    });
+
+    it('leaves the cursor unsaved when the database write fails', async () => {
+      // Rejects once, then succeeds, so teardown's final flush can complete;
+      // the assertions below are about the state left by the failed attempt.
+      const db = {
+        query: vi
+          .fn()
+          .mockRejectedValueOnce(new Error('write failed'))
+          .mockResolvedValue({ rows: [] }),
+      };
+      const redis = createRedis();
+      const manager = track(build(db as never, redis, { batchSize: 1000 }));
+
+      await manager.updateCursor(11);
+      await expect(manager.flush()).rejects.toThrow('write failed');
+
+      // The cache must not advance past a position the database rejected.
+      expect(redis.setex).not.toHaveBeenCalled();
+      expect(manager.getPendingCursor()).toBe(11);
+    });
+  });
+
+  describe('close', () => {
+    it('flushes the pending cursor, so a shutdown does not lose position', async () => {
+      const db = createDb();
+      const manager = build(db, createRedis(), { batchSize: 1000 });
+
+      await manager.updateCursor(123);
+      await manager.close();
+
+      expect(db.query).toHaveBeenCalledTimes(1);
+      expect((db.query.mock.calls[0] as [string, unknown[]])[1]).toEqual(['indexer', 123]);
+    });
+
+    it('stops the periodic timer', async () => {
+      vi.useFakeTimers();
+      try {
+        const db = createDb();
+        const manager = build(db, createRedis(), { batchSize: 1000, flushInterval: 1000 });
+
+        await manager.updateCursor(1);
+        await manager.close();
+        db.query.mockClear();
+
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(db.query).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/tests/unit/services/indexing/dlq-handler.test.ts
+++ b/tests/unit/services/indexing/dlq-handler.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for DeadLetterQueue.
+ *
+ * @remarks
+ * The DLQ is where firehose events go when indexing them fails. If it drops an
+ * event, that record is never indexed and nothing says so; if a retry deletes
+ * an entry it did not actually reprocess, the same. It had no unit test.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { DeadLetterQueue } from '@/services/indexing/dlq-handler.js';
+import type { DLQEvent } from '@/services/indexing/dlq-handler.js';
+
+function createDb(): { query: ReturnType<typeof vi.fn> } {
+  return { query: vi.fn().mockResolvedValue({ rows: [{ id: 1 }] }) };
+}
+
+function createAlerts(): { send: ReturnType<typeof vi.fn> } {
+  return { send: vi.fn().mockResolvedValue(undefined) };
+}
+
+const EVENT: DLQEvent = {
+  seq: 42,
+  repo: 'did:plc:someone',
+  $type: 'commit',
+} as DLQEvent;
+
+function build(
+  db: ReturnType<typeof createDb>,
+  alerts: ReturnType<typeof createAlerts>,
+  overrides: Record<string, unknown> = {}
+): DeadLetterQueue {
+  return new DeadLetterQueue({ db: db as never, alerts: alerts as never, ...overrides });
+}
+
+describe('DeadLetterQueue', () => {
+  describe('add', () => {
+    it('records the event, the error and the retry count', async () => {
+      const db = createDb();
+      const dlq = build(db, createAlerts());
+
+      const id = await dlq.add(EVENT, new Error('indexing blew up'), 2);
+
+      expect(id).toBe(1);
+      const [sql, params] = db.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('INSERT INTO firehose_dlq');
+      expect(params[0]).toBe(42);
+      expect(params[1]).toBe('did:plc:someone');
+      expect(params[4]).toBe('indexing blew up');
+      expect(params[6]).toBe(2);
+    });
+
+    it('stores the whole event, so a retry has something to replay', async () => {
+      const db = createDb();
+      const dlq = build(db, createAlerts());
+
+      await dlq.add(EVENT, new Error('boom'));
+
+      const params = (db.query.mock.calls[0] as [string, unknown[]])[1];
+      expect(JSON.parse(params[3] as string)).toMatchObject({ seq: 42, $type: 'commit' });
+    });
+
+    it('throws when the insert returns no id rather than reporting success', async () => {
+      // A silent failure here loses the event outright: the caller believes it
+      // is queued for retry and it is not in the table.
+      const db = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+      const dlq = build(db as never, createAlerts());
+
+      await expect(dlq.add(EVENT, new Error('boom'))).rejects.toThrow(/no ID returned/);
+    });
+
+    it('classifies the error so retries can be targeted', async () => {
+      const db = createDb();
+      const classifier = { classify: vi.fn().mockReturnValue('permanent') };
+      const dlq = build(db, createAlerts(), { classifier });
+
+      await dlq.add(EVENT, new Error('bad record'));
+
+      expect(classifier.classify).toHaveBeenCalled();
+      expect((db.query.mock.calls[0] as [string, unknown[]])[1][5]).toBe('permanent');
+    });
+  });
+
+  describe('retry', () => {
+    it('removes the entry only after the processor succeeds', async () => {
+      const db = {
+        query: vi
+          .fn()
+          .mockResolvedValueOnce({ rows: [{ event_data: JSON.stringify(EVENT), retry_count: 0 }] })
+          .mockResolvedValue({ rows: [] }),
+      };
+      const dlq = build(db as never, createAlerts());
+
+      const processor = vi.fn().mockResolvedValue(undefined);
+      expect(await dlq.retry(1, processor)).toBe(true);
+
+      expect(processor).toHaveBeenCalledWith(expect.objectContaining({ seq: 42 }));
+      expect((db.query.mock.calls[1] as [string])[0]).toContain('DELETE FROM firehose_dlq');
+    });
+
+    it('keeps the entry and increments the count when the processor fails', async () => {
+      const db = {
+        query: vi
+          .fn()
+          .mockResolvedValueOnce({ rows: [{ event_data: JSON.stringify(EVENT), retry_count: 3 }] })
+          .mockResolvedValue({ rows: [] }),
+      };
+      const dlq = build(db as never, createAlerts());
+
+      expect(await dlq.retry(1, vi.fn().mockRejectedValue(new Error('still broken')))).toBe(false);
+
+      const [sql, params] = db.query.mock.calls[1] as [string, unknown[]];
+      expect(sql).toContain('UPDATE firehose_dlq');
+      expect(sql).not.toContain('DELETE');
+      expect(params[0]).toBe(4);
+    });
+
+    it('reports a missing entry rather than silently succeeding', async () => {
+      const db = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+      const dlq = build(db as never, createAlerts());
+
+      await expect(dlq.retry(999, vi.fn())).rejects.toThrow();
+    });
+
+    it('accepts an already-parsed JSONB column', async () => {
+      // The pg driver parses jsonb itself; treating the value as a string would
+      // throw and turn every retry into a failure.
+      const db = {
+        query: vi
+          .fn()
+          .mockResolvedValueOnce({ rows: [{ event_data: EVENT, retry_count: 0 }] })
+          .mockResolvedValue({ rows: [] }),
+      };
+      const dlq = build(db as never, createAlerts());
+
+      const processor = vi.fn().mockResolvedValue(undefined);
+      expect(await dlq.retry(1, processor)).toBe(true);
+      expect(processor).toHaveBeenCalledWith(expect.objectContaining({ seq: 42 }));
+    });
+  });
+});

--- a/tests/unit/services/indexing/event-queue.test.ts
+++ b/tests/unit/services/indexing/event-queue.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for EventQueue.
+ *
+ * @remarks
+ * The queue sits between the firehose and the indexer. Two of its properties
+ * decide whether events are lost: backpressure, which stops an unbounded queue
+ * exhausting memory, and the hand-off to the dead letter queue when a job has
+ * exhausted its retries. Neither had a test.
+ *
+ * BullMQ is mocked because it opens a Redis connection in its constructor; what
+ * is under test is Chive's logic around it, not BullMQ.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const queueState = {
+  waiting: 0,
+  active: 0,
+  delayed: 0,
+  added: [] as { name: string; data: unknown; opts: unknown }[],
+};
+
+const workerHandlers = new Map<string, (job: unknown, error: unknown) => void>();
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add(name: string, data: unknown, opts: unknown): Promise<void> {
+      queueState.added.push({ name, data, opts });
+      return Promise.resolve();
+    }
+    getWaitingCount(): Promise<number> {
+      return Promise.resolve(queueState.waiting);
+    }
+    getActiveCount(): Promise<number> {
+      return Promise.resolve(queueState.active);
+    }
+    getDelayedCount(): Promise<number> {
+      return Promise.resolve(queueState.delayed);
+    }
+    getCompletedCount(): Promise<number> {
+      return Promise.resolve(0);
+    }
+    getFailedCount(): Promise<number> {
+      return Promise.resolve(0);
+    }
+    pause(): Promise<void> {
+      return Promise.resolve();
+    }
+    resume(): Promise<void> {
+      return Promise.resolve();
+    }
+    drain(): Promise<void> {
+      return Promise.resolve();
+    }
+    close(): Promise<void> {
+      return Promise.resolve();
+    }
+    obliterate(): Promise<void> {
+      return Promise.resolve();
+    }
+  },
+  Worker: class {
+    on(event: string, handler: (job: unknown, error: unknown) => void): void {
+      workerHandlers.set(event, handler);
+    }
+    pause(): Promise<void> {
+      return Promise.resolve();
+    }
+    resume(): void {
+      return;
+    }
+    close(): Promise<void> {
+      return Promise.resolve();
+    }
+  },
+  QueueEvents: class {
+    on(): void {
+      return;
+    }
+    close(): Promise<void> {
+      return Promise.resolve();
+    }
+  },
+}));
+
+const { EventQueue, BackpressureError } = await import('@/services/indexing/event-queue.js');
+
+function createDlq(): { add: ReturnType<typeof vi.fn> } {
+  return { add: vi.fn().mockResolvedValue(1) };
+}
+
+function build(dlq: ReturnType<typeof createDlq>, overrides: Record<string, unknown> = {}) {
+  return new EventQueue({
+    redis: {} as never,
+    processor: vi.fn(),
+    dlq: dlq as never,
+    ...overrides,
+  });
+}
+
+const EVENT = { seq: 1, repo: 'did:plc:x', $type: 'commit' } as never;
+
+describe('EventQueue', () => {
+  beforeEach(() => {
+    queueState.waiting = 0;
+    queueState.active = 0;
+    queueState.delayed = 0;
+    queueState.added = [];
+    workerHandlers.clear();
+  });
+
+  describe('backpressure', () => {
+    it('accepts events below the threshold', async () => {
+      queueState.waiting = 5;
+      const queue = build(createDlq(), { maxQueueDepth: 10 });
+
+      await queue.add(EVENT);
+
+      expect(queueState.added).toHaveLength(1);
+    });
+
+    it('refuses events at the threshold rather than growing without bound', async () => {
+      queueState.waiting = 10;
+      const queue = build(createDlq(), { maxQueueDepth: 10 });
+
+      await expect(queue.add(EVENT)).rejects.toBeInstanceOf(BackpressureError);
+      expect(queueState.added).toHaveLength(0);
+    });
+
+    it('counts waiting, active and delayed jobs toward the depth', async () => {
+      // Counting only waiting jobs would let the queue hold three times the
+      // configured maximum before it refused anything.
+      queueState.waiting = 4;
+      queueState.active = 4;
+      queueState.delayed = 4;
+      const queue = build(createDlq(), { maxQueueDepth: 10 });
+
+      await expect(queue.add(EVENT)).rejects.toBeInstanceOf(BackpressureError);
+    });
+
+    it('reports the depth and the limit on the error', async () => {
+      queueState.waiting = 12;
+      const queue = build(createDlq(), { maxQueueDepth: 10 });
+
+      await expect(queue.add(EVENT)).rejects.toMatchObject({ queueDepth: 12, maxDepth: 10 });
+    });
+  });
+
+  describe('dead letter hand-off', () => {
+    it('sends a job to the DLQ once its retries are exhausted', () => {
+      const dlq = createDlq();
+      build(dlq, { maxRetries: 3 });
+
+      const failed = workerHandlers.get('failed');
+      expect(failed, 'the queue must subscribe to failed jobs').toBeDefined();
+
+      failed?.({ data: { event: EVENT }, attemptsMade: 4 }, new Error('permanent'));
+
+      expect(dlq.add).toHaveBeenCalledWith(EVENT, expect.any(Error), 3);
+    });
+
+    it('leaves a job alone while retries remain', () => {
+      // Sending it to the DLQ early would record a permanent failure for an
+      // event BullMQ is about to try again.
+      const dlq = createDlq();
+      build(dlq, { maxRetries: 3 });
+
+      workerHandlers.get('failed')?.(
+        { data: { event: EVENT }, attemptsMade: 2 },
+        new Error('transient')
+      );
+
+      expect(dlq.add).not.toHaveBeenCalled();
+    });
+
+    it('ignores a failure with no job rather than throwing inside the handler', () => {
+      const dlq = createDlq();
+      build(dlq);
+
+      expect(() => workerHandlers.get('failed')?.(null, new Error('x'))).not.toThrow();
+      expect(dlq.add).not.toHaveBeenCalled();
+    });
+
+    it('wraps a non-Error rejection so the DLQ always records a message', () => {
+      const dlq = createDlq();
+      build(dlq, { maxRetries: 1 });
+
+      workerHandlers.get('failed')?.({ data: { event: EVENT }, attemptsMade: 2 }, 'a bare string');
+
+      expect(dlq.add).toHaveBeenCalledWith(EVENT, expect.any(Error), 1);
+    });
+  });
+});

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -57,10 +57,10 @@ export default defineConfig({
         // Treat them as a ratchet: raise them as coverage improves, never
         // lower them to accommodate a new gap. The frontend equivalent lives
         // in web/vitest.config.ts and is further behind still.
-        lines: 46,
-        functions: 48,
+        lines: 47,
+        functions: 49,
         branches: 41,
-        statements: 46,
+        statements: 47,
       },
     },
     include: [


### PR DESCRIPTION
CI-6, in part: the durability half of indexing and the trust boundary had no unit tests at all.

## What was untested

- **`cursor-manager.ts`** decides where the firehose resumes. Lose the cursor and the indexer replays from the beginning; advance it past unprocessed events and those records are never seen again.
- **`event-queue.ts`** sits between the firehose and the indexer. Two of its properties decide whether events are lost: backpressure, and the hand-off to the dead letter queue when retries are exhausted.
- **`dlq-handler.ts`** is where events go when indexing them fails. If it drops one, that record is never indexed and nothing says so.
- **`service-auth-verifier.ts`** is the trust boundary — whatever it returns becomes the caller's identity for the rest of the request. This is the same file whose missing lexicon-method check was SEC-3, accepted for four months because nothing tested it.

37 tests across the four. Each is mutation-checked; two examples:

- Removing the `lxm` argument from `verifyJwt` — reintroducing SEC-3 exactly — fails `checks the lexicon method when one is given`.
- Removing the unchanged-cursor guard fails `does not rewrite an unchanged cursor`.

## What the tests assert, and why those things

Not line coverage for its own sake — the properties whose failure loses data:

- The cursor returns **null** on a first run rather than a zero someone might resume from, ignores a cache value that is not a number, and writes PostgreSQL **before** Redis so a cache entry can never point past a position the database rejected. A failed write leaves the cursor pending rather than silently advancing.
- The queue counts waiting, active **and** delayed jobs toward its depth — counting only waiting would let it hold three times the configured maximum before refusing anything — and hands a job to the DLQ only once retries are exhausted, never while BullMQ is still going to retry it.
- The DLQ throws when an insert returns no id, rather than reporting a queued event that is not in the table; removes an entry only after the processor succeeds; and accepts an already-parsed JSONB column, since the pg driver parses `jsonb` itself and treating it as a string would turn every retry into a failure.
- The verifier passes the audience and the lexicon method to `verifyJwt` rather than checking them afterwards, and returns `null` on every failure path — never a partially verified identity with the DID filled in from an unverified token.

BullMQ and `@atproto/xrpc-server` are mocked, deliberately: both open connections or do cryptography, and what is under test is what Chive asks them to check and what it does with the answer, not their own correctness.

## Coverage

46.6% → 47.12% lines. The ratchet in `vitest.unit.config.ts` is raised to match — that is what a ratchet is for, and leaving it at the old number would let this ground be given back.

- Unit: 222 files pass
- `tsc --noEmit` clean, lint clean

## Compliance

Tests only. No production code changed.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source