### PR TITLE
Add unit tests for the DID verifier and the OAuth state and session stores

### DIFF
--- a/tests/unit/auth/atproto-oauth/oauth-stores.test.ts
+++ b/tests/unit/auth/atproto-oauth/oauth-stores.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for the ATProto OAuth state and session stores.
+ *
+ * @remarks
+ * These hold the two things an attacker most wants: the CSRF state that binds
+ * an authorization response to the request that started it, and the refresh
+ * tokens that grant continued access to a user's PDS. Neither had a unit test.
+ *
+ * @packageDocumentation
+ */
+
+import { randomBytes } from 'node:crypto';
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { RedisSessionStore } from '@/auth/atproto-oauth/session-store.js';
+import { RedisStateStore } from '@/auth/atproto-oauth/state-store.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+function createLogger(): ILogger {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+/** A Redis stand-in that records what it was asked to store. */
+function createRedis(): {
+  store: Map<string, string>;
+  get: ReturnType<typeof vi.fn>;
+  setex: ReturnType<typeof vi.fn>;
+  del: ReturnType<typeof vi.fn>;
+} {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get: vi.fn((key: string) => Promise.resolve(store.get(key) ?? null)),
+    setex: vi.fn((key: string, _ttl: number, value: string) => {
+      store.set(key, value);
+      return Promise.resolve('OK');
+    }),
+    del: vi.fn((key: string) => {
+      store.delete(key);
+      return Promise.resolve(1);
+    }),
+  };
+}
+
+const KEY = 'hex'.repeat(0) + randomBytes(32).toString('hex');
+
+describe('RedisStateStore', () => {
+  it('round-trips state', async () => {
+    const redis = createRedis();
+    const store = new RedisStateStore({ redis: redis as never, logger: createLogger() });
+
+    await store.set('state-123', { dpopKey: 'k' } as never);
+
+    expect(await store.get('state-123')).toEqual({ dpopKey: 'k' });
+  });
+
+  it('returns undefined for a key that is absent', async () => {
+    const store = new RedisStateStore({ redis: createRedis() as never, logger: createLogger() });
+
+    expect(await store.get('never-stored')).toBeUndefined();
+  });
+
+  it('gives state a bounded lifetime', async () => {
+    // OAuth state is single-use and short-lived. Storing it without an expiry
+    // would leave a replayable value in Redis indefinitely.
+    const redis = createRedis();
+    const store = new RedisStateStore({ redis: redis as never, logger: createLogger() });
+
+    await store.set('state-123', { dpopKey: 'k' } as never);
+
+    const [, ttl] = redis.setex.mock.calls[0] as [string, number, string];
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(900);
+  });
+
+  it('namespaces its keys so state cannot collide with another store', async () => {
+    const redis = createRedis();
+    const store = new RedisStateStore({ redis: redis as never, logger: createLogger() });
+
+    await store.set('abc', { dpopKey: 'k' } as never);
+
+    expect([...redis.store.keys()][0]).toMatch(/^chive:atproto:state:abc$/);
+  });
+
+  it('deletes corrupt state rather than returning it', async () => {
+    // A half-written value must not be handed back as if it were valid state,
+    // and must not sit there failing every subsequent read.
+    const redis = createRedis();
+    redis.store.set('chive:atproto:state:bad', '{not json');
+    const store = new RedisStateStore({ redis: redis as never, logger: createLogger() });
+
+    expect(await store.get('bad')).toBeUndefined();
+    expect(redis.del).toHaveBeenCalledWith('chive:atproto:state:bad');
+  });
+
+  it('deletes on request', async () => {
+    const redis = createRedis();
+    const store = new RedisStateStore({ redis: redis as never, logger: createLogger() });
+
+    await store.set('abc', { dpopKey: 'k' } as never);
+    await store.del('abc');
+
+    expect(await store.get('abc')).toBeUndefined();
+  });
+});
+
+describe('RedisSessionStore', () => {
+  it('round-trips a session', async () => {
+    const redis = createRedis();
+    const store = new RedisSessionStore({ redis: redis as never, logger: createLogger() });
+
+    await store.set('did:plc:user', { tokenSet: { refresh_token: 'r' } } as never);
+
+    expect(await store.get('did:plc:user')).toEqual({ tokenSet: { refresh_token: 'r' } });
+  });
+
+  it('does not write refresh tokens in the clear when a key is configured', async () => {
+    // Sessions hold the credentials that grant continued access to a user's
+    // PDS. Anyone who can read Redis must not be able to read those.
+    const redis = createRedis();
+    const store = new RedisSessionStore({
+      redis: redis as never,
+      logger: createLogger(),
+      config: { encryptionKey: KEY },
+    });
+
+    await store.set('did:plc:user', { tokenSet: { refresh_token: 'super-secret' } } as never);
+
+    const stored = [...redis.store.values()][0] ?? '';
+    expect(stored).not.toContain('super-secret');
+    expect(stored).not.toContain('refresh_token');
+  });
+
+  it('round-trips through encryption', async () => {
+    const redis = createRedis();
+    const store = new RedisSessionStore({
+      redis: redis as never,
+      logger: createLogger(),
+      config: { encryptionKey: KEY },
+    });
+
+    await store.set('did:plc:user', { tokenSet: { refresh_token: 'super-secret' } } as never);
+
+    expect(await store.get('did:plc:user')).toEqual({
+      tokenSet: { refresh_token: 'super-secret' },
+    });
+  });
+
+  it('cannot be decrypted with a different key', async () => {
+    const redis = createRedis();
+    const writer = new RedisSessionStore({
+      redis: redis as never,
+      logger: createLogger(),
+      config: { encryptionKey: KEY },
+    });
+    await writer.set('did:plc:user', { tokenSet: { refresh_token: 'r' } } as never);
+
+    const reader = new RedisSessionStore({
+      redis: redis as never,
+      logger: createLogger(),
+      config: { encryptionKey: randomBytes(32).toString('hex') },
+    });
+
+    // Authenticated encryption: the wrong key must fail, not return garbage.
+    expect(await reader.get('did:plc:user')).toBeUndefined();
+  });
+
+  it('rejects an encryption key that is not 32 bytes', () => {
+    // A short key would otherwise be padded or truncated silently, producing
+    // encryption weaker than it appears.
+    expect(
+      () =>
+        new RedisSessionStore({
+          redis: createRedis() as never,
+          logger: createLogger(),
+          config: { encryptionKey: 'abcd' },
+        })
+    ).toThrow(/32 bytes/);
+  });
+
+  it('gives sessions a bounded lifetime', async () => {
+    const redis = createRedis();
+    const store = new RedisSessionStore({ redis: redis as never, logger: createLogger() });
+
+    await store.set('did:plc:user', { tokenSet: {} } as never);
+
+    const [, ttl] = redis.setex.mock.calls[0] as [string, number, string];
+    expect(ttl).toBeGreaterThan(0);
+  });
+
+  it('deletes a corrupt session rather than returning it', async () => {
+    const redis = createRedis();
+    const store = new RedisSessionStore({
+      redis: redis as never,
+      logger: createLogger(),
+      config: { encryptionKey: KEY },
+    });
+    redis.store.set('chive:atproto:session:did:plc:user', 'not-base64-ciphertext');
+
+    expect(await store.get('did:plc:user')).toBeUndefined();
+    expect(redis.del).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/auth/did/did-verifier.test.ts
+++ b/tests/unit/auth/did/did-verifier.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for DIDVerifier.
+ *
+ * @remarks
+ * The verifier decides whether a JWT proves the holder controls a DID. It had
+ * no unit test, and its failure modes are the quiet kind: accepting an
+ * unsigned token, accepting one signed with `alg: none`, or accepting an
+ * expired one all look exactly like working authentication.
+ *
+ * The signature check itself is exercised through a stub resolver rather than
+ * real keys — what is under test is the order and completeness of the checks
+ * around it, which is where this class can be wrong.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { DIDVerifier } from '@/auth/did/did-verifier.js';
+import type { IIdentityResolver } from '@/types/interfaces/identity.interface.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+function createLogger(): ILogger {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+function createResolver(document: unknown): IIdentityResolver {
+  return {
+    resolveDID: vi.fn().mockResolvedValue(document),
+    resolveHandle: vi.fn(),
+    getPDSEndpoint: vi.fn(),
+  } as unknown as IIdentityResolver;
+}
+
+/** Encode a JWT part without signing it. */
+function part(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function token(header: unknown, payload: unknown, signature = 'not-a-real-signature'): string {
+  return `${part(header)}.${part(payload)}.${signature}`;
+}
+
+const DID = 'did:plc:subject';
+const FUTURE = Math.floor(Date.now() / 1000) + 3600;
+const PAST = Math.floor(Date.now() / 1000) - 3600;
+
+function build(resolver: IIdentityResolver, overrides: Record<string, unknown> = {}): DIDVerifier {
+  return new DIDVerifier({
+    identityResolver: resolver,
+    logger: createLogger(),
+    ...overrides,
+  } as never);
+}
+
+describe('DIDVerifier', () => {
+  it('rejects an algorithm other than ES256', async () => {
+    // `alg: none` is the classic JWT forgery: a token with no signature that a
+    // permissive verifier accepts as valid.
+    const verifier = build(createResolver({ id: DID }));
+
+    const result = await verifier.verify(token({ alg: 'none' }, { sub: DID, exp: FUTURE }));
+
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatch(/Unsupported algorithm/);
+  });
+
+  it('rejects HS256, which would let a shared secret stand in for a key', async () => {
+    const verifier = build(createResolver({ id: DID }));
+
+    const result = await verifier.verify(token({ alg: 'HS256' }, { sub: DID, exp: FUTURE }));
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects a subject that is not a DID', async () => {
+    const verifier = build(createResolver({ id: DID }));
+
+    const result = await verifier.verify(token({ alg: 'ES256' }, { sub: 'alice', exp: FUTURE }));
+
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatch(/subject/i);
+  });
+
+  it('rejects a missing subject', async () => {
+    const verifier = build(createResolver({ id: DID }));
+
+    const result = await verifier.verify(token({ alg: 'ES256' }, { exp: FUTURE }));
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects a DID that cannot be resolved', async () => {
+    // An unresolvable DID means there is no document to check the signature
+    // against; treating that as valid would accept any signature at all.
+    const verifier = build(createResolver(null));
+
+    const result = await verifier.verify(token({ alg: 'ES256' }, { sub: DID, exp: FUTURE }));
+
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatch(/Failed to resolve/);
+  });
+
+  it('rejects a malformed token without throwing', async () => {
+    const verifier = build(createResolver({ id: DID }));
+
+    const result = await verifier.verify('not.a.jwt');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors?.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a token with too few segments', async () => {
+    const verifier = build(createResolver({ id: DID }));
+
+    const result = await verifier.verify('onlyonesegment');
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('never returns valid without also returning the DID it verified', async () => {
+    // A result of `{ valid: true }` with no `did` would let a caller treat an
+    // unidentified token as an authenticated one.
+    const verifier = build(createResolver(null));
+
+    for (const t of [
+      token({ alg: 'none' }, { sub: DID }),
+      token({ alg: 'ES256' }, { sub: 'not-a-did' }),
+      token({ alg: 'ES256' }, { sub: DID }),
+      'garbage',
+    ]) {
+      const result = await verifier.verify(t);
+      if (result.valid) expect(result.did).toBeDefined();
+      else expect(result.did).toBeUndefined();
+    }
+  });
+
+  it('resolves the DID from the token subject, not from anything caller-supplied', async () => {
+    const resolver = createResolver(null);
+    const verifier = build(resolver);
+
+    await verifier.verify(token({ alg: 'ES256' }, { sub: DID, exp: FUTURE }));
+
+    expect(resolver.resolveDID).toHaveBeenCalledWith(DID);
+  });
+
+  it('does not resolve anything when the algorithm is already wrong', async () => {
+    // Rejecting before the network call keeps a forged token from costing a
+    // DID resolution, which is the cheap half of a denial-of-service.
+    const resolver = createResolver({ id: DID });
+    const verifier = build(resolver);
+
+    await verifier.verify(token({ alg: 'none' }, { sub: DID, exp: PAST }));
+
+    expect(resolver.resolveDID).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
CI-6, continued. Three more untested modules on the trust boundary.

## What they hold

- **`did-verifier.ts`** decides whether a JWT proves the holder controls a DID. Its failure modes are the quiet kind: accepting an unsigned token, one with `alg: none`, or one whose DID cannot be resolved all look exactly like working authentication.
- **`state-store.ts`** holds the OAuth state that binds an authorization response to the request that started it — the CSRF defence for the whole login flow.
- **`session-store.ts`** holds the refresh tokens that grant continued access to a user's PDS.

23 tests across the three, each mutation-checked. Two examples: removing the `alg !== 'ES256'` guard fails two tests, and removing the `encrypt()` call before the Redis write fails two more.

## What is asserted

**The verifier** rejects `alg: none` (the classic JWT forgery — a token with no signature that a permissive verifier accepts) and `HS256` (which would let a shared secret stand in for a key); rejects a subject that is not a DID, a missing subject, a DID that cannot be resolved, and a malformed token — the last without throwing, since an exception escaping here is a 500 that tells a caller their token broke the server rather than that it was rejected.

Two structural properties matter as much as the individual rejections:

- **A valid result always carries the DID it verified.** `{ valid: true }` with no `did` would let a caller treat an unidentified token as an authenticated one, so every failure path is checked to leave `did` undefined.
- **A wrong algorithm is rejected before any DID resolution.** Rejecting after would let a forged token cost a network round trip, which is the cheap half of a denial-of-service.

**The state store** gives state a bounded lifetime — state is single-use, and storing it without an expiry leaves a replayable value in Redis indefinitely — namespaces its keys, and deletes corrupt state rather than returning it or failing every subsequent read on it.

**The session store** does not write refresh tokens in the clear when a key is configured (asserted by checking the stored bytes contain neither the token nor the field name), round-trips through encryption, fails closed when read with a different key rather than returning garbage, and rejects a key that is not 32 bytes — which would otherwise be padded or truncated silently, producing encryption weaker than it appears.

## Coverage

47.12% → 47.5% lines.

- Unit: 225 files pass
- `tsc --noEmit` clean, lint clean

## Compliance

Tests only. No production code changed.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source