### PR TITLE
Give the PDS scanner the shared collection list and drop a collection with no lexicon

### DIFF
--- a/src/services/indexing/event-processor.ts
+++ b/src/services/indexing/event-processor.ts
@@ -1059,7 +1059,6 @@ async function processRecord(
       return success();
     }
 
-    case 'pub.chive.eprint.tag':
     case 'pub.chive.eprint.userTag': {
       logger.debug('Processing tag', { action, uri });
 

--- a/src/services/indexing/indexed-collections.ts
+++ b/src/services/indexing/indexed-collections.ts
@@ -19,6 +19,17 @@
  * "indexed". A test asserts the two agree, so adding a `case` without adding it
  * here fails rather than silently reintroducing the divergence.
  *
+ * The PDS scanner now derives its backfill list from here too, so a repository
+ * scan covers exactly what the firehose covers. It had its own copy, which had
+ * drifted in both directions: it scanned `pub.chive.review.entityLink`, which
+ * the processor does not index, and missed both `collaboration` collections, so
+ * a backfill could never recover a co-author invitation.
+ *
+ * `pub.chive.eprint.tag` used to appear here. There is no such lexicon — the
+ * record type is `pub.chive.eprint.userTag`, and the processor keeps a
+ * fall-through case for the old name. Listing it here let `sync.indexRecord`
+ * accept a manual index request for a collection with no schema at all.
+ *
  * The PDS scanner's governance subset is deliberately out of scope here; it is
  * owned separately (G-04).
  *
@@ -42,7 +53,6 @@ export const INDEXED_COLLECTIONS: readonly string[] = [
   'pub.chive.eprint.citation',
   'pub.chive.eprint.relatedWork',
   'pub.chive.eprint.submission',
-  'pub.chive.eprint.tag',
   'pub.chive.eprint.userTag',
   'pub.chive.eprint.version',
   'pub.chive.graph.edge',

--- a/src/services/pds-discovery/pds-scanner.ts
+++ b/src/services/pds-discovery/pds-scanner.ts
@@ -36,6 +36,7 @@ import type {
   UserTagRecord,
   VersionRecord,
 } from '../indexing/event-processor.js';
+import { INDEXED_COLLECTIONS } from '../indexing/indexed-collections.js';
 import type { ReviewService } from '../review/review-service.js';
 
 import type { IPDSRegistry, ScanResult } from './pds-registry.js';
@@ -338,27 +339,12 @@ export class PDSScanner {
    * @returns Number of records indexed
    */
   private async scanRepoForChiveRecords(pdsUrl: string, did: DID): Promise<number> {
-    const collections = [
-      'pub.chive.eprint.submission',
-      'pub.chive.eprint.version',
-      'pub.chive.review.comment',
-      'pub.chive.review.endorsement',
-      'pub.chive.review.entityLink',
-      'pub.chive.eprint.userTag',
-      'pub.chive.eprint.tag',
-      'pub.chive.eprint.citation',
-      'pub.chive.eprint.relatedWork',
-      'pub.chive.eprint.changelog',
-      'pub.chive.graph.node',
-      'pub.chive.graph.edge',
-      'pub.chive.graph.nodeProposal',
-      'pub.chive.graph.edgeProposal',
-      'pub.chive.graph.vote',
-      'pub.chive.annotation.comment',
-      'pub.chive.annotation.entityLink',
-      'pub.chive.actor.profile',
-      'pub.chive.actor.profileConfig',
-    ];
+    // One shared list rather than a copy that drifts. This array had gone out
+    // of step in both directions: it scanned `pub.chive.review.entityLink`,
+    // which the event processor does not index, and it omitted both
+    // `collaboration` collections, so a backfill could never recover a
+    // co-author invitation the firehose had missed.
+    const collections = INDEXED_COLLECTIONS;
 
     let totalIndexed = 0;
 
@@ -616,8 +602,7 @@ export class PDSScanner {
               }
             }
 
-            case 'pub.chive.eprint.userTag':
-            case 'pub.chive.eprint.tag': {
+            case 'pub.chive.eprint.userTag': {
               return this.indexUserTag(record, did, metadata, collection, endTimer);
             }
 

--- a/tests/unit/services/indexing/indexed-collections-invariants.test.ts
+++ b/tests/unit/services/indexing/indexed-collections-invariants.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import { INDEXED_COLLECTIONS } from '@/services/indexing/indexed-collections.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+
+function recordLexicons(dir: string, out = new Set<string>()): Set<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) recordLexicons(full, out);
+    else if (entry.name.endsWith('.json')) {
+      const doc = JSON.parse(readFileSync(full, 'utf8')) as {
+        id?: string;
+        defs?: Record<string, { type?: string }>;
+      };
+      if (doc.id && doc.defs?.main?.type === 'record') out.add(doc.id);
+    }
+  }
+  return out;
+}
+
+const RECORDS = recordLexicons(join(REPO_ROOT, 'lexicons/pub/chive'));
+
+const scopes = readFileSync(join(REPO_ROOT, 'src/auth/scopes/chive-scopes.ts'), 'utf8');
+const GRANTED_WRITES = new Set(
+  [...scopes.matchAll(/repo:(pub\.chive\.[a-zA-Z.]+)/g)].map((m) => m[1]!)
+);
+
+/**
+ * Granted a write scope, given a schema, indexed from the firehose: a
+ * collection needs all three, and the three lists were maintained separately.
+ * `pub.chive.actor.profileConfig` had a scope and no lexicon (CFG-2);
+ * `pub.chive.eprint.tag` was in the indexed set with no lexicon at all, so
+ * `sync.indexRecord` accepted manual index requests for a collection that has
+ * no schema to validate against.
+ */
+describe('indexed collections, lexicons and write scopes agree', () => {
+  it('reads a non-trivial number of record lexicons', () => {
+    expect(RECORDS.size).toBeGreaterThan(15);
+    expect(GRANTED_WRITES.size).toBeGreaterThan(15);
+  });
+
+  it('every indexed collection has a record lexicon', () => {
+    for (const collection of INDEXED_COLLECTIONS) {
+      expect(RECORDS, `${collection} is indexed but has no record lexicon`).toContain(collection);
+    }
+  });
+
+  it('every granted write scope names a record lexicon', () => {
+    // A write scope for a collection with no schema means clients can write
+    // whatever they like into it and the indexer has nothing to validate.
+    for (const scope of GRANTED_WRITES) {
+      expect(RECORDS, `${scope} is a granted write scope with no record lexicon`).toContain(scope);
+    }
+  });
+
+  it('records only the two collections granted for writing that are not indexed', () => {
+    // Both are real gaps, listed here rather than hidden so that adding a third
+    // fails this test:
+    //
+    //   - `pub.chive.actor.mute`: the frontend writes these records to the
+    //     user's PDS (web/lib/atproto/record-creator.ts), and the firehose
+    //     processor drops them. The mute list the UI shows comes from
+    //     localStorage, so mutes do not follow a user to another device and
+    //     Chive cannot apply them server-side.
+    //   - `pub.chive.discovery.settings`: granted, with a lexicon, and written
+    //     by nothing — permission requested and not used.
+    const notIndexed = [...GRANTED_WRITES].filter((s) => !INDEXED_COLLECTIONS.includes(s)).sort();
+
+    expect(notIndexed).toEqual(['pub.chive.actor.mute', 'pub.chive.discovery.settings']);
+  });
+});

--- a/tests/unit/services/indexing/indexed-collections.test.ts
+++ b/tests/unit/services/indexing/indexed-collections.test.ts
@@ -65,9 +65,15 @@ describe('INDEXED_COLLECTIONS', () => {
     'pub.chive.collaboration.inviteAcceptance',
     'pub.chive.eprint.changelog',
     'pub.chive.eprint.version',
-    'pub.chive.eprint.tag',
   ])('includes %s, previously unreachable by manual reindex', (collection) => {
     expect(isIndexedCollection(collection)).toBe(true);
+  });
+
+  it('excludes pub.chive.eprint.tag, for which there is no lexicon', () => {
+    // The record type is `pub.chive.eprint.userTag`. Listing the old name here
+    // let `sync.indexRecord` accept a manual index request for a collection
+    // with no schema to validate the record against.
+    expect(isIndexedCollection('pub.chive.eprint.tag')).toBe(false);
   });
 
   it('rejects a collection outside the namespace', () => {


### PR DESCRIPTION
IDX-5, finishing it, plus what checking the invariant turned up.

## The scanner still had its own copy, drifted in both directions

The event processor and `sync.indexRecord` were unified onto `INDEXED_COLLECTIONS` earlier. `pds-scanner.ts` kept a hard-coded array, and it had gone out of step **both ways**:

- It scanned `pub.chive.review.entityLink`, which the event processor does not index — so a backfill fetched those records and threw them away.
- It omitted **both `collaboration` collections**, so a repository scan could never recover a co-author invitation or its acceptance if the firehose had missed one. That is the exact failure mode a backfill exists to fix.

It now uses the shared list, so a scan covers exactly what the firehose covers.

## `pub.chive.eprint.tag` does not exist

It was in the indexed set, in the event processor's dispatch, and in the scanner's — but there is no such lexicon anywhere, in `lexicons/` or in the generated `lexicons.ts`. The record type is `pub.chive.eprint.userTag`; this was the old name, kept as a fall-through case.

Listing it in the indexed set let `sync.indexRecord` **accept a manual index request for a collection with no schema to validate against** — the same hole as CFG-2, one collection over. Removed from all three, with the reasoning recorded where the list is defined.

## What enforcing the invariant found

A new test requires: every indexed collection has a record lexicon, and every granted `repo:` write scope names a record lexicon. Both hold. The third assertion is the interesting one — it pins the exact set of collections Chive asks to write and does not index, so adding a third fails:

- **`pub.chive.actor.mute`** — the frontend writes these records to the user's PDS (`web/lib/atproto/record-creator.ts:871`), and the firehose processor drops them. The mute list the UI shows comes from `localStorage` under `chive:mutedAuthors`. So mutes do not follow a user to another device or browser, the PDS records accumulate with nothing reading them, and Chive cannot apply a mute server-side in feeds, search or notifications because it does not know it exists.
- **`pub.chive.discovery.settings`** — granted, with a lexicon, written by nothing. Permission requested and not used.

**Neither is fixed here**, and I want to be plain about why. Indexing mutes properly needs a table, an indexer branch, a read endpoint and a frontend change to stop using `localStorage` — and a decision about what a server-side mute should actually do. Dropping the scopes instead is the other coherent answer, and it is a product call, not a mechanical one. The test records both as known gaps so they are data rather than something the next person rediscovers.

**Your call on which way those two go.**

## Testing

- Unit: 224 files pass, coverage 47.12% against the 47% floor
- Integration: 33 passed, 1 skipped; Compliance: 14/14
- `tsc --noEmit` clean, lint clean

## Compliance

Changes which collections a backfill scans — toward covering more of what the firehose covers, not less.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source