### PR TITLE
Forward every field the update lexicon accepts instead of a hand-written list

### DIFF
--- a/web/lib/hooks/use-eprint-mutations.test.ts
+++ b/web/lib/hooks/use-eprint-mutations.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -473,5 +477,45 @@ describe('formatVersion', () => {
     const version = { major: 1, minor: 2, patch: 3, prerelease: '' };
     // Empty string is falsy, so it should not include the prerelease
     expect(formatVersion(version)).toBe('1.2.3');
+  });
+});
+
+describe('useUpdateEprint forwards whatever the lexicon accepts', () => {
+  // The hook used to re-list the fields it forwarded, and that list had fallen
+  // two behind the lexicon: `abstract` and `document` were missing, so an
+  // eprint's abstract could not be edited through the frontend, and nothing
+  // could notice — a field the lexicon accepts and the hook omits is invisible.
+  //
+  // The fix is structural, so these assertions are too. "The hook forwards
+  // abstract" would pass again the moment a thirteenth field is added and left
+  // out; "the hook does not enumerate at all" is what actually holds.
+  const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+  const hook = readFileSync(join(REPO_ROOT, 'web/lib/hooks/use-eprint-mutations.ts'), 'utf8');
+  const lexicon = JSON.parse(
+    readFileSync(join(REPO_ROOT, 'lexicons/pub/chive/eprint/updateSubmission.json'), 'utf8')
+  ) as { defs: { main: { input: { schema: { properties: Record<string, unknown> } } } } };
+
+  it('takes its parameter type from the lexicon', () => {
+    expect(hook).toContain('type UpdateEprintParams = UpdateSubmissionInput');
+  });
+
+  it('does not re-enumerate the fields it forwards', () => {
+    const start = hook.indexOf('client.pub.chive.eprint.updateSubmission');
+    const call = hook.slice(start, hook.indexOf('return response.data;', start));
+
+    expect(call).toContain('updateSubmission(params)');
+    expect(call).not.toContain('uri: params.uri');
+  });
+
+  it('strips only the local-only agent before forwarding', () => {
+    // `overrideAgent` selects which agent signs the request and is not part of
+    // the lexicon input; everything else must reach the server.
+    expect(hook).toContain('{ overrideAgent, ...params }');
+  });
+
+  it('has a lexicon that declares the two fields that were being dropped', () => {
+    const fields = Object.keys(lexicon.defs.main.input.schema.properties);
+    expect(fields).toContain('abstract');
+    expect(fields).toContain('document');
   });
 });

--- a/web/lib/hooks/use-eprint-mutations.ts
+++ b/web/lib/hooks/use-eprint-mutations.ts
@@ -23,6 +23,7 @@ import type { Affiliation as AuthorAffiliation } from '@/lib/api/generated/types
 import type { ChangelogSection } from '@/lib/api/generated/types/pub/chive/eprint/changelog';
 import type { OutputSchema as DeleteOutput } from '@/lib/api/generated/types/pub/chive/eprint/deleteSubmission';
 import type { OutputSchema as GetChangelogOutput } from '@/lib/api/generated/types/pub/chive/eprint/getChangelog';
+import type { InputSchema as UpdateSubmissionInput } from '@/lib/api/generated/types/pub/chive/eprint/updateSubmission';
 import type {
   OutputSchema as ListChangelogsOutput,
   ChangelogView,
@@ -80,34 +81,20 @@ interface DeleteEprintParams {
  * @remarks
  * Uses generated types from the lexicon schema for authors and changelog.
  */
-interface UpdateEprintParams {
-  /** AT-URI of the eprint to update */
-  uri: string;
-  /** Type of version increment */
-  versionBump: VersionBumpType;
-  /** Updated title (optional) */
-  title?: string;
-  /** Updated keywords (optional) */
-  keywords?: string[];
-  /** Updated field node URIs (optional) */
-  fieldUris?: string[];
-  /** Updated authors (optional) */
-  authors?: AuthorContribution[];
-  /** Structured changelog data (optional) */
-  changelog?: ChangelogInput;
-  /** Published version metadata (optional) */
-  publishedVersion?: Record<string, unknown>;
-  /** External identifiers such as arXiv, PubMed (optional) */
-  externalIds?: Record<string, unknown>;
-  /** Code and data repository links (optional) */
-  repositories?: Record<string, unknown>;
-  /** Conference presentation metadata (optional) */
-  conferencePresentation?: Record<string, unknown>;
-  /** Funding sources (optional) */
-  funding?: Record<string, unknown>[];
+/**
+ * Parameters for {@link useUpdateEprint}.
+ *
+ * @remarks
+ * Derived from the lexicon's own input type rather than re-listed by hand. The
+ * hand-written version had fallen two fields behind: `abstract` and `document`
+ * were absent, so an eprint's abstract could not be edited through the frontend
+ * at all — and nothing could notice, because a field the lexicon accepts and
+ * the interface omits is simply invisible.
+ */
+type UpdateEprintParams = UpdateSubmissionInput & {
   /** Agent to use for service auth (paper agent for paper-centric eprints) */
   overrideAgent?: Agent;
-}
+};
 
 /**
  * Mutation hook for deleting eprints.
@@ -197,20 +184,10 @@ export function useUpdateEprint() {
     mutationFn: async ({ overrideAgent, ...params }) => {
       try {
         const client = overrideAgent ? createAuthenticatedClient(overrideAgent) : authApi;
-        const response = await client.pub.chive.eprint.updateSubmission({
-          uri: params.uri,
-          versionBump: params.versionBump,
-          title: params.title,
-          keywords: params.keywords,
-          fieldUris: params.fieldUris,
-          authors: params.authors,
-          changelog: params.changelog,
-          publishedVersion: params.publishedVersion,
-          externalIds: params.externalIds,
-          repositories: params.repositories,
-          conferencePresentation: params.conferencePresentation,
-          funding: params.funding,
-        });
+        // Forward everything the caller passed, minus the local-only agent.
+        // Enumerating the fields here is what dropped `abstract` and
+        // `document`, and would silently drop the next one added to the lexicon.
+        const response = await client.pub.chive.eprint.updateSubmission(params);
         return response.data;
       } catch (error) {
         if (error instanceof APIError) throw error;


### PR DESCRIPTION
FE-6.

## An eprint's abstract could not be edited

`useUpdateEprint` declared its own `UpdateEprintParams` interface and then forwarded twelve named fields to `pub.chive.eprint.updateSubmission`. The lexicon accepts **fourteen**. The two missing ones were `abstract` and `document`.

So the frontend had no way to change an eprint's abstract, and no way to replace its document on update — not because the API refused, but because the hook never sent the field. Nothing could notice: a field the lexicon accepts and the hook omits is simply invisible, with no error, no type failure, and no test that would fail.

`UpdateEprintParams` is now the lexicon's own `InputSchema` plus the local-only `overrideAgent`, and the call forwards the rest object rather than re-listing fields. The next field added to the lexicon reaches the server without anyone remembering to add it here.

## The tests are structural, deliberately

Asserting "the hook forwards `abstract`" would pass again the moment a fifteenth field is added and left out — it would fix this instance and leave the mechanism in place. What actually holds is that the hook **does not enumerate at all**, so that is what is asserted: the parameter type comes from the lexicon, the call site contains `updateSubmission(params)` and not `uri: params.uri`, and only `overrideAgent` is destructured away.

## A note on how I nearly shipped a regression

Writing the new tests, I created `web/lib/hooks/use-eprint-mutations.test.ts` with a heredoc — and that file already existed. The write clobbered 32 existing tests. The suite still passed, at 2,549 tests instead of 2,577, and the file count was unchanged because my file replaced the one it destroyed.

I caught it by comparing test counts against the branch point rather than reading the green result, restored the file, and appended. This is the second time in this batch that generating a file over an existing one has silently removed tests; I am checking `git status` for `M` versus `??` before writing test files from now on.

## Testing

- Web: 145 files, 2,581 tests pass — 4 more than the 2,577 baseline, which is the arithmetic that shows nothing was lost
- Web `tsc --noEmit` clean, lint clean

## Compliance

Frontend only. Sends fields the API already accepts.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source