### PR TITLE
Schedule the graph algorithm job so getCommunities has something to read

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,16 @@ TRUSTED_PROXY_COUNT=1
 # signing key are all present. None is set in any checked-in configuration,
 # so governance-PDS writing is inert and grantDelegation / revokeDelegation
 # return 503 permanently (DEAD-4).
+# How often the graph algorithm job recomputes communities and PageRank, in
+# milliseconds (default: 86400000, one day).
+#
+# This job is the only producer for the cache `pub.chive.graph.getCommunities`
+# reads. It was never scheduled until 0.11.0, so that endpoint answered with an
+# empty list on every request. Community detection over the whole graph is
+# expensive and its results change slowly; the job also runs once immediately on
+# start so a fresh deployment does not serve an empty result for a day.
+GRAPH_ALGORITHM_INTERVAL_MS=86400000
+
 # GRAPH_PDS_URL=https://governance.chive.pub
 # GRAPH_PDS_HANDLE=chive-governance.governance.chive.pub
 # GRAPH_PDS_PASSWORD=            # required; no default

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { CitationExtractionJob } from './jobs/citation-extraction-job.js';
 import { CollaborativeFilteringSyncJob } from './jobs/collaborative-filtering-sync.js';
 import { FreshnessScanJob } from './jobs/freshness-scan-job.js';
 import { GovernanceSyncJob } from './jobs/governance-sync-job.js';
+import { GraphAlgorithmJob, createGraphAlgorithmJobScheduler } from './jobs/graph-algorithm-job.js';
 import { PDSScanSchedulerJob } from './jobs/pds-scan-scheduler-job.js';
 import { TagSyncJob } from './jobs/tag-sync-job.js';
 import { PinoLogger } from './observability/logger.js';
@@ -90,6 +91,7 @@ import { Neo4jConnection } from './storage/neo4j/connection.js';
 import { EdgeRepository } from './storage/neo4j/edge-repository.js';
 import { FacetManager } from './storage/neo4j/facet-manager.js';
 import { GraphAlgorithmCache } from './storage/neo4j/graph-algorithm-cache.js';
+import { GraphAlgorithms } from './storage/neo4j/graph-algorithms.js';
 import { NodeRepository } from './storage/neo4j/node-repository.js';
 import { RecommendationService } from './storage/neo4j/recommendations.js';
 import { TagManager } from './storage/neo4j/tag-manager.js';
@@ -236,6 +238,20 @@ function loadConfig(): EnvConfig {
 }
 
 /**
+ * How often the graph algorithm job recomputes communities and PageRank.
+ *
+ * @remarks
+ * Community detection over the whole knowledge graph is expensive and its
+ * results change slowly, so daily is the right order of magnitude. The job runs
+ * once immediately on start, so a fresh deployment does not serve an empty
+ * `getCommunities` for a day.
+ */
+const GRAPH_ALGORITHM_INTERVAL_MS = Number.parseInt(
+  process.env.GRAPH_ALGORITHM_INTERVAL_MS ?? String(24 * 60 * 60 * 1000),
+  10
+);
+
+/**
  * Application state for cleanup.
  */
 interface AppState {
@@ -248,6 +264,7 @@ interface AppState {
   server?: ReturnType<typeof serve>;
   importScheduler?: ImportScheduler;
   governanceSyncJob?: GovernanceSyncJob;
+  graphAlgorithmScheduler?: { start: () => void; stop: () => void };
   freshnessWorker?: FreshnessWorker;
   freshnessScanJob?: FreshnessScanJob;
   pdsScanSchedulerJob?: PDSScanSchedulerJob;
@@ -733,6 +750,10 @@ async function shutdown(state: AppState, signal: string): Promise<void> {
   }
 
   // Stop governance sync job
+  if (state.graphAlgorithmScheduler) {
+    state.graphAlgorithmScheduler.stop();
+  }
+
   if (state.governanceSyncJob) {
     state.logger.info('Stopping governance sync job...');
     state.governanceSyncJob.stop();
@@ -1182,6 +1203,35 @@ async function main(): Promise<void> {
       pdsUrl: config.graphPdsUrl,
       graphPdsDid: config.graphPdsDid,
     });
+
+    // Compute the community and PageRank results `pub.chive.graph.getCommunities`
+    // reads.
+    //
+    // The job was written, tested and never constructed. 0.9.0 built the cache
+    // the handler reads, which had never existed, and stopped there — so the
+    // endpoint went from failing on an undefined service to succeeding with an
+    // empty list, which is harder to notice. This is the producer.
+    if (serverConfig.graphAlgorithmCache) {
+      const graphAlgorithmJob = new GraphAlgorithmJob({
+        algorithms: new GraphAlgorithms(neo4jConnection),
+        cache: serverConfig.graphAlgorithmCache,
+        logger,
+      });
+      state.graphAlgorithmScheduler = createGraphAlgorithmJobScheduler(
+        graphAlgorithmJob,
+        GRAPH_ALGORITHM_INTERVAL_MS
+      );
+      state.graphAlgorithmScheduler.start();
+      logger.info('Graph algorithm job scheduled', {
+        intervalMs: GRAPH_ALGORITHM_INTERVAL_MS,
+      });
+    } else {
+      // Loudly, because the endpoint stays empty and that is now the only way
+      // it can be — which is the state this job was scheduled to end.
+      logger.warn(
+        'Graph algorithm cache is not configured; getCommunities will return an empty list'
+      );
+    }
 
     // Initialize freshness system (if enabled)
     if (config.freshnessEnabled) {

--- a/tests/unit/config/graph-algorithm-scheduling.test.ts
+++ b/tests/unit/config/graph-algorithm-scheduling.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const entrypoint = readFileSync(join(REPO_ROOT, 'src/index.ts'), 'utf8');
+
+/**
+ * `GraphAlgorithmJob` is the only producer for the cache
+ * `pub.chive.graph.getCommunities` reads. It was written, tested, and never
+ * constructed. 0.9.0 built the cache the handler reads — which had never
+ * existed — and stopped there, so the endpoint went from failing on an
+ * undefined service to succeeding with an empty list, which is harder to
+ * notice than the failure it replaced.
+ *
+ * These assertions are structural because the defect was structural: the job
+ * was correct and simply never ran.
+ */
+describe('the graph algorithm job is scheduled', () => {
+  it('is constructed at startup', () => {
+    expect(entrypoint).toContain('new GraphAlgorithmJob(');
+  });
+
+  it('is started, not merely constructed', () => {
+    expect(entrypoint).toContain('createGraphAlgorithmJobScheduler(');
+    expect(entrypoint).toContain('state.graphAlgorithmScheduler.start()');
+  });
+
+  it('is stopped on shutdown', () => {
+    // An interval left running holds the process open past SIGTERM.
+    expect(entrypoint).toContain('state.graphAlgorithmScheduler.stop()');
+  });
+
+  it('writes into the same cache the handler reads', () => {
+    const construction = entrypoint.slice(
+      entrypoint.indexOf('new GraphAlgorithmJob('),
+      entrypoint.indexOf('createGraphAlgorithmJobScheduler(')
+    );
+    expect(construction).toContain('serverConfig.graphAlgorithmCache');
+  });
+
+  it('says so when the cache is absent rather than starting nothing quietly', () => {
+    expect(entrypoint).toMatch(/getCommunities will return an empty list/);
+  });
+
+  it('has an interval that is configurable and defaults to daily', () => {
+    expect(entrypoint).toContain('GRAPH_ALGORITHM_INTERVAL_MS');
+    expect(entrypoint).toContain('24 * 60 * 60 * 1000');
+  });
+});

--- a/tests/unit/services/indexing/indexed-collections-invariants.test.ts
+++ b/tests/unit/services/indexing/indexed-collections-invariants.test.ts
@@ -58,19 +58,26 @@ describe('indexed collections, lexicons and write scopes agree', () => {
     }
   });
 
-  it('records only the two collections granted for writing that are not indexed', () => {
-    // Both are real gaps, listed here rather than hidden so that adding a third
-    // fails this test:
+  it('separates collections read through from the PDS from ones that are simply dropped', () => {
+    // Not every granted write scope should be indexed. `discovery.settings` is
+    // read on demand straight from the user's PDS
+    // (`actor/getDiscoverySettings.ts` issues `com.atproto.repo.getRecord`), so
+    // it is deliberately absent from the firehose set — a per-user preference
+    // does not belong in a shared index.
     //
-    //   - `pub.chive.actor.mute`: the frontend writes these records to the
-    //     user's PDS (web/lib/atproto/record-creator.ts), and the firehose
-    //     processor drops them. The mute list the UI shows comes from
-    //     localStorage, so mutes do not follow a user to another device and
-    //     Chive cannot apply them server-side.
-    //   - `pub.chive.discovery.settings`: granted, with a lexicon, and written
-    //     by nothing — permission requested and not used.
-    const notIndexed = [...GRANTED_WRITES].filter((s) => !INDEXED_COLLECTIONS.includes(s)).sort();
+    // `actor.mute` is the other kind. The frontend writes those records to the
+    // user's PDS (`web/lib/atproto/record-creator.ts`), nothing reads them from
+    // the PDS, and the firehose processor has no branch for them, so they are
+    // dropped. The mute list the UI shows comes from `localStorage`, which is
+    // why mutes do not follow a user to another device.
+    const READ_THROUGH = ['pub.chive.discovery.settings'];
+    const KNOWN_DROPPED = ['pub.chive.actor.mute'];
 
-    expect(notIndexed).toEqual(['pub.chive.actor.mute', 'pub.chive.discovery.settings']);
+    const unconsumed = [...GRANTED_WRITES]
+      .filter((s) => !INDEXED_COLLECTIONS.includes(s))
+      .filter((s) => !READ_THROUGH.includes(s))
+      .sort();
+
+    expect(unconsumed).toEqual(KNOWN_DROPPED);
   });
 });


### PR DESCRIPTION
DEAD-6, the job half. Plus a correction to something I got wrong.

## The job was written, tested, and never ran

`GraphAlgorithmJob` is the only producer for the cache `pub.chive.graph.getCommunities` reads. 0.9.0 constructed that cache — it had never existed, and the handler was reading `undefined` — and stopped there. So the endpoint went from failing on an undefined service to **succeeding with an empty list**, which is harder to notice than the failure it replaced. I shipped that and then wrote a changelog line saying the endpoint returned data.

It now runs on a schedule beside the governance sync job: once immediately on start, so a fresh deployment does not serve an empty result for a day, then every `GRAPH_ALGORITHM_INTERVAL_MS` (default 24h — community detection over the whole graph is expensive and its results change slowly). Stopped on shutdown, because an interval left running holds the process open past SIGTERM.

If the cache is somehow absent the job is skipped **with a warning naming the consequence**, rather than silently starting nothing.

Six structural tests, because the defect was structural: the job was correct and simply never constructed.

## Correction: `discovery.settings` is not an unused scope

In the previous PR I recorded `pub.chive.discovery.settings` as "granted, with a lexicon, written by nothing — permission requested and not used," and recommended dropping the scope.

**That was wrong.** `actor/getDiscoverySettings.ts:233` reads the record straight from the user's PDS with `com.atproto.repo.getRecord`. It is absent from `INDEXED_COLLECTIONS` **by design**: it is read-through, not indexed, which is the right shape for a per-user preference — it has no business in a shared index.

I had read "not in the indexed set" as "not consumed". Those are different, and the test I wrote framed both gaps as defects when only one is. The scope stays; the test now distinguishes **read-through from the PDS** from **dropped on the floor**, and records `discovery.settings` as the first kind.

`pub.chive.actor.mute` remains the second kind, and I checked specifically for a read-through path before saying so: there is none. The frontend writes those records to users' PDSes, nothing reads them from the PDS, and the firehose processor has no branch for them. Indexing it is the next PR.

## Testing

- Unit: 228 files pass, coverage 47.48% against the 47% floor
- `tsc --noEmit` clean, lint clean
- `GRAPH_ALGORITHM_INTERVAL_MS` documented in `.env.example`

## Compliance

Reads the knowledge graph and writes to Chive's own Redis cache.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source