### PR TITLE
Refuse to publish lexicons from anything but a clean tagged checkout

### DIFF
--- a/scripts/publish-lexicons.ts
+++ b/scripts/publish-lexicons.ts
@@ -24,7 +24,7 @@
  * - `LEXICON_PUBLISH_PASSWORD`  account/app password (required unless `--dry-run`)
  *
  * Usage:
- *   pnpm tsx scripts/publish-lexicons.ts [--dry-run] [nsid ...]
+ *   pnpm tsx scripts/publish-lexicons.ts [--dry-run] [--allow-dirty] [nsid ...]
  *
  * Examples:
  *   # Preview what would change against the live PDS (no credentials needed):
@@ -38,6 +38,8 @@
  *
  * @packageDocumentation
  */
+
+import { execSync } from 'node:child_process';
 
 import { AtpAgent } from '@atproto/api';
 
@@ -98,10 +100,67 @@ async function fetchPublished(
   }
 }
 
+/**
+ * Refuse to write from a working tree that is not a released commit.
+ *
+ * @param dryRun - Whether this is a preview run
+ * @param force - Whether `--allow-dirty` was passed
+ *
+ * @remarks
+ * The publisher reads `lexicons/` from the working tree, not from a tag. That
+ * is convenient and it is a trap: publishing from a feature branch pushes
+ * schemas that have not shipped to the account external services resolve
+ * `pub.chive.*` from.
+ *
+ * It nearly happened. A dry run during the 0.10.0 release listed eight changes
+ * instead of seven; the extra was a lexicon written minutes earlier on an
+ * unmerged branch. Only the count gave it away.
+ *
+ * So: writes require a clean tree at a commit carrying a version tag. A dry run
+ * is always allowed — previewing from a branch is exactly how you check what a
+ * change would do. `--allow-dirty` exists for a deliberate out-of-band fix and
+ * says what it is.
+ */
+function assertPublishableCheckout(dryRun: boolean, force: boolean): void {
+  if (dryRun || force) return;
+
+  const status = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
+  if (status.length > 0) {
+    console.error(
+      '✗ Refusing to publish from a dirty working tree.\n' +
+        '  The publisher reads lexicons/ from disk, so uncommitted edits would be\n' +
+        '  written to the PDS as though they had shipped.\n' +
+        '  Commit or stash them, or pass --allow-dirty if that is deliberate.'
+    );
+    process.exit(1);
+  }
+
+  const tags = execSync('git tag --points-at HEAD', { encoding: 'utf8' })
+    .split('\n')
+    .map((t) => t.trim())
+    .filter((t) => /^v\d+\.\d+\.\d+$/.test(t));
+
+  if (tags.length === 0) {
+    const head = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+    console.error(
+      `✗ Refusing to publish from ${head}, which carries no version tag.\n` +
+        '  Check out the released commit (git checkout v0.10.0) and publish from\n' +
+        '  there, so what reaches the PDS is what shipped.\n' +
+        '  Pass --allow-dirty to override.'
+    );
+    process.exit(1);
+  }
+
+  console.log(`  Checkout:   ${tags.join(', ')} (clean)`);
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
+  const allowDirty = args.includes('--allow-dirty');
   const nsidFilter = new Set(args.filter((a) => !a.startsWith('--')));
+
+  assertPublishableCheckout(dryRun, allowDirty);
 
   // The lexicon account is only the authority for `pub.chive.*` NSIDs.
   // Other namespaces present in lexicons/ (com.atproto.*, site.standard.*) are

--- a/tests/unit/scripts/publish-lexicons-guard.test.ts
+++ b/tests/unit/scripts/publish-lexicons-guard.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const script = readFileSync(join(REPO_ROOT, 'scripts/publish-lexicons.ts'), 'utf8');
+
+/**
+ * The publisher reads `lexicons/` from the working tree, not from a tag. That
+ * is convenient and it is a trap: publishing from a feature branch writes
+ * schemas that have not shipped to the account external services resolve
+ * `pub.chive.*` from.
+ *
+ * It nearly happened during the 0.10.0 release. A dry run listed eight changes
+ * instead of the expected seven; the extra was a lexicon written minutes
+ * earlier on an unmerged branch. Only the count gave it away — nothing in the
+ * tool would have stopped the write.
+ */
+describe('the lexicon publisher refuses an unreleased checkout', () => {
+  it('checks the working tree is clean before writing', () => {
+    expect(script).toContain('git status --porcelain');
+    expect(script).toContain('Refusing to publish from a dirty working tree');
+  });
+
+  it('requires the commit to carry a version tag', () => {
+    expect(script).toContain('git tag --points-at HEAD');
+    expect(script).toMatch(/carries no version tag/);
+  });
+
+  it('matches only release tags, not any tag that happens to be present', () => {
+    // A `nightly` or `deploy-2026-08-28` tag must not satisfy the guard.
+    expect(script).toContain('.test(t)');
+    expect(script).toContain('\\d+\\.\\d+\\.\\d+');
+  });
+
+  it('always allows a dry run', () => {
+    // Previewing from a branch is exactly how you check what a change would do,
+    // so the guard must not block it.
+    const guard = script.slice(
+      script.indexOf('function assertPublishableCheckout'),
+      script.indexOf('async function main')
+    );
+    expect(guard).toContain('if (dryRun || force) return;');
+  });
+
+  it('offers a named override rather than leaving no way out', () => {
+    expect(script).toContain('--allow-dirty');
+  });
+
+  it('names the override in its usage line', () => {
+    expect(script).toContain('[--dry-run] [--allow-dirty]');
+  });
+});


### PR DESCRIPTION
A near miss during the v0.10.0 release, turned into a guard.

## What happened

`scripts/publish-lexicons.ts` reads `lexicons/` **from the working tree**, not from a tag. That is convenient, and it is a trap: publishing from a feature branch writes schemas that have not shipped to the account external services resolve `pub.chive.*` from.

During the 0.10.0 release the dry run reported **eight** changes where I expected seven. The extra was `pub.chive.actor.listMutes` — a lexicon I had written twenty minutes earlier on an unmerged branch. I noticed because I had written the expected number down; nothing in the tool would have stopped the write, and the result would have been an unreleased schema live on the governance PDS with no obvious way to tell it apart from a real one.

I checked out the released commit and published from there, so the seven records that landed are exactly what shipped. This makes that the only thing the tool will do.

## The rule

A **write** requires a clean working tree at a commit carrying a `vX.Y.Z` tag.

- **Dirty tree** → refused, saying why: the publisher reads from disk, so uncommitted edits would be written as though they had shipped.
- **Clean but untagged** → refused, naming the commit and telling you to check out the release.
- **Dry run** → always allowed. Previewing from a branch is exactly how you check what a change would do, and blocking that would push people toward `--allow-dirty` for ordinary work.
- **`--allow-dirty`** → the override, named for what it permits rather than something bland like `--force`.

The tag pattern is anchored `^v\d+\.\d+\.\d+$`, so a `nightly` or `deploy-2026-08-28` tag does not satisfy it.

## Verified by running it, all four ways

| Situation | Result |
|---|---|
| Dirty tree, write | refused |
| Clean, untagged commit, write | refused, names the commit |
| Any branch, `--dry-run` | proceeds |
| Clean tagged commit, write | proceeds, logs `Checkout: v9.9.9 (clean)` |

The last needed a throwaway local tag, since the guard is not in v0.10.0 — it will be in the next one. Tag deleted afterwards.

Six tests pin the structure, including that the dry-run escape sits at the top of the guard and that the tag pattern is anchored.

## Testing

- Unit: 225 files pass, coverage 49.82% against the 49% floor
- `tsc --noEmit` clean, lint clean

## Compliance

Tooling. Makes an outward-facing write harder to do by accident.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source