### PR TITLE
Index actor mute records so Chive can apply a mute server-side

### DIFF
--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -734,6 +734,30 @@
         },
         "type": "object"
       },
+      "pub.chive.actor.listMutes.mutedAuthor": {
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "subjectDid": {
+            "description": "DID of the muted author",
+            "format": "did",
+            "type": "string"
+          },
+          "uri": {
+            "description": "AT-URI of the mute record in the muter's repository",
+            "format": "at-uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subjectDid",
+          "uri",
+          "createdAt"
+        ],
+        "type": "object"
+      },
       "pub.chive.actor.mute": {
         "properties": {
           "createdAt": {
@@ -15820,6 +15844,110 @@
           }
         },
         "summary": "pub.chive.actor.getProfileConfig",
+        "tags": [
+          "actor"
+        ]
+      }
+    },
+    "/xrpc/pub.chive.actor.listMutes": {
+      "get": {
+        "description": "List the authors the authenticated user has muted. Reads the index built from the user's own pub.chive.actor.mute records, so the list follows the user between devices rather than living in one browser.",
+        "operationId": "pub_chive_actor_listMutes",
+        "parameters": [
+          {
+            "description": "Maximum number of mutes to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Maximum number of mutes to return",
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination cursor from a previous response",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Pagination cursor from a previous response",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cursor": {
+                      "description": "Cursor for the next page, absent when there are no more",
+                      "type": "string"
+                    },
+                    "mutes": {
+                      "items": {
+                        "$ref": "#/components/schemas/pub.chive.actor.listMutes.mutedAuthor"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "mutes"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "enum": [
+                        "InvalidRequest",
+                        "ExpiredToken",
+                        "InvalidToken"
+                      ],
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "pub.chive.actor.listMutes",
         "tags": [
           "actor"
         ]

--- a/docs/reference/lexicons.md
+++ b/docs/reference/lexicons.md
@@ -1,6 +1,6 @@
 # Lexicons reference
 
-Chive uses the `pub.chive.*` namespace for all AT Protocol lexicons. These lexicons define 23 record types, 126 queries, and 49 procedures across 24 namespaces. All records are stored in user-controlled PDSes and indexed by the Chive AppView via the ATProto firehose.
+Chive uses the `pub.chive.*` namespace for all AT Protocol lexicons. These lexicons define 23 record types, 127 queries, and 49 procedures across 24 namespaces. All records are stored in user-controlled PDSes and indexed by the Chive AppView via the ATProto firehose.
 
 For the ATProto lexicon specification, see the [Lexicon Guide](https://atproto.com/guides/lexicon).
 

--- a/lexicons/pub/chive/actor/listMutes.json
+++ b/lexicons/pub/chive/actor/listMutes.json
@@ -1,0 +1,61 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.actor.listMutes",
+  "revision": 1,
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List the authors the authenticated user has muted. Reads the index built from the user's own pub.chive.actor.mute records, so the list follows the user between devices rather than living in one browser.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 100,
+            "description": "Maximum number of mutes to return"
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Pagination cursor from a previous response"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["mutes"],
+          "properties": {
+            "mutes": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "#mutedAuthor" }
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Cursor for the next page, absent when there are no more"
+            }
+          }
+        }
+      }
+    },
+    "mutedAuthor": {
+      "type": "object",
+      "required": ["subjectDid", "uri", "createdAt"],
+      "properties": {
+        "subjectDid": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the muted author"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "AT-URI of the mute record in the muter's repository"
+        },
+        "createdAt": { "type": "string", "format": "datetime" }
+      }
+    }
+  }
+}

--- a/src/api/handlers/xrpc/actor/index.ts
+++ b/src/api/handlers/xrpc/actor/index.ts
@@ -19,6 +19,7 @@ import { getDiscoverySettings } from './getDiscoverySettings.js';
 import { getMyProfile } from './getMyProfile.js';
 import { getMyRoles } from './getMyRoles.js';
 import { getProfileConfig } from './getProfileConfig.js';
+import { listMutes } from './listMutes.js';
 
 // Re-export handlers
 export { autocompleteAffiliation } from './autocompleteAffiliation.js';
@@ -30,6 +31,7 @@ export { getMyProfile } from './getMyProfile.js';
 export { getMyRoles } from './getMyRoles.js';
 export { getDiscoverySettings } from './getDiscoverySettings.js';
 export { getProfileConfig } from './getProfileConfig.js';
+export { listMutes } from './listMutes.js';
 
 // Re-export types from generated lexicons for external consumers
 export type {
@@ -91,4 +93,5 @@ export const actorMethods: Record<string, XRPCMethod<any, any, any>> = {
   'pub.chive.actor.getMyProfile': getMyProfile,
   'pub.chive.actor.getMyRoles': getMyRoles,
   'pub.chive.actor.getProfileConfig': getProfileConfig,
+  'pub.chive.actor.listMutes': listMutes,
 };

--- a/src/api/handlers/xrpc/actor/listMutes.ts
+++ b/src/api/handlers/xrpc/actor/listMutes.ts
@@ -1,0 +1,110 @@
+/**
+ * XRPC handler for pub.chive.actor.listMutes.
+ *
+ * @remarks
+ * Returns the authenticated user's mutes from `muted_authors_index`, which is
+ * built from their own `pub.chive.actor.mute` records on the firehose.
+ *
+ * Before 0.11.0 there was no such index. The client reads mutes from the PDS
+ * directly and always could; what did not exist was any server-side knowledge
+ * of them, so a mute could not be applied in a feed, a search or a
+ * notification.
+ *
+ * This endpoint exists for server-side consumers and for clients that want the
+ * list without a per-request PDS round trip. The frontend deliberately still
+ * reads its own repository: the index lags the firehose by a moment, and a user
+ * should not watch their own mute disappear and come back.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type {
+  QueryParams,
+  OutputSchema,
+  MutedAuthor,
+} from '../../../../lexicons/generated/types/pub/chive/actor/listMutes.js';
+import type { AtUri, DID } from '../../../../types/atproto.js';
+import { AuthenticationError, ServiceUnavailableError } from '../../../../types/errors.js';
+import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/** Re-exported query parameters for pub.chive.actor.listMutes. */
+export type ListMutesParams = QueryParams;
+
+/** Re-exported output schema for pub.chive.actor.listMutes. */
+export type ListMutesOutput = OutputSchema;
+
+/** Largest page this endpoint will return. */
+const MAX_LIMIT = 200;
+
+/**
+ * XRPC method for pub.chive.actor.listMutes query.
+ *
+ * @public
+ */
+export const listMutes: XRPCMethod<QueryParams, void, OutputSchema> = {
+  auth: true,
+  handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
+    const logger = c.get('logger');
+    const user = c.get('user');
+
+    if (!user) {
+      throw new AuthenticationError('Authentication required');
+    }
+
+    const pool = c.get('pool');
+    if (!pool) {
+      throw new ServiceUnavailableError('Mute list is not available', 'postgresql');
+    }
+    const limit = Math.min(params.limit ?? 100, MAX_LIMIT);
+
+    // Keyset pagination on (created_at, uri): a stable pair, unlike an offset,
+    // which shifts under the reader when a mute is added mid-page.
+    const cursorParts = params.cursor ? params.cursor.split('::') : null;
+    const cursorTime = cursorParts?.[0];
+    const cursorUri = cursorParts?.[1];
+
+    const conditions = ['muter_did = $1'];
+    const values: unknown[] = [user.did];
+
+    if (cursorTime && cursorUri) {
+      conditions.push(`(created_at, uri) < ($${values.length + 1}, $${values.length + 2})`);
+      values.push(new Date(cursorTime), cursorUri);
+    }
+
+    // One extra row tells us whether another page exists without a second query.
+    values.push(limit + 1);
+
+    const result = await pool.query<{
+      subject_did: string;
+      uri: string;
+      created_at: Date;
+    }>(
+      `SELECT subject_did, uri, created_at
+         FROM muted_authors_index
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY created_at DESC, uri DESC
+        LIMIT $${values.length}`,
+      values
+    );
+
+    const hasMore = result.rows.length > limit;
+    const rows = result.rows.slice(0, limit);
+
+    const mutes: MutedAuthor[] = rows.map((row) => ({
+      subjectDid: row.subject_did as DID,
+      uri: row.uri as AtUri,
+      createdAt: row.created_at.toISOString(),
+    }));
+
+    const last = rows[rows.length - 1];
+    const cursor = hasMore && last ? `${last.created_at.toISOString()}::${last.uri}` : undefined;
+
+    logger.debug('Listed mutes', { did: user.did, count: mutes.length });
+
+    return {
+      encoding: 'application/json',
+      body: { mutes, ...(cursor ? { cursor } : {}) },
+    };
+  },
+};

--- a/src/services/indexing/event-processor.ts
+++ b/src/services/indexing/event-processor.ts
@@ -1656,6 +1656,72 @@ async function processRecord(
       return success();
     }
 
+    case 'pub.chive.actor.mute': {
+      logger.debug('Processing actor mute', { action, uri });
+
+      // These records were dropped entirely before 0.11.0: the collection had
+      // no branch here, so a user's mutes never reached the index. The client
+      // reads them from the PDS directly and so has always worked; what could
+      // not work was anything server-side — a mute could not be applied in a
+      // feed, a search or a notification, because Chive did not know it
+      // existed.
+      if (action === 'delete') {
+        try {
+          await pool.query('DELETE FROM muted_authors_index WHERE uri = $1', [uri]);
+          logger.info('Deleted mute from index', { uri });
+        } catch (dbError) {
+          const error = dbError instanceof Error ? dbError : new Error(String(dbError));
+          logger.error('Failed to delete mute', error, { uri });
+          return failure(
+            'Failed to delete mute',
+            false,
+            new DatabaseError('DELETE', error.message, error)
+          );
+        }
+      } else if (record) {
+        try {
+          const muteRecord = record as { subjectDid?: string; createdAt?: string };
+          const subjectDid = muteRecord.subjectDid;
+
+          if (!subjectDid) {
+            // A mute with no subject names nobody. Reject it rather than store
+            // a row that can never match an author.
+            logger.warn('Mute record has no subjectDid', { uri });
+            return failure('Mute record has no subjectDid', false);
+          }
+
+          await pool.query(
+            `INSERT INTO muted_authors_index (uri, cid, muter_did, subject_did, created_at, pds_url)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             ON CONFLICT (muter_did, subject_did)
+             DO UPDATE SET uri = EXCLUDED.uri, cid = EXCLUDED.cid,
+                           created_at = EXCLUDED.created_at, pds_url = EXCLUDED.pds_url,
+                           indexed_at = NOW()`,
+            [
+              uri,
+              metadata.cid,
+              data.repo,
+              subjectDid,
+              muteRecord.createdAt ? new Date(muteRecord.createdAt) : new Date(),
+              metadata.pdsUrl,
+            ]
+          );
+
+          logger.info('Indexed mute', { uri, subjectDid });
+        } catch (dbError) {
+          const error = dbError instanceof Error ? dbError : new Error(String(dbError));
+          logger.error('Failed to index mute', error, { uri });
+          return failure(
+            'Failed to index mute',
+            false,
+            new DatabaseError('CREATE', error.message, error)
+          );
+        }
+      }
+
+      return success();
+    }
+
     case 'pub.chive.actor.profile': {
       logger.debug('Processing actor profile', { action, uri });
 

--- a/src/services/indexing/indexed-collections.ts
+++ b/src/services/indexing/indexed-collections.ts
@@ -43,6 +43,7 @@
  * @public
  */
 export const INDEXED_COLLECTIONS: readonly string[] = [
+  'pub.chive.actor.mute',
   'pub.chive.actor.profile',
   'pub.chive.actor.profileConfig',
   'pub.chive.annotation.comment',

--- a/src/storage/postgresql/migrations/1742100000000_muted-authors-index.ts
+++ b/src/storage/postgresql/migrations/1742100000000_muted-authors-index.ts
@@ -1,0 +1,50 @@
+/**
+ * Index `pub.chive.actor.mute` records.
+ *
+ * @remarks
+ * The frontend writes these records to the user's PDS and reads them back from
+ * it directly (`web/lib/hooks/use-muted-authors.ts` calls
+ * `com.atproto.repo.listRecords`), so the client side works.
+ *
+ * The server side did not exist. The firehose processor had no branch for this
+ * collection, so every mute was dropped on arrival and Chive could not apply
+ * one anywhere it matters — feeds, search, notifications — because it did not
+ * know the mute existed. Muting an author hid them in one browser tab's view
+ * and nowhere else.
+ *
+ * `(muter_did, subject_did)` is unique: muting the same author twice is the
+ * same mute, and a client that writes a second record should not produce a
+ * second row. The record URI is kept so a deletion arriving from the firehose
+ * can find the row it refers to.
+ *
+ * @packageDocumentation
+ */
+
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable('muted_authors_index', {
+    uri: { type: 'text', primaryKey: true },
+    cid: { type: 'text', notNull: true },
+    muter_did: { type: 'text', notNull: true },
+    subject_did: { type: 'text', notNull: true },
+    created_at: { type: 'timestamptz', notNull: true },
+    indexed_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    // Every `*_index` table carries these two: `pds_url` records which server
+    // the record came from, and `last_synced_at` when it was last checked
+    // against that server. Together they are what makes staleness detection
+    // possible, which is why the schema tests require them of every index.
+    last_synced_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    pds_url: { type: 'text', notNull: true },
+  });
+
+  pgm.createIndex('muted_authors_index', 'muter_did');
+  pgm.createIndex('muted_authors_index', 'subject_did');
+  pgm.addConstraint('muted_authors_index', 'muted_authors_unique_pair', {
+    unique: ['muter_did', 'subject_did'],
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable('muted_authors_index');
+}

--- a/tests/compliance/database-compliance.test.ts
+++ b/tests/compliance/database-compliance.test.ts
@@ -601,12 +601,12 @@ describe('ATProto Database Compliance', () => {
         {
           name: 'Index semantics (_index naming)',
           query: `SELECT COUNT(*) as count FROM information_schema.tables WHERE table_schema = 'public' AND table_name LIKE '%_index'`,
-          expected: 24, // eprints, reviews, endorsements, user_tags, relevance_logs, activity_log, authors, coauthor_claims, changelogs, annotations, entity_links, user_related_works, personal_graph_nodes, personal_graph_edges, collections, collection_edges, eprint_versions, cosmik_connections, cosmik_follows, margin_annotations, margin_bookmarks, cosmik_link_removals, collaboration_invites, collaboration_acceptances
+          expected: 25, // eprints, reviews, endorsements, user_tags, relevance_logs, activity_log, authors, coauthor_claims, changelogs, annotations, entity_links, user_related_works, personal_graph_nodes, personal_graph_edges, collections, collection_edges, eprint_versions, cosmik_connections, cosmik_follows, margin_annotations, margin_bookmarks, cosmik_link_removals, collaboration_invites, collaboration_acceptances, muted_authors
         },
         {
           name: 'PDS source tracking',
           query: `SELECT COUNT(*) as count FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE '%_index' AND column_name = 'pds_url'`,
-          expected: 24, // All index tables have pds_url
+          expected: 25, // All index tables have pds_url
         },
         {
           name: 'No blob data',

--- a/tests/integration/services/mute-indexing.test.ts
+++ b/tests/integration/services/mute-indexing.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Mute indexing integration tests.
+ *
+ * @remarks
+ * `pub.chive.actor.mute` records were dropped by the firehose processor: the
+ * collection had no branch, so Chive never learned that a mute existed and
+ * could not apply one server-side. The client reads mutes from the PDS
+ * directly, so the interface worked and nothing looked wrong.
+ *
+ * These run against a real PostgreSQL because the behaviour under test is an
+ * upsert with a uniqueness constraint, which a mocked pool cannot exercise.
+ *
+ * @packageDocumentation
+ */
+
+import { Pool } from 'pg';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+
+import { getDatabaseConfig } from '@/storage/postgresql/config.js';
+
+const MUTER = 'did:plc:mutertestaccount';
+const SUBJECT = 'did:plc:subjecttestaccount';
+const PDS = 'https://pds.mute.test';
+
+describe('muted_authors_index', () => {
+  let pool: Pool;
+
+  beforeAll(() => {
+    pool = new Pool(getDatabaseConfig());
+  });
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM muted_authors_index WHERE muter_did = $1', [MUTER]);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM muted_authors_index WHERE muter_did = $1', [MUTER]);
+  });
+
+  async function insert(uri: string, subject = SUBJECT, createdAt = new Date()): Promise<void> {
+    await pool.query(
+      `INSERT INTO muted_authors_index (uri, cid, muter_did, subject_did, created_at, pds_url)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (muter_did, subject_did)
+       DO UPDATE SET uri = EXCLUDED.uri, cid = EXCLUDED.cid,
+                     created_at = EXCLUDED.created_at, pds_url = EXCLUDED.pds_url,
+                     indexed_at = NOW()`,
+      [uri, 'bafytest', MUTER, subject, createdAt, PDS]
+    );
+  }
+
+  it('records a mute', async () => {
+    await insert(`at://${MUTER}/pub.chive.actor.mute/one`);
+
+    const { rows } = await pool.query('SELECT * FROM muted_authors_index WHERE muter_did = $1', [
+      MUTER,
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.subject_did).toBe(SUBJECT);
+  });
+
+  it('treats muting the same author twice as one mute', async () => {
+    // A client that writes a second record for the same subject — or a replay
+    // of the same firehose event — must not produce a second row, or a mute
+    // could be "unmuted" once and still apply.
+    await insert(`at://${MUTER}/pub.chive.actor.mute/one`);
+    await insert(`at://${MUTER}/pub.chive.actor.mute/two`);
+
+    const { rows } = await pool.query('SELECT uri FROM muted_authors_index WHERE muter_did = $1', [
+      MUTER,
+    ]);
+    expect(rows).toHaveLength(1);
+    // The newer record wins, so a delete arriving for it finds the row.
+    expect(rows[0]?.uri).toContain('/two');
+  });
+
+  it('keeps mutes of different authors apart', async () => {
+    await insert(`at://${MUTER}/pub.chive.actor.mute/a`, 'did:plc:one');
+    await insert(`at://${MUTER}/pub.chive.actor.mute/b`, 'did:plc:two');
+
+    const { rows } = await pool.query(
+      'SELECT subject_did FROM muted_authors_index WHERE muter_did = $1',
+      [MUTER]
+    );
+    expect(rows).toHaveLength(2);
+  });
+
+  it('deletes by record URI, which is what a firehose tombstone carries', async () => {
+    const uri = `at://${MUTER}/pub.chive.actor.mute/one`;
+    await insert(uri);
+
+    await pool.query('DELETE FROM muted_authors_index WHERE uri = $1', [uri]);
+
+    const { rows } = await pool.query('SELECT 1 FROM muted_authors_index WHERE muter_did = $1', [
+      MUTER,
+    ]);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('orders newest first, which is what the endpoint pages through', async () => {
+    await insert(`at://${MUTER}/pub.chive.actor.mute/old`, 'did:plc:one', new Date('2026-01-01'));
+    await insert(`at://${MUTER}/pub.chive.actor.mute/new`, 'did:plc:two', new Date('2026-06-01'));
+
+    const { rows } = await pool.query<{ uri: string }>(
+      `SELECT uri FROM muted_authors_index WHERE muter_did = $1
+       ORDER BY created_at DESC, uri DESC`,
+      [MUTER]
+    );
+    expect(rows[0]?.uri).toContain('/new');
+  });
+});

--- a/tests/unit/services/indexing/indexed-collections-invariants.test.ts
+++ b/tests/unit/services/indexing/indexed-collections-invariants.test.ts
@@ -58,26 +58,25 @@ describe('indexed collections, lexicons and write scopes agree', () => {
     }
   });
 
-  it('separates collections read through from the PDS from ones that are simply dropped', () => {
+  it('every granted write scope is either indexed or read through from the PDS', () => {
     // Not every granted write scope should be indexed. `discovery.settings` is
     // read on demand straight from the user's PDS
     // (`actor/getDiscoverySettings.ts` issues `com.atproto.repo.getRecord`), so
-    // it is deliberately absent from the firehose set — a per-user preference
-    // does not belong in a shared index.
+    // it is deliberately outside the firehose set — a per-user preference does
+    // not belong in a shared index.
     //
-    // `actor.mute` is the other kind. The frontend writes those records to the
-    // user's PDS (`web/lib/atproto/record-creator.ts`), nothing reads them from
-    // the PDS, and the firehose processor has no branch for them, so they are
-    // dropped. The mute list the UI shows comes from `localStorage`, which is
-    // why mutes do not follow a user to another device.
+    // What must not exist is a third category: a collection Chive asks to write
+    // and then never sees again. `pub.chive.actor.mute` was exactly that until
+    // 0.11.0 — the client read the records straight from the PDS, so muting
+    // worked in the interface, while the server had no idea any mute existed
+    // and so could not apply one in a feed, a search or a notification.
     const READ_THROUGH = ['pub.chive.discovery.settings'];
-    const KNOWN_DROPPED = ['pub.chive.actor.mute'];
 
     const unconsumed = [...GRANTED_WRITES]
       .filter((s) => !INDEXED_COLLECTIONS.includes(s))
       .filter((s) => !READ_THROUGH.includes(s))
       .sort();
 
-    expect(unconsumed).toEqual(KNOWN_DROPPED);
+    expect(unconsumed).toEqual([]);
   });
 });


### PR DESCRIPTION
The `actor.mute` half of what you approved.

## What was actually wrong

`pub.chive.actor.mute` is a granted OAuth write scope with a real lexicon, and the frontend writes those records to the user's PDS. The firehose processor had **no branch for the collection**, so every one was dropped on arrival.

I want to be accurate about the consequence, because I got it wrong twice while investigating and said so at the time. The **client side works**: `use-muted-authors.ts` reads mutes straight from the user's repository with `com.atproto.repo.listRecords`, so muting takes effect in the interface and does follow a user between devices. `localStorage` is a fallback for unauthenticated users and errors, not the primary source.

What did not exist was any **server-side** knowledge. Chive could not apply a mute in a feed, a search or a notification, because it did not know one existed. Muting an author hid them in the client's own rendering and nowhere else.

## What this adds

- `muted_authors_index`, with `(muter_did, subject_did)` unique — muting the same author twice is one mute, and a replayed firehose event must not produce a second row, or one unmute would leave the mute in force.
- An event-processor branch handling create, update and delete. A record with no `subjectDid` is rejected rather than stored as a row that can never match an author.
- `pub.chive.actor.listMutes`, keyset-paginated on `(created_at, uri)` — an offset would shift under a reader when a mute is added mid-page.

## What this deliberately does not change

**The frontend still reads its own repository.** Switching it to the new endpoint would look tidier and would be worse: the index lags the firehose by a moment, so a user would watch their own mute vanish and reappear after making it. The PDS read is immediately consistent. The endpoint exists for server-side consumers and for clients that want the list without a per-request PDS round trip.

The `limit: 100` TODO in that hook is untouched and still open.

## Three invariant tests fired, and all three were right

Adding one table and one lexicon broke:

- the lexicon reference's stated query count (126 → 127)
- the compliance suite's `*_index` table count (24 → 25)
- the schema suite's rule that **every** `*_index` table has `last_synced_at`

The third caught a real omission — I had not included the column, and it is what makes staleness detection possible for indexed records. Added to the migration rather than exempting the table.

## Testing

- Five integration tests against a real PostgreSQL, covering the uniqueness constraint, deletion by record URI (what a tombstone carries), and newest-first ordering — behaviour a mocked pool cannot exercise
- Unit 224 files, integration 33 + 1 skipped, compliance 14/14
- `tsc --noEmit` clean, lint clean

## Compliance

Indexes a user-owned collection from the firehose. Rebuildable like every other index.

- [x] Does not write to user PDSes
- [x] Does not store blob data
- [x] Indexes rebuildable from firehose
- [x] Tracks PDS source — `pds_url` and `last_synced_at`