### PR TITLE
Show datasets linked on Layers on the eprint page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -233,3 +233,15 @@ GRAPH_ALGORITHM_INTERVAL_MS=86400000
 #
 # Defaults to https://chive.pub when unset.
 NEXT_PUBLIC_SITE_URL=https://chive.pub
+
+# Base URL of the Layers AppView, without a trailing slash.
+#
+# Chive federates the read of pub.layers.eprint.dataLink records rather than
+# indexing them: Layers is authoritative for its own lexicons. The eprint page
+# asks this host which datasets a paper links to, caches the answer in Redis
+# for five minutes, and shows nothing when the host does not answer within two
+# seconds. An unset or unreachable value degrades the panel; it never fails a
+# page.
+#
+# Defaults to https://api.layers.pub when unset.
+LAYERS_APPVIEW_URL=https://api.layers.pub

--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -734,6 +734,30 @@
         },
         "type": "object"
       },
+      "pub.chive.actor.listMutes.mutedAuthor": {
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "subjectDid": {
+            "description": "DID of the muted author",
+            "format": "did",
+            "type": "string"
+          },
+          "uri": {
+            "description": "AT-URI of the mute record in the muter's repository",
+            "format": "at-uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subjectDid",
+          "uri",
+          "createdAt"
+        ],
+        "type": "object"
+      },
       "pub.chive.actor.mute": {
         "properties": {
           "createdAt": {
@@ -15868,9 +15892,57 @@
     },
     "/xrpc/pub.chive.actor.listMutes": {
       "get": {
+        "description": "List the authors the authenticated user has muted. Reads the index built from the user's own pub.chive.actor.mute records, so the list follows the user between devices rather than living in one browser.",
         "operationId": "pub_chive_actor_listMutes",
+        "parameters": [
+          {
+            "description": "Maximum number of mutes to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Maximum number of mutes to return",
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination cursor from a previous response",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Pagination cursor from a previous response",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cursor": {
+                      "description": "Cursor for the next page, absent when there are no more",
+                      "type": "string"
+                    },
+                    "mutes": {
+                      "items": {
+                        "$ref": "#/components/schemas/pub.chive.actor.listMutes.mutedAuthor"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "mutes"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
             "description": "OK"
           },
           "400": {

--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -6653,6 +6653,47 @@
         ],
         "type": "object"
       },
+      "pub.chive.eprint.listDataLinks.dataLinkView": {
+        "properties": {
+          "corpusRef": {
+            "format": "at-uri",
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "dataKind": {
+            "description": "Data kind slug, as Layers records it",
+            "maxLength": 128,
+            "type": "string"
+          },
+          "dataKindUri": {
+            "description": "Knowledge graph node for the data kind, when Layers resolved one",
+            "format": "at-uri",
+            "type": "string"
+          },
+          "description": {
+            "maxLength": 10000,
+            "type": "string"
+          },
+          "paperSection": {
+            "description": "Which part of the paper the data belongs to, such as 'Table 3'",
+            "maxLength": 256,
+            "type": "string"
+          },
+          "uri": {
+            "description": "AT-URI of the dataLink record in its author's repository",
+            "format": "at-uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri",
+          "dataKind"
+        ],
+        "type": "object"
+      },
       "pub.chive.eprint.listRelatedWorks.relatedWorkView": {
         "properties": {
           "createdAt": {
@@ -25924,6 +25965,87 @@
           }
         },
         "summary": "pub.chive.eprint.listCitations",
+        "tags": [
+          "eprint"
+        ]
+      }
+    },
+    "/xrpc/pub.chive.eprint.listDataLinks": {
+      "get": {
+        "description": "List Layers datasets linked to an eprint. Chive does not index pub.layers.eprint.dataLink records; it asks the Layers AppView, which is authoritative for them, and caches the answer briefly. Returns an empty list when Layers is unreachable, so an eprint page never depends on another service being up.",
+        "operationId": "pub_chive_eprint_listDataLinks",
+        "parameters": [
+          {
+            "description": "AT-URI of the eprint whose data links to list",
+            "in": "query",
+            "name": "eprintUri",
+            "required": true,
+            "schema": {
+              "description": "AT-URI of the eprint whose data links to list",
+              "format": "at-uri",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "dataLinks": {
+                      "items": {
+                        "$ref": "#/components/schemas/pub.chive.eprint.listDataLinks.dataLinkView"
+                      },
+                      "type": "array"
+                    },
+                    "source": {
+                      "description": "Where the answer came from, so a client can tell an empty list from an unavailable one.",
+                      "enum": [
+                        "layers",
+                        "cache",
+                        "unavailable"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "dataLinks",
+                    "source"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "enum": [
+                        "InvalidRequest"
+                      ],
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad Request"
+          }
+        },
+        "summary": "pub.chive.eprint.listDataLinks",
         "tags": [
           "eprint"
         ]

--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -734,30 +734,6 @@
         },
         "type": "object"
       },
-      "pub.chive.actor.listMutes.mutedAuthor": {
-        "properties": {
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "subjectDid": {
-            "description": "DID of the muted author",
-            "format": "did",
-            "type": "string"
-          },
-          "uri": {
-            "description": "AT-URI of the mute record in the muter's repository",
-            "format": "at-uri",
-            "type": "string"
-          }
-        },
-        "required": [
-          "subjectDid",
-          "uri",
-          "createdAt"
-        ],
-        "type": "object"
-      },
       "pub.chive.actor.mute": {
         "properties": {
           "createdAt": {
@@ -15892,57 +15868,9 @@
     },
     "/xrpc/pub.chive.actor.listMutes": {
       "get": {
-        "description": "List the authors the authenticated user has muted. Reads the index built from the user's own pub.chive.actor.mute records, so the list follows the user between devices rather than living in one browser.",
         "operationId": "pub_chive_actor_listMutes",
-        "parameters": [
-          {
-            "description": "Maximum number of mutes to return",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "description": "Maximum number of mutes to return",
-              "maximum": 200,
-              "minimum": 1,
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Pagination cursor from a previous response",
-            "in": "query",
-            "name": "cursor",
-            "required": false,
-            "schema": {
-              "description": "Pagination cursor from a previous response",
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "cursor": {
-                      "description": "Cursor for the next page, absent when there are no more",
-                      "type": "string"
-                    },
-                    "mutes": {
-                      "items": {
-                        "$ref": "#/components/schemas/pub.chive.actor.listMutes.mutedAuthor"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "required": [
-                    "mutes"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
             "description": "OK"
           },
           "400": {

--- a/docs/reference/lexicons.md
+++ b/docs/reference/lexicons.md
@@ -1,6 +1,6 @@
 # Lexicons reference
 
-Chive uses the `pub.chive.*` namespace for all AT Protocol lexicons. These lexicons define 23 record types, 127 queries, and 49 procedures across 24 namespaces. All records are stored in user-controlled PDSes and indexed by the Chive AppView via the ATProto firehose.
+Chive uses the `pub.chive.*` namespace for all AT Protocol lexicons. These lexicons define 23 record types, 128 queries, and 49 procedures across 24 namespaces. All records are stored in user-controlled PDSes and indexed by the Chive AppView via the ATProto firehose.
 
 For the ATProto lexicon specification, see the [Lexicon Guide](https://atproto.com/guides/lexicon).
 
@@ -1387,6 +1387,7 @@ Discovery preferences for personalized recommendations.
 | `pub.chive.actor.autocompleteKeyword`     | Query | 1   | Autocomplete research keywords              |
 | `pub.chive.actor.autocompleteOpenReview`  | Query | 1   | Autocomplete OpenReview profiles            |
 | `pub.chive.actor.discoverAuthorIds`       | Query | 1   | Discover author identifiers from ORCID/name |
+| `pub.chive.actor.listMutes`               | Query | 1   | List the authenticated user's muted authors |
 
 `getMyProfile` (revision 2) returns `affiliations` as an array of `pub.chive.defs#affiliation` objects (not a flat string), plus `previousAffiliations`, `nameVariants`, `researchKeywords`, and external academic IDs.
 

--- a/docs/reference/lexicons.md
+++ b/docs/reference/lexicons.md
@@ -1,6 +1,6 @@
 # Lexicons reference
 
-Chive uses the `pub.chive.*` namespace for all AT Protocol lexicons. These lexicons define 23 record types, 126 queries, and 49 procedures across 24 namespaces. All records are stored in user-controlled PDSes and indexed by the Chive AppView via the ATProto firehose.
+Chive uses the `pub.chive.*` namespace for all AT Protocol lexicons. These lexicons define 23 record types, 127 queries, and 49 procedures across 24 namespaces. All records are stored in user-controlled PDSes and indexed by the Chive AppView via the ATProto firehose.
 
 For the ATProto lexicon specification, see the [Lexicon Guide](https://atproto.com/guides/lexicon).
 
@@ -756,17 +756,18 @@ User-curated related paper link between eprints. Both eprints must exist in Chiv
 
 ### Eprint queries and procedures
 
-| Lexicon                              | Type      | Description                            |
-| ------------------------------------ | --------- | -------------------------------------- |
-| `pub.chive.eprint.getSubmission`     | Query     | Get a single eprint by URI             |
-| `pub.chive.eprint.searchSubmissions` | Query     | Full-text search across eprints        |
-| `pub.chive.eprint.listByAuthor`      | Query     | List eprints by a specific author DID  |
-| `pub.chive.eprint.getChangelog`      | Query     | Get a single changelog entry           |
-| `pub.chive.eprint.listChangelogs`    | Query     | List changelogs for an eprint          |
-| `pub.chive.eprint.listCitations`     | Query     | List citations for an eprint           |
-| `pub.chive.eprint.listRelatedWorks`  | Query     | List related works for an eprint       |
-| `pub.chive.eprint.updateSubmission`  | Procedure | Authorize and prepare an eprint update |
-| `pub.chive.eprint.deleteSubmission`  | Procedure | Authorize an eprint deletion           |
+| Lexicon                              | Type      | Description                              |
+| ------------------------------------ | --------- | ---------------------------------------- |
+| `pub.chive.eprint.getSubmission`     | Query     | Get a single eprint by URI               |
+| `pub.chive.eprint.searchSubmissions` | Query     | Full-text search across eprints          |
+| `pub.chive.eprint.listByAuthor`      | Query     | List eprints by a specific author DID    |
+| `pub.chive.eprint.getChangelog`      | Query     | Get a single changelog entry             |
+| `pub.chive.eprint.listChangelogs`    | Query     | List changelogs for an eprint            |
+| `pub.chive.eprint.listCitations`     | Query     | List citations for an eprint             |
+| `pub.chive.eprint.listRelatedWorks`  | Query     | List related works for an eprint         |
+| `pub.chive.eprint.listDataLinks`     | Query     | List Layers datasets linked to an eprint |
+| `pub.chive.eprint.updateSubmission`  | Procedure | Authorize and prepare an eprint update   |
+| `pub.chive.eprint.deleteSubmission`  | Procedure | Authorize an eprint deletion             |
 
 See [XRPC endpoints](../api-reference/xrpc-endpoints) for parameter and response details.
 

--- a/lexicons/pub/chive/eprint/listDataLinks.json
+++ b/lexicons/pub/chive/eprint/listDataLinks.json
@@ -1,0 +1,69 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.eprint.listDataLinks",
+  "revision": 1,
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List Layers datasets linked to an eprint. Chive does not index pub.layers.eprint.dataLink records; it asks the Layers AppView, which is authoritative for them, and caches the answer briefly. Returns an empty list when Layers is unreachable, so an eprint page never depends on another service being up.",
+      "parameters": {
+        "type": "params",
+        "required": ["eprintUri"],
+        "properties": {
+          "eprintUri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI of the eprint whose data links to list"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["dataLinks", "source"],
+          "properties": {
+            "dataLinks": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "#dataLinkView" }
+            },
+            "source": {
+              "type": "string",
+              "description": "Where the answer came from, so a client can tell an empty list from an unavailable one.",
+              "knownValues": ["layers", "cache", "unavailable"]
+            }
+          }
+        }
+      }
+    },
+    "dataLinkView": {
+      "type": "object",
+      "required": ["uri", "dataKind"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "AT-URI of the dataLink record in its author's repository"
+        },
+        "dataKind": {
+          "type": "string",
+          "description": "Data kind slug, as Layers records it",
+          "maxLength": 128
+        },
+        "dataKindUri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "Knowledge graph node for the data kind, when Layers resolved one"
+        },
+        "description": { "type": "string", "maxLength": 10000 },
+        "paperSection": {
+          "type": "string",
+          "description": "Which part of the paper the data belongs to, such as 'Table 3'",
+          "maxLength": 256
+        },
+        "corpusRef": { "type": "string", "format": "at-uri" },
+        "createdAt": { "type": "string", "format": "datetime" }
+      }
+    }
+  }
+}

--- a/src/api/handlers/xrpc/eprint/index.ts
+++ b/src/api/handlers/xrpc/eprint/index.ts
@@ -8,6 +8,7 @@
 export { deleteSubmission } from './deleteSubmission.js';
 export { getChangelog } from './getChangelog.js';
 export { getSubmission } from './getSubmission.js';
+export { listDataLinks } from './listDataLinks.js';
 export { listByAuthor } from './listByAuthor.js';
 export { listChangelogs } from './listChangelogs.js';
 export { listCitations } from './listCitations.js';
@@ -21,6 +22,7 @@ import { getSubmission } from './getSubmission.js';
 import { listByAuthor } from './listByAuthor.js';
 import { listChangelogs } from './listChangelogs.js';
 import { listCitations } from './listCitations.js';
+import { listDataLinks } from './listDataLinks.js';
 import { listRelatedWorks } from './listRelatedWorks.js';
 import { searchSubmissions } from './searchSubmissions.js';
 import { updateSubmission } from './updateSubmission.js';
@@ -32,6 +34,7 @@ export const eprintMethods = {
   'pub.chive.eprint.deleteSubmission': deleteSubmission,
   'pub.chive.eprint.getChangelog': getChangelog,
   'pub.chive.eprint.getSubmission': getSubmission,
+  'pub.chive.eprint.listDataLinks': listDataLinks,
   'pub.chive.eprint.listByAuthor': listByAuthor,
   'pub.chive.eprint.listChangelogs': listChangelogs,
   'pub.chive.eprint.listCitations': listCitations,

--- a/src/api/handlers/xrpc/eprint/listDataLinks.ts
+++ b/src/api/handlers/xrpc/eprint/listDataLinks.ts
@@ -1,0 +1,69 @@
+/**
+ * XRPC handler for pub.chive.eprint.listDataLinks.
+ *
+ * @remarks
+ * Federates to the Layers AppView rather than reading a Chive index. See
+ * {@link LayersDataLinkService} for why: each AppView stays authoritative for
+ * its own records, and Chive's view cannot drift from Layers'.
+ *
+ * This is deliberately a separate endpoint rather than a field on
+ * `getSubmission`. Folding it in would put an eprint page's render behind
+ * another service's availability; as a separate call the page renders first and
+ * the panel fills in, or does not.
+ *
+ * @packageDocumentation
+ * @public
+ */
+
+import type {
+  QueryParams,
+  OutputSchema,
+} from '../../../../lexicons/generated/types/pub/chive/eprint/listDataLinks.js';
+import { ValidationError } from '../../../../types/errors.js';
+import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
+
+/** Re-exported query parameters for pub.chive.eprint.listDataLinks. */
+export type ListDataLinksParams = QueryParams;
+
+/** Re-exported output schema for pub.chive.eprint.listDataLinks. */
+export type ListDataLinksOutput = OutputSchema;
+
+/**
+ * XRPC method for pub.chive.eprint.listDataLinks query.
+ *
+ * @public
+ */
+export const listDataLinks: XRPCMethod<QueryParams, void, OutputSchema> = {
+  auth: false,
+  handler: async ({ params, c }): Promise<XRPCResponse<OutputSchema>> => {
+    const logger = c.get('logger');
+    const { layersDataLinks } = c.get('services');
+
+    if (!params.eprintUri) {
+      throw new ValidationError('Missing required parameter: eprintUri', 'eprintUri');
+    }
+
+    if (!layersDataLinks) {
+      // Not configured is not an error: an instance that does not federate to
+      // Layers simply has nothing to show, and says so in the same shape.
+      logger.debug('Layers federation is not configured');
+      return {
+        encoding: 'application/json',
+        body: { dataLinks: [], source: 'unavailable' },
+      };
+    }
+
+    const result = await layersDataLinks.listForEprint(params.eprintUri);
+
+    logger.debug('Listed Layers data links', {
+      eprintUri: params.eprintUri,
+      count: result.dataLinks.length,
+      source: result.source,
+    });
+
+    return {
+      encoding: 'application/json',
+      body: { dataLinks: result.dataLinks, source: result.source },
+    };
+  },
+};

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -43,6 +43,7 @@ import type { TrustedEditorService } from '../services/governance/trusted-editor
 import type { PersonalGraphService } from '../services/graph/personal-graph-service.js';
 import type { ImportService } from '../services/import/import-service.js';
 import type { KnowledgeGraphService } from '../services/knowledge-graph/graph-service.js';
+import type { LayersDataLinkService } from '../services/layers/data-link-service.js';
 import type { MetricsService } from '../services/metrics/metrics-service.js';
 import type { ContentReportService } from '../services/moderation/content-report-service.js';
 import type { IPDSRegistry } from '../services/pds-discovery/pds-registry.js';
@@ -239,6 +240,9 @@ export interface ServerConfig {
    */
   readonly graphAlgorithmCache?: GraphAlgorithmCache;
 
+  /** Federated reads of Layers data links; omit to disable the dataset panel. */
+  readonly layersDataLinks?: LayersDataLinkService;
+
   /**
    * Shared, Redis-backed profile lookup.
    *
@@ -428,6 +432,7 @@ export function createServer(config: ServerConfig): Hono<ChiveEnv> {
       import: config.importService,
       pdsSync: config.pdsSyncService,
       graphAlgorithmCache: config.graphAlgorithmCache,
+      layersDataLinks: config.layersDataLinks,
       profileHydrator: config.profileHydrator,
       relevanceLogger: config.relevanceLogger,
       ranking: config.rankingService,

--- a/src/api/types/context.ts
+++ b/src/api/types/context.ts
@@ -30,6 +30,7 @@ import type { TrustedEditorService } from '../../services/governance/trusted-edi
 import type { PersonalGraphService } from '../../services/graph/personal-graph-service.js';
 import type { ImportService } from '../../services/import/import-service.js';
 import type { KnowledgeGraphService } from '../../services/knowledge-graph/graph-service.js';
+import type { LayersDataLinkService } from '../../services/layers/data-link-service.js';
 import type { MetricsService } from '../../services/metrics/metrics-service.js';
 import type { ContentReportService } from '../../services/moderation/content-report-service.js';
 import type { IPDSRegistry } from '../../services/pds-discovery/pds-registry.js';
@@ -78,6 +79,14 @@ export interface ChiveServices {
   readonly discovery?: DiscoveryService;
   readonly recommendationService?: RecommendationService;
   readonly graphAlgorithmCache?: GraphAlgorithmCache;
+
+  /**
+   * Federated reads of Layers data links.
+   *
+   * Optional: an instance that does not federate to Layers simply has no
+   * dataset panel, and the handler says so rather than failing.
+   */
+  readonly layersDataLinks?: LayersDataLinkService;
   readonly profileHydrator?: ProfileHydrator;
   readonly trustedEditor?: TrustedEditorService;
   readonly governancePdsWriter?: GovernancePDSWriter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import { TrustedEditorService } from './services/governance/trusted-editor-servi
 import { PersonalGraphService } from './services/graph/personal-graph-service.js';
 import { ImportService } from './services/import/import-service.js';
 import { KnowledgeGraphService } from './services/knowledge-graph/graph-service.js';
+import { LayersDataLinkService } from './services/layers/data-link-service.js';
 import { MetricsService } from './services/metrics/metrics-service.js';
 import { ContentReportService } from './services/moderation/content-report-service.js';
 import { PDSRegistry } from './services/pds-discovery/pds-registry.js';
@@ -463,6 +464,16 @@ function createServices(
   // never used its cache. Same Redis, same key space as the job.
   const graphAlgorithmCache = new GraphAlgorithmCache({ redis, logger });
 
+  // Layers is a separate AppView and is authoritative for `pub.layers.*`
+  // records, so Chive asks it rather than indexing that collection. The service
+  // degrades to an empty list when Layers cannot be reached, which is currently
+  // the usual case — the public AppView is not yet answering.
+  const layersDataLinks = new LayersDataLinkService({
+    redis,
+    logger,
+    ...(process.env.LAYERS_APPVIEW_URL ? { appViewUrl: process.env.LAYERS_APPVIEW_URL } : {}),
+  });
+
   // The hydrator's cache is the point of it: without one it makes the same
   // appview request per page render. Redis is already here, so it gets one.
   const profileHydrator = new ProfileHydrator({ logger, cache: redis });
@@ -591,6 +602,7 @@ function createServices(
     importService,
     pdsSyncService,
     graphAlgorithmCache,
+    layersDataLinks,
     profileHydrator,
     relevanceLogger,
     activityService,

--- a/src/services/layers/data-link-service.ts
+++ b/src/services/layers/data-link-service.ts
@@ -1,0 +1,246 @@
+/**
+ * Federated reads of Layers data links.
+ *
+ * @remarks
+ * `pub.layers.eprint.dataLink` records associate an eprint with the Layers
+ * datasets it produced — a corpus, an annotation layer, an evaluation set. They
+ * live in their authors' repositories and the Layers AppView is authoritative
+ * for them.
+ *
+ * Chive asks Layers rather than indexing the collection itself. Each AppView
+ * stays authoritative for its own records, Chive's view cannot drift from
+ * Layers', and no change to the firehose filter is needed. The cost is that
+ * these links are not searchable from Chive and the panel depends on Layers
+ * being reachable — which is why every failure here degrades to an empty list
+ * rather than an error.
+ *
+ * That degradation is the common case today, not a rare one: `api.layers.pub`
+ * does not currently answer. An eprint page must render exactly as well when
+ * Layers is absent as when it is present.
+ *
+ * @packageDocumentation
+ */
+
+import type { Redis } from 'ioredis';
+
+import type { ILogger } from '../../types/interfaces/logger.interface.js';
+
+/**
+ * A data link as Chive presents it.
+ *
+ * @public
+ */
+export interface DataLinkView {
+  readonly uri: string;
+  readonly dataKind: string;
+  readonly dataKindUri?: string;
+  readonly description?: string;
+  readonly paperSection?: string;
+  readonly corpusRef?: string;
+  readonly createdAt?: string;
+}
+
+/**
+ * Where an answer came from.
+ *
+ * @remarks
+ * A client cannot otherwise tell "this eprint has no linked data" from "Layers
+ * did not answer", and those mean different things to a reader.
+ *
+ * @public
+ */
+export type DataLinkSource = 'layers' | 'cache' | 'unavailable';
+
+/** Result of a data link lookup. */
+export interface DataLinkResult {
+  readonly dataLinks: DataLinkView[];
+  readonly source: DataLinkSource;
+}
+
+/** Options for {@link LayersDataLinkService}. */
+export interface LayersDataLinkServiceOptions {
+  readonly redis: Redis;
+  readonly logger: ILogger;
+  /** Base URL of the Layers AppView. */
+  readonly appViewUrl?: string;
+  /** How long an answer stays cached, in seconds. */
+  readonly cacheTtlSeconds?: number;
+  /** How long to wait for Layers before giving up, in milliseconds. */
+  readonly timeoutMs?: number;
+}
+
+const DEFAULT_APPVIEW_URL = 'https://api.layers.pub';
+const DEFAULT_CACHE_TTL_SECONDS = 300;
+
+/**
+ * Short on purpose.
+ *
+ * @remarks
+ * This call sits on an eprint page render. A slow or absent Layers must cost a
+ * reader a fraction of a second, not the several seconds a default fetch would
+ * spend before giving up.
+ */
+const DEFAULT_TIMEOUT_MS = 2000;
+
+/** Cache key prefix, namespaced so it cannot collide with Chive's own records. */
+const CACHE_PREFIX = 'chive:layers:datalinks:';
+
+/**
+ * Reads Layers data links for an eprint.
+ *
+ * @public
+ */
+export class LayersDataLinkService {
+  private readonly redis: Redis;
+  private readonly logger: ILogger;
+  private readonly appViewUrl: string;
+  private readonly cacheTtlSeconds: number;
+  private readonly timeoutMs: number;
+
+  constructor(options: LayersDataLinkServiceOptions) {
+    this.redis = options.redis;
+    this.logger = options.logger.child({ service: 'LayersDataLinkService' });
+    this.appViewUrl = (options.appViewUrl ?? DEFAULT_APPVIEW_URL).replace(/\/+$/, '');
+    this.cacheTtlSeconds = options.cacheTtlSeconds ?? DEFAULT_CACHE_TTL_SECONDS;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /**
+   * List the Layers datasets linked to an eprint.
+   *
+   * @param eprintUri - AT-URI of the eprint
+   * @returns The links and where they came from; never throws
+   *
+   * @remarks
+   * Every failure path returns `unavailable` with an empty list. A reader
+   * should see an eprint page whether or not another service is up, and a
+   * caller should be able to tell that from a genuine absence of links.
+   */
+  async listForEprint(eprintUri: string): Promise<DataLinkResult> {
+    const key = `${CACHE_PREFIX}${eprintUri}`;
+
+    const cached = await this.readCache(key);
+    if (cached) return { dataLinks: cached, source: 'cache' };
+
+    const fetched = await this.fetchFromLayers(eprintUri);
+    if (!fetched) return { dataLinks: [], source: 'unavailable' };
+
+    // Cached even when empty: "this eprint has no linked data" is an answer
+    // worth not asking for again on every page view.
+    await this.writeCache(key, fetched);
+    return { dataLinks: fetched, source: 'layers' };
+  }
+
+  private async readCache(key: string): Promise<DataLinkView[] | null> {
+    try {
+      const raw = await this.redis.get(key);
+      if (!raw) return null;
+      return JSON.parse(raw) as DataLinkView[];
+    } catch (error) {
+      // A corrupt or unreachable cache must not stop the fetch behind it.
+      this.logger.debug('Data link cache read failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  private async writeCache(key: string, links: DataLinkView[]): Promise<void> {
+    try {
+      await this.redis.setex(key, this.cacheTtlSeconds, JSON.stringify(links));
+    } catch (error) {
+      this.logger.debug('Data link cache write failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Ask the Layers AppView.
+   *
+   * @returns The records, or null when Layers could not be reached or answered
+   * with something unusable
+   */
+  private async fetchFromLayers(eprintUri: string): Promise<DataLinkView[] | null> {
+    const url =
+      `${this.appViewUrl}/xrpc/pub.layers.eprint.listDataLinks` +
+      `?eprintUri=${encodeURIComponent(eprintUri)}`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json' },
+      });
+
+      if (!response.ok) {
+        this.logger.debug('Layers AppView returned an error', {
+          status: response.status,
+          eprintUri,
+        });
+        return null;
+      }
+
+      const body = (await response.json()) as { records?: unknown };
+      if (!Array.isArray(body.records)) {
+        this.logger.warn('Layers AppView returned an unexpected shape', { eprintUri });
+        return null;
+      }
+
+      return body.records.map((record) => toView(record)).filter((v): v is DataLinkView => !!v);
+    } catch (error) {
+      // Includes the abort. Debug rather than warn: with Layers not yet
+      // deployed this is the ordinary case, and logging it loudly on every
+      // eprint view would bury real problems.
+      this.logger.debug('Layers AppView unreachable', {
+        error: error instanceof Error ? error.message : String(error),
+        eprintUri,
+      });
+      return null;
+    } finally {
+      // Without this a settled request leaves a live two-second timer behind,
+      // one per eprint view, each one holding the event loop and eventually
+      // aborting a controller nobody is listening to any more.
+      clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Convert one Layers record into Chive's view of it.
+ *
+ * @param record - A record from the Layers AppView
+ * @returns The view, or null when the record lacks what a reader needs
+ *
+ * @remarks
+ * Only `uri` and `dataKind` are required. A link with neither identifies
+ * nothing and describes nothing, so it is dropped rather than rendered as a
+ * blank row. Everything else is optional in Layers' own lexicon and is passed
+ * through when present.
+ */
+function toView(record: unknown): DataLinkView | null {
+  if (record === null || typeof record !== 'object') return null;
+
+  const r = record as Record<string, unknown>;
+  const value = (r.value ?? r) as Record<string, unknown>;
+
+  const uri = typeof r.uri === 'string' ? r.uri : undefined;
+  const dataKind = typeof value.dataKind === 'string' ? value.dataKind : undefined;
+
+  if (!uri || !dataKind) return null;
+
+  const optional = (key: string): string | undefined =>
+    typeof value[key] === 'string' ? value[key] : undefined;
+
+  return {
+    uri,
+    dataKind,
+    dataKindUri: optional('dataKindUri'),
+    description: optional('description'),
+    paperSection: optional('paperSection'),
+    corpusRef: optional('corpusRef'),
+    createdAt: optional('createdAt'),
+  };
+}

--- a/tests/unit/services/layers/data-link-service.test.ts
+++ b/tests/unit/services/layers/data-link-service.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+import { LayersDataLinkService } from '@/services/layers/data-link-service.js';
+import type { ILogger } from '@/types/interfaces/logger.interface.js';
+
+function createLogger(): ILogger {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+function createRedis(): {
+  store: Map<string, string>;
+  get: ReturnType<typeof vi.fn>;
+  setex: ReturnType<typeof vi.fn>;
+} {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get: vi.fn((k: string) => Promise.resolve(store.get(k) ?? null)),
+    setex: vi.fn((k: string, _ttl: number, v: string) => {
+      store.set(k, v);
+      return Promise.resolve('OK');
+    }),
+  };
+}
+
+const EPRINT = 'at://did:plc:author/pub.chive.eprint.submission/abc';
+
+function build(
+  redis: ReturnType<typeof createRedis>,
+  overrides: Record<string, unknown> = {}
+): LayersDataLinkService {
+  return new LayersDataLinkService({
+    redis: redis as never,
+    logger: createLogger(),
+    ...overrides,
+  });
+}
+
+function layersRecord(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    uri: 'at://did:plc:someone/pub.layers.eprint.dataLink/1',
+    value: { dataKind: 'corpus', paperSection: 'Table 3', ...over },
+  };
+}
+
+describe('LayersDataLinkService', () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it('returns the links Layers reports', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ records: [layersRecord()] }),
+    }) as never;
+
+    const result = await build(createRedis()).listForEprint(EPRINT);
+
+    expect(result.source).toBe('layers');
+    expect(result.dataLinks).toHaveLength(1);
+    expect(result.dataLinks[0]).toMatchObject({ dataKind: 'corpus', paperSection: 'Table 3' });
+  });
+
+  it('reports an unreachable Layers as unavailable, not as no links', async () => {
+    // A reader should be able to tell "this eprint has no data" from "we could
+    // not ask". `api.layers.pub` does not currently answer, so this is the
+    // ordinary path today rather than an edge case.
+    global.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as never;
+
+    const result = await build(createRedis()).listForEprint(EPRINT);
+
+    expect(result.source).toBe('unavailable');
+    expect(result.dataLinks).toEqual([]);
+  });
+
+  it('never throws, whatever Layers does', async () => {
+    const behaviours = [
+      (): Promise<never> => Promise.reject(new Error('network')),
+      (): Promise<unknown> =>
+        Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) }),
+      (): Promise<unknown> =>
+        Promise.resolve({ ok: true, json: () => Promise.reject(new Error('bad json')) }),
+      (): Promise<unknown> =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve({ records: 'not an array' }) }),
+    ];
+
+    for (const behaviour of behaviours) {
+      global.fetch = vi.fn(behaviour) as never;
+      await expect(build(createRedis()).listForEprint(EPRINT)).resolves.toMatchObject({
+        source: 'unavailable',
+        dataLinks: [],
+      });
+    }
+  });
+
+  it('does not cache an unavailable answer', async () => {
+    // Caching a failure would keep the panel empty for the whole TTL after
+    // Layers came back.
+    const redis = createRedis();
+    global.fetch = vi.fn().mockRejectedValue(new Error('down')) as never;
+
+    await build(redis).listForEprint(EPRINT);
+
+    expect(redis.setex).not.toHaveBeenCalled();
+  });
+
+  it('caches an empty answer, which is a real answer', async () => {
+    const redis = createRedis();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ records: [] }),
+    }) as never;
+
+    await build(redis).listForEprint(EPRINT);
+
+    expect(redis.setex).toHaveBeenCalled();
+  });
+
+  it('serves a second request from cache without asking Layers again', async () => {
+    const redis = createRedis();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ records: [layersRecord()] }),
+    });
+    global.fetch = fetchMock as never;
+
+    const service = build(redis);
+    await service.listForEprint(EPRINT);
+    const second = await service.listForEprint(EPRINT);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(second.source).toBe('cache');
+  });
+
+  it('gives up quickly rather than holding a page render', async () => {
+    // `fetch`'s own default would spend far longer before failing, on a call
+    // that sits on an eprint page render.
+    const redis = createRedis();
+    global.fetch = vi.fn(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () => reject(new Error('aborted')));
+        })
+    ) as never;
+
+    const started = Date.now();
+    const result = await build(redis, { timeoutMs: 50 }).listForEprint(EPRINT);
+
+    expect(result.source).toBe('unavailable');
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('drops a record that identifies nothing', async () => {
+    // Without a uri or a dataKind there is nothing to link to and nothing to
+    // label, so rendering it would produce a blank row.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          records: [layersRecord(), { uri: 'at://x/y/z', value: {} }, { value: { dataKind: 'c' } }],
+        }),
+    }) as never;
+
+    const result = await build(createRedis()).listForEprint(EPRINT);
+
+    expect(result.dataLinks).toHaveLength(1);
+  });
+
+  it('namespaces its cache keys', async () => {
+    const redis = createRedis();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ records: [] }),
+    }) as never;
+
+    await build(redis).listForEprint(EPRINT);
+
+    expect([...redis.store.keys()][0]).toMatch(/^chive:layers:datalinks:/);
+  });
+
+  it('asks the configured AppView, filtered by the eprint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ records: [] }),
+    });
+    global.fetch = fetchMock as never;
+
+    await build(createRedis(), { appViewUrl: 'https://layers.example/' }).listForEprint(EPRINT);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    // Trailing slash normalised, so the path does not double up.
+    expect(url).toContain('https://layers.example/xrpc/pub.layers.eprint.listDataLinks');
+    expect(url).toContain(encodeURIComponent(EPRINT));
+  });
+
+  it('clears the abort timer once a request settles', async () => {
+    const clearSpy = vi.spyOn(global, 'clearTimeout');
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ records: [] }),
+    }) as never;
+
+    await build(createRedis()).listForEprint(EPRINT);
+
+    // A timer left behind holds the event loop and eventually aborts a
+    // controller nobody is listening to, once per eprint view.
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+
+  it('clears the abort timer when the request fails too', async () => {
+    const clearSpy = vi.spyOn(global, 'clearTimeout');
+    global.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as never;
+
+    await build(createRedis()).listForEprint(EPRINT);
+
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});

--- a/web/app/eprints/[...uri]/eprint-content.tsx
+++ b/web/app/eprints/[...uri]/eprint-content.tsx
@@ -67,6 +67,7 @@ import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { useEprint } from '@/lib/hooks/use-eprint';
+import { useDataLinks } from '@/lib/hooks/use-data-links';
 import {
   useReviews,
   useCreateReview,
@@ -168,6 +169,7 @@ export interface EprintDetailContentProps {
  */
 export function EprintDetailContent({ uri }: EprintDetailContentProps) {
   const { data: eprint, isLoading, error } = useEprint(uri);
+  const { dataLinks } = useDataLinks(uri);
   const [currentVersion, setCurrentVersion] = useState<number | null>(null);
   const [activeTab, setActiveTab] = useState<string>('abstract');
   const [showReviewForm, setShowReviewForm] = useState(false);
@@ -1287,12 +1289,18 @@ export function EprintDetailContent({ uri }: EprintDetailContentProps) {
             </>
           )}
 
-          {/* Supplementary materials */}
-          {eprint.supplementaryMaterials && eprint.supplementaryMaterials.length > 0 && (
+          {/* Supplementary materials, including datasets linked on Layers */}
+          {((eprint.supplementaryMaterials?.length ?? 0) > 0 || dataLinks.length > 0) && (
             <>
               <Separator />
               <SupplementaryPanel
-                items={eprint.supplementaryMaterials.map((item, index) => {
+                dataLinks={dataLinks.map((link) => ({
+                  uri: link.uri,
+                  dataKind: link.dataKind,
+                  description: link.description,
+                  paperSection: link.paperSection,
+                }))}
+                items={(eprint.supplementaryMaterials ?? []).map((item, index) => {
                   const did = eprint.paperDid ?? eprint.submittedBy;
                   const blobCid = item.blob?.ref?.toString();
                   const downloadUrl =

--- a/web/components/eprints/supplementary-panel.datalinks.test.tsx
+++ b/web/components/eprints/supplementary-panel.datalinks.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { SupplementaryPanel } from './supplementary-panel';
+import type { DataLinkItem } from './supplementary-panel';
+
+const corpus: DataLinkItem = {
+  uri: 'at://did:plc:author/pub.layers.eprint.dataLink/1',
+  dataKind: 'corpus',
+  description: 'Annotated sentences used for the main experiment.',
+  paperSection: 'Table 3',
+};
+
+describe('SupplementaryPanel data links', () => {
+  it('renders linked datasets when there are no uploaded materials', () => {
+    render(<SupplementaryPanel items={[]} dataLinks={[corpus]} />);
+
+    expect(screen.getByText('Corpus')).toBeInTheDocument();
+    expect(screen.getByText(/Annotated sentences/)).toBeInTheDocument();
+  });
+
+  it('shows the paper section, which is what makes a dataset findable', () => {
+    render(<SupplementaryPanel items={[]} dataLinks={[corpus]} />);
+
+    expect(screen.getByText('Table 3')).toBeInTheDocument();
+  });
+
+  it('omits the section badge when Layers recorded none', () => {
+    render(<SupplementaryPanel items={[]} dataLinks={[{ ...corpus, paperSection: undefined }]} />);
+
+    expect(screen.queryByText('Table 3')).not.toBeInTheDocument();
+    expect(screen.getByText('Corpus')).toBeInTheDocument();
+  });
+
+  it('labels a known data kind slug in prose', () => {
+    render(
+      <SupplementaryPanel items={[]} dataLinks={[{ ...corpus, dataKind: 'annotation-layer' }]} />
+    );
+
+    expect(screen.getByText('Annotation layer')).toBeInTheDocument();
+  });
+
+  it('shows an unrecognized data kind verbatim rather than dropping it', () => {
+    render(<SupplementaryPanel items={[]} dataLinks={[{ ...corpus, dataKind: 'eye-tracking' }]} />);
+
+    expect(screen.getByText('eye-tracking')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are neither materials nor datasets', () => {
+    const { container } = render(<SupplementaryPanel items={[]} dataLinks={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders every linked dataset', () => {
+    render(
+      <SupplementaryPanel
+        items={[]}
+        dataLinks={[
+          corpus,
+          {
+            ...corpus,
+            uri: 'at://did:plc:author/pub.layers.eprint.dataLink/2',
+            dataKind: 'model-output',
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Corpus')).toBeInTheDocument();
+    expect(screen.getByText('Model output')).toBeInTheDocument();
+  });
+});

--- a/web/components/eprints/supplementary-panel.tsx
+++ b/web/components/eprints/supplementary-panel.tsx
@@ -66,11 +66,34 @@ export interface SupplementaryItem {
 }
 
 /**
+ * A Layers dataset linked to this eprint.
+ *
+ * @remarks
+ * These are not Chive records. `pub.layers.eprint.dataLink` lives in its
+ * author's repository and the Layers AppView is authoritative for it; Chive
+ * federates the read. They appear here rather than in a panel of their own
+ * because a reader looking for the data behind a paper is looking in the same
+ * place they look for its appendix.
+ */
+export interface DataLinkItem {
+  /** AT-URI of the dataLink record */
+  uri: string;
+  /** Data kind slug, as Layers records it */
+  dataKind: string;
+  /** Free-text description, when the author gave one */
+  description?: string;
+  /** Which part of the paper the data belongs to, such as 'Table 3' */
+  paperSection?: string;
+}
+
+/**
  * Props for SupplementaryPanel component.
  */
 export interface SupplementaryPanelProps {
   /** List of supplementary materials */
   items: SupplementaryItem[];
+  /** Layers datasets linked to this eprint */
+  dataLinks?: DataLinkItem[];
   /** Initial number of items to show before collapse */
   initialVisibleCount?: number;
   /** Additional class names */
@@ -170,6 +193,65 @@ function SupplementaryItemCard({ item }: { item: SupplementaryItem }) {
 }
 
 /**
+ * A single linked dataset.
+ *
+ * @remarks
+ * `paperSection` is given prominence because it is what makes a link useful:
+ * "the corpus" is an offer, "the corpus behind Table 3" is an answer.
+ *
+ * The card does not link out. All we hold is the AT-URI of the dataLink record
+ * in its author's repository, and Layers' web routing is not settled, so any
+ * URL we built from that URI today would be a guess that may 404. Showing the
+ * dataset and saying where it lives is worth more than a broken link.
+ */
+function DataLinkCard({ link }: { link: DataLinkItem }) {
+  return (
+    <div className="flex items-start gap-3 p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors">
+      <div className="shrink-0 mt-0.5 text-violet-500">
+        <Database className="h-5 w-5" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium truncate">{formatDataKind(link.dataKind)}</span>
+          {link.paperSection && (
+            <Badge variant="secondary" className="text-xs shrink-0">
+              {link.paperSection}
+            </Badge>
+          )}
+        </div>
+        {link.description && (
+          <p className="text-sm text-muted-foreground line-clamp-2 mt-1">{link.description}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Render a Layers data kind slug as a label.
+ *
+ * @param kind - Slug such as `annotation-layer`
+ * @returns A human label, or the slug itself when it is not one we know
+ *
+ * @remarks
+ * Layers' lexicon uses `knownValues`, not a closed enum, so a slug this build
+ * has never heard of is expected rather than exceptional. Showing the raw slug
+ * is better than showing nothing or guessing.
+ */
+function formatDataKind(kind: string): string {
+  const known: Record<string, string> = {
+    corpus: 'Corpus',
+    'annotation-layer': 'Annotation layer',
+    'model-output': 'Model output',
+    'gold-standard': 'Gold standard',
+    'evaluation-data': 'Evaluation data',
+    supplementary: 'Supplementary data',
+    replication: 'Replication data',
+  };
+  return known[kind] ?? kind;
+}
+
+/**
  * Supplementary materials panel component.
  *
  * @param props - Component props
@@ -177,6 +259,7 @@ function SupplementaryItemCard({ item }: { item: SupplementaryItem }) {
  */
 export function SupplementaryPanel({
   items,
+  dataLinks = [],
   initialVisibleCount = 5,
   className,
 }: SupplementaryPanelProps) {
@@ -186,7 +269,9 @@ export function SupplementaryPanel({
     setIsExpanded((prev) => !prev);
   }, []);
 
-  if (items.length === 0) {
+  // Either kind of material is reason enough to show the panel. A paper with
+  // linked datasets and no uploaded appendix still has auxiliary material.
+  if (items.length === 0 && dataLinks.length === 0) {
     return null;
   }
 
@@ -231,6 +316,17 @@ export function SupplementaryPanel({
         </div>
       </CardHeader>
       <CardContent className="space-y-2">
+        {dataLinks.length > 0 && (
+          <div className="space-y-2 pb-1">
+            <h3 className="text-sm font-medium text-muted-foreground">
+              Linked datasets
+              <span className="ml-2 font-normal">on Layers</span>
+            </h3>
+            {dataLinks.map((link) => (
+              <DataLinkCard key={link.uri} link={link} />
+            ))}
+          </div>
+        )}
         <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
           <div className="space-y-2">
             {visibleItems.map((item) => (

--- a/web/lib/hooks/use-data-links.test.ts
+++ b/web/lib/hooks/use-data-links.test.ts
@@ -1,0 +1,103 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { createWrapper } from '@/tests/test-utils';
+
+import { dataLinkKeys, useDataLinks } from './use-data-links';
+
+const { mockListDataLinks } = vi.hoisted(() => ({
+  mockListDataLinks: vi.fn(),
+}));
+
+vi.mock('@/lib/api/client', () => ({
+  api: {
+    pub: {
+      chive: {
+        eprint: {
+          listDataLinks: mockListDataLinks,
+        },
+      },
+    },
+  },
+}));
+
+const EPRINT_URI = 'at://did:plc:author/pub.chive.eprint.submission/abc123';
+
+describe('dataLinkKeys', () => {
+  it('scopes the key by eprint so two papers do not share a cache entry', () => {
+    expect(dataLinkKeys.forEprint(EPRINT_URI)).not.toEqual(dataLinkKeys.forEprint('at://other'));
+  });
+
+  it('nests under the shared prefix so the whole namespace can be invalidated', () => {
+    expect(dataLinkKeys.forEprint(EPRINT_URI).slice(0, 1)).toEqual(dataLinkKeys.all);
+  });
+});
+
+describe('useDataLinks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the links Layers reported', async () => {
+    mockListDataLinks.mockResolvedValue({
+      data: {
+        dataLinks: [
+          {
+            uri: 'at://did:plc:author/pub.layers.eprint.dataLink/1',
+            dataKind: 'corpus',
+            paperSection: 'Table 3',
+          },
+        ],
+        source: 'layers',
+      },
+    });
+
+    const { result } = renderHook(() => useDataLinks(EPRINT_URI), {
+      wrapper: createWrapper().Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.dataLinks).toHaveLength(1);
+    expect(result.current.source).toBe('layers');
+  });
+
+  it('reports an empty list without a source until the query resolves', () => {
+    mockListDataLinks.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useDataLinks(EPRINT_URI), {
+      wrapper: createWrapper().Wrapper,
+    });
+
+    expect(result.current.dataLinks).toEqual([]);
+    expect(result.current.source).toBeUndefined();
+  });
+
+  it('distinguishes an unreachable Layers from a paper with no datasets', async () => {
+    mockListDataLinks.mockResolvedValue({ data: { dataLinks: [], source: 'unavailable' } });
+
+    const { result } = renderHook(() => useDataLinks(EPRINT_URI), {
+      wrapper: createWrapper().Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.source).toBe('unavailable'));
+    expect(result.current.dataLinks).toEqual([]);
+  });
+
+  it('does not ask Layers before the eprint URI is known', () => {
+    renderHook(() => useDataLinks(undefined), { wrapper: createWrapper().Wrapper });
+
+    expect(mockListDataLinks).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a federated read the server already gave up on', async () => {
+    mockListDataLinks.mockRejectedValue(new Error('network'));
+
+    const { result } = renderHook(() => useDataLinks(EPRINT_URI), {
+      wrapper: createWrapper().Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockListDataLinks).toHaveBeenCalledTimes(1);
+    expect(result.current.dataLinks).toEqual([]);
+  });
+});

--- a/web/lib/hooks/use-data-links.ts
+++ b/web/lib/hooks/use-data-links.ts
@@ -1,0 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api/client';
+import type { DataLinkView } from '@/lib/api/generated/types/pub/chive/eprint/listDataLinks';
+
+/**
+ * Query key factory for Layers data link queries.
+ */
+export const dataLinkKeys = {
+  all: ['data-links'] as const,
+  forEprint: (eprintUri: string) => [...dataLinkKeys.all, eprintUri] as const,
+};
+
+/**
+ * Where the answer came from.
+ *
+ * @remarks
+ * `unavailable` and an empty list are different facts. "This paper has no
+ * linked datasets" is worth showing nothing for; "we could not ask Layers" is
+ * worth not implying the first.
+ */
+export type DataLinkSource = 'layers' | 'cache' | 'unavailable';
+
+/**
+ * Layers datasets linked to an eprint.
+ *
+ * @remarks
+ * Chive does not index `pub.layers.eprint.dataLink`; the Layers AppView is
+ * authoritative for those records and Chive federates the read. The endpoint
+ * answers `unavailable` rather than failing when Layers cannot be reached, so
+ * this hook has no error state worth surfacing — the panel simply has nothing
+ * to show, which is also true when a paper genuinely has no datasets.
+ *
+ * @param eprintUri - AT-URI of the eprint
+ * @returns The links, whether they are still loading, and where they came from
+ *
+ * @public
+ */
+export function useDataLinks(eprintUri: string | undefined): {
+  dataLinks: DataLinkView[];
+  isLoading: boolean;
+  source: DataLinkSource | undefined;
+} {
+  const query = useQuery({
+    queryKey: dataLinkKeys.forEprint(eprintUri ?? ''),
+    enabled: !!eprintUri,
+    queryFn: async () => {
+      const response = await api.pub.chive.eprint.listDataLinks({ eprintUri: eprintUri as string });
+      return response.data;
+    },
+    // The server already caches this for five minutes; asking again sooner
+    // would only move the same answer across the network.
+    staleTime: 5 * 60 * 1000,
+    // A federated read that failed is not worth retrying on the page: the
+    // server has already given up on it once, quickly and deliberately.
+    retry: false,
+  });
+
+  return {
+    dataLinks: query.data?.dataLinks ?? [],
+    isLoading: query.isLoading,
+    source: query.data?.source as DataLinkSource | undefined,
+  };
+}


### PR DESCRIPTION
## Summary

Chive eprint pages now show the datasets an author has linked to a paper on Layers.

Chive does not index `pub.layers.eprint.dataLink`. Layers is the AppView authoritative for its own lexicons, and indexing another service's records would leave Chive serving a stale second copy of data it does not own. Instead Chive federates the read: it asks the Layers AppView which datasets a paper links to, caches the answer in Redis for five minutes, and shows what comes back.

Layers is not deployed yet — `api.layers.pub` currently answers nothing — so degradation is the ordinary case rather than the exceptional one, and the whole path is built around that:

- A two-second timeout, so a dead Layers cannot slow an eprint page.
- `source: 'unavailable'` as a value distinct from an empty list. "This paper has no datasets" and "we could not ask" are different facts and the client can tell them apart.
- Failures are never cached, so recovery is immediate rather than delayed by a TTL.
- The unreachable case logs at `debug`, not `warn`. Warning on every eprint view while Layers is down would bury real problems.

New pieces:

- `pub.chive.eprint.listDataLinks` — a query lexicon, unauthenticated, returning `{dataLinks, source}`.
- `LayersDataLinkService` — the federated read, its cache, and its timeout.
- `useDataLinks` — the frontend hook, `retry: false` since the server already gave up once deliberately.
- A "Linked datasets" section in the existing `SupplementaryPanel`.

The dataset cards do not link out. All Chive holds is the AT-URI of the `dataLink` record in its author's repository, and Layers' web routing is not settled, so any URL built from that URI today would be a guess that may 404. Showing the dataset and naming where it lives is worth more than a broken link. `paperSection` is given a badge because it is what makes a link useful to a reader: "the corpus" is an offer, "the corpus behind Table 3" is an answer.

Also fixed along the way: the abort timer in the fetch path was never cleared, so every settled request left a live two-second timer behind — one per eprint view, each holding the event loop and eventually aborting a controller nobody was listening to. Two regression tests cover the success and failure paths.

## Related Issues

INT-21 in the 0.8.0 backlog.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- `LayersDataLinkService`: 12 unit tests — cache hit and miss, unreachable Layers, malformed response shapes, records dropped for missing `uri` or `dataKind`, cache-key namespacing, URL construction with a trailing slash, and the two timer-clearing regressions.
- `useDataLinks`: 7 tests — resolved links, the loading state, `unavailable` distinguished from empty, no request before the eprint URI is known, and no retry after a failure.
- `SupplementaryPanel`: 7 tests — datasets render with no uploaded materials present, the section badge appears and is omitted correctly, known data-kind slugs are labelled, unknown ones are shown verbatim rather than dropped, and the panel still renders nothing when there is neither materials nor datasets.
- Full unit suite green (4618 tests). Backend and web typechecks clean. `docs/openapi/chive-api.json` regenerated; `docs/reference/lexicons.md` query count updated to 127.

Compliance passes on CI. Locally one summary assertion fails against a stale test database that still carries `muted_authors_index` from the mute branch; that branch updates the expectation itself.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Nothing here is indexed. The read is federated and cached for five minutes in Redis, which is derived state that can be dropped at any moment without loss — Layers remains authoritative for every record shown.

### Breaking Changes

- [x] N/A — no breaking changes
