### PR TITLE
Let submitters link Layers datasets to an eprint from the submission wizard

### DIFF
--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -6677,47 +6677,6 @@
         ],
         "type": "object"
       },
-      "pub.chive.eprint.listDataLinks.dataLinkView": {
-        "properties": {
-          "corpusRef": {
-            "format": "at-uri",
-            "type": "string"
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "dataKind": {
-            "description": "Data kind slug, as Layers records it",
-            "maxLength": 128,
-            "type": "string"
-          },
-          "dataKindUri": {
-            "description": "Knowledge graph node for the data kind, when Layers resolved one",
-            "format": "at-uri",
-            "type": "string"
-          },
-          "description": {
-            "maxLength": 10000,
-            "type": "string"
-          },
-          "paperSection": {
-            "description": "Which part of the paper the data belongs to, such as 'Table 3'",
-            "maxLength": 256,
-            "type": "string"
-          },
-          "uri": {
-            "description": "AT-URI of the dataLink record in its author's repository",
-            "format": "at-uri",
-            "type": "string"
-          }
-        },
-        "required": [
-          "uri",
-          "dataKind"
-        ],
-        "type": "object"
-      },
       "pub.chive.eprint.listRelatedWorks.relatedWorkView": {
         "properties": {
           "createdAt": {

--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -6677,6 +6677,47 @@
         ],
         "type": "object"
       },
+      "pub.chive.eprint.listDataLinks.dataLinkView": {
+        "properties": {
+          "corpusRef": {
+            "format": "at-uri",
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "dataKind": {
+            "description": "Data kind slug, as Layers records it",
+            "maxLength": 128,
+            "type": "string"
+          },
+          "dataKindUri": {
+            "description": "Knowledge graph node for the data kind, when Layers resolved one",
+            "format": "at-uri",
+            "type": "string"
+          },
+          "description": {
+            "maxLength": 10000,
+            "type": "string"
+          },
+          "paperSection": {
+            "description": "Which part of the paper the data belongs to, such as 'Table 3'",
+            "maxLength": 256,
+            "type": "string"
+          },
+          "uri": {
+            "description": "AT-URI of the dataLink record in its author's repository",
+            "format": "at-uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri",
+          "dataKind"
+        ],
+        "type": "object"
+      },
       "pub.chive.eprint.listRelatedWorks.relatedWorkView": {
         "properties": {
           "createdAt": {

--- a/web/components/submit/step-supplementary.datalinks.test.tsx
+++ b/web/components/submit/step-supplementary.datalinks.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for the linked-datasets section of StepSupplementary.
+ *
+ * @remarks
+ * Covers only the Layers data link controls. The supplementary file handling
+ * in the same step is unchanged and tested elsewhere.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, FormProvider } from 'react-hook-form';
+
+import { StepSupplementary } from './step-supplementary';
+import type { EprintFormValues } from './submission-wizard';
+
+// NodeAutocomplete talks to the knowledge graph on focus. The fallback
+// vocabulary is what this section must work without, so the graph is stubbed.
+vi.mock('@/components/forms', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    NodeAutocomplete: ({ placeholder }: { placeholder?: string }) => (
+      <div data-testid="node-autocomplete">{placeholder}</div>
+    ),
+  };
+});
+
+let latestValues: EprintFormValues | undefined;
+
+function renderStep() {
+  const TestComponent = () => {
+    const form = useForm<EprintFormValues>({
+      defaultValues: {
+        title: '',
+        abstract: '',
+        licenseSlug: 'CC-BY-4.0',
+        authors: [],
+        fieldNodes: [],
+        supplementaryMaterials: [],
+        dataLinks: [],
+      } as EprintFormValues,
+    });
+    latestValues = form.watch();
+
+    return (
+      <FormProvider {...form}>
+        <StepSupplementary form={form} />
+      </FormProvider>
+    );
+  };
+
+  return render(<TestComponent />);
+}
+
+describe('StepSupplementary linked datasets', () => {
+  it('offers the section even when no datasets have been added', () => {
+    renderStep();
+
+    expect(screen.getByText('Linked datasets')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add a dataset link/i })).toBeInTheDocument();
+  });
+
+  it('adds a row with a sensible default kind', async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByRole('button', { name: /Add a dataset link/i }));
+
+    expect(latestValues?.dataLinks).toEqual([{ dataKind: 'corpus' }]);
+  });
+
+  it('offers the whole fallback vocabulary when no graph node is chosen', async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByRole('button', { name: /Add a dataset link/i }));
+
+    const select = screen.getByLabelText('Kind of data');
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Annotation layer' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Replication data' })).toBeInTheDocument();
+  });
+
+  it('records the paper section a reader needs to find the data', async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByRole('button', { name: /Add a dataset link/i }));
+    await user.type(screen.getByPlaceholderText(/Table 3, Section 4.2/), 'Table 3');
+
+    expect(latestValues?.dataLinks?.[0]?.paperSection).toBe('Table 3');
+  });
+
+  it('removes a row without disturbing the others', async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    const add = screen.getByRole('button', { name: /Add a dataset link/i });
+    await user.click(add);
+    await user.click(add);
+    expect(latestValues?.dataLinks).toHaveLength(2);
+
+    await user.click(screen.getAllByRole('button', { name: 'Remove dataset link' })[0]);
+
+    expect(latestValues?.dataLinks).toHaveLength(1);
+  });
+
+  it('changes the kind of an existing row', async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByRole('button', { name: /Add a dataset link/i }));
+    await user.selectOptions(screen.getByLabelText('Kind of data'), 'model-output');
+
+    expect(latestValues?.dataLinks?.[0]?.dataKind).toBe('model-output');
+  });
+});

--- a/web/components/submit/step-supplementary.tsx
+++ b/web/components/submit/step-supplementary.tsx
@@ -46,7 +46,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 // Note: Categories are fetched via NodeAutocomplete with subkind='supplementary-category'
-import type { EprintFormValues, SupplementaryMaterialInput } from './submission-wizard';
+import type {
+  DataLinkDraft,
+  EprintFormValues,
+  SupplementaryMaterialInput,
+} from './submission-wizard';
 
 // =============================================================================
 // TYPES
@@ -117,6 +121,10 @@ const SUPPLEMENTARY_ACCEPT = {
 
 const MAX_SUPPLEMENTARY_SIZE = 104857600; // 100MB per file
 const MAX_SUPPLEMENTARY_FILES = 50;
+
+// Each link is a separate record write after the eprint exists, so the ceiling
+// is about how long a submitter waits at the end, not about storage.
+const MAX_DATA_LINKS = 20;
 
 /**
  * Category labels for display (fallback when knowledge graph name not available).
@@ -489,8 +497,129 @@ function SupplementaryItem({
  * @param props - Component props
  * @returns Supplementary materials step element
  */
+/**
+ * Human labels for the vocabulary Layers publishes.
+ *
+ * @remarks
+ * Only a fallback. When a knowledge graph node is chosen its own label wins,
+ * which is the point of the graph being community-expandable.
+ */
+const DATA_KIND_LABELS: Record<string, string> = {
+  corpus: 'Corpus',
+  'annotation-layer': 'Annotation layer',
+  'model-output': 'Model output',
+  'gold-standard': 'Gold standard',
+  'evaluation-data': 'Evaluation data',
+  supplementary: 'Supplementary data',
+  replication: 'Replication data',
+};
+
+interface DataLinkRowProps {
+  item: DataLinkDraft;
+  index: number;
+  onUpdate: (index: number, updates: Partial<DataLinkDraft>) => void;
+  onRemove: (index: number) => void;
+}
+
+/**
+ * One dataset being linked to the eprint.
+ */
+function DataLinkRow({ item, index, onUpdate, onRemove }: DataLinkRowProps) {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <Database className="h-5 w-5 text-muted-foreground shrink-0 mt-2" />
+
+        <div className="flex-1 space-y-3 min-w-0">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Kind of data</label>
+              <NodeAutocomplete
+                kind="type"
+                subkind="data-kind"
+                label="Data Kind"
+                value={item.dataKindUri}
+                onSelect={(node) =>
+                  onUpdate(index, {
+                    dataKind: node.id,
+                    dataKindUri: node.uri,
+                    dataKindName: node.label,
+                  })
+                }
+                placeholder={item.dataKindName ?? DATA_KIND_LABELS[item.dataKind] ?? item.dataKind}
+                className="h-8"
+              />
+              {!item.dataKindUri && (
+                <select
+                  aria-label="Kind of data"
+                  value={item.dataKind}
+                  onChange={(e) => onUpdate(index, { dataKind: e.target.value })}
+                  className="w-full h-8 rounded-md border bg-background px-2 text-sm"
+                >
+                  {Object.entries(DATA_KIND_LABELS).map(([slug, label]) => (
+                    <option key={slug} value={slug}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">
+                Section of the paper <span className="font-normal">(optional)</span>
+              </label>
+              <Input
+                value={item.paperSection ?? ''}
+                onChange={(e) => onUpdate(index, { paperSection: e.target.value || undefined })}
+                placeholder="Table 3, Section 4.2, Appendix A..."
+                className="h-8 text-sm"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">
+              Layers corpus <span className="font-normal">(optional)</span>
+            </label>
+            <Input
+              value={item.corpusRef ?? ''}
+              onChange={(e) => onUpdate(index, { corpusRef: e.target.value || undefined })}
+              placeholder="at://did:plc:.../pub.layers.corpus/..."
+              className="h-8 text-sm font-mono"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Description (optional)</label>
+            <Textarea
+              value={item.description ?? ''}
+              onChange={(e) => onUpdate(index, { description: e.target.value || undefined })}
+              placeholder="What this data is..."
+              rows={2}
+              className="resize-none text-sm"
+            />
+          </div>
+        </div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => onRemove(index)}
+          aria-label="Remove dataset link"
+          className="shrink-0"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function StepSupplementary({ form, className }: StepSupplementaryProps) {
   const watchedMaterials = form.watch('supplementaryMaterials');
+  const watchedDataLinks = form.watch('dataLinks');
   const materials = useMemo(() => watchedMaterials ?? [], [watchedMaterials]);
 
   const [dragIndex, setDragIndex] = useState<number | null>(null);
@@ -573,6 +702,31 @@ export function StepSupplementary({ form, className }: StepSupplementaryProps) {
 
   const canAddMore = materials.length < MAX_SUPPLEMENTARY_FILES;
 
+  const dataLinks = useMemo(() => watchedDataLinks ?? [], [watchedDataLinks]);
+
+  const handleAddDataLink = useCallback(() => {
+    form.setValue('dataLinks', [...dataLinks, { dataKind: 'corpus' }], { shouldValidate: true });
+  }, [dataLinks, form]);
+
+  const handleUpdateDataLink = useCallback(
+    (index: number, updates: Partial<DataLinkDraft>) => {
+      const updated = dataLinks.map((link, i) => (i === index ? { ...link, ...updates } : link));
+      form.setValue('dataLinks', updated, { shouldValidate: true });
+    },
+    [dataLinks, form]
+  );
+
+  const handleRemoveDataLink = useCallback(
+    (index: number) => {
+      form.setValue(
+        'dataLinks',
+        dataLinks.filter((_, i) => i !== index),
+        { shouldValidate: true }
+      );
+    },
+    [dataLinks, form]
+  );
+
   return (
     <div className={cn('space-y-6', className)}>
       {/* Header */}
@@ -629,6 +783,43 @@ export function StepSupplementary({ form, className }: StepSupplementaryProps) {
           </div>
         </div>
       )}
+
+      {/* Datasets linked on Layers */}
+      <section className="space-y-3">
+        <div>
+          <h4 className="font-medium flex items-center gap-2">
+            <Database className="h-4 w-4" />
+            Linked datasets
+            <span className="text-sm font-normal text-muted-foreground">(optional)</span>
+          </h4>
+          <p className="text-sm text-muted-foreground mt-1">
+            Link a corpus, annotation layer or model output that already lives on Layers. These are
+            written to your PDS as Layers records, so they stay yours and stay readable by both
+            services. Naming the section they belong to is what makes them useful to a reader.
+          </p>
+        </div>
+
+        {dataLinks.length > 0 && (
+          <div className="space-y-2">
+            {dataLinks.map((item, index) => (
+              <DataLinkRow
+                key={index}
+                item={item}
+                index={index}
+                onUpdate={handleUpdateDataLink}
+                onRemove={handleRemoveDataLink}
+              />
+            ))}
+          </div>
+        )}
+
+        {dataLinks.length < MAX_DATA_LINKS && (
+          <Button type="button" variant="outline" size="sm" onClick={handleAddDataLink}>
+            <Plus className="h-4 w-4 mr-2" />
+            Add a dataset link
+          </Button>
+        )}
+      </section>
 
       {/* Category guide */}
       <section className="rounded-lg border border-muted bg-muted/30 p-4">

--- a/web/components/submit/submission-wizard.tsx
+++ b/web/components/submit/submission-wizard.tsx
@@ -32,6 +32,7 @@ import { useAuth, useAgent } from '@/lib/auth/auth-context';
 import {
   createEprintRecord,
   createStandardDocument,
+  createLayersDataLinks,
   type CreateRecordResult,
   type EprintRecord,
 } from '@/lib/atproto';
@@ -96,6 +97,31 @@ export type PublicationStatusValue = PublicationStatus;
 // are stored in platformUri/presentationTypeUri fields.
 // Display names are stored in platformName/presentationTypeName fields.
 
+/**
+ * One dataset link as the wizard holds it before submission.
+ *
+ * @remarks
+ * `dataKindName` is carried only so the form can show the label the knowledge
+ * graph gave a node; it is not part of the record. The record keeps the slug
+ * and the node URI, which is what Layers reads.
+ *
+ * @public
+ */
+export interface DataLinkDraft {
+  /** Data kind slug, from the graph node or the fallback vocabulary */
+  dataKind: string;
+  /** AT-URI of the knowledge graph node, when one was chosen */
+  dataKindUri?: string;
+  /** Label of the chosen node, for display only */
+  dataKindName?: string;
+  /** AT-URI of the Layers corpus the data lives in */
+  corpusRef?: string;
+  /** What the data is */
+  description?: string;
+  /** Where in the paper it belongs */
+  paperSection?: string;
+}
+
 export interface EprintFormValues {
   // Step 1: Files
   documentFile?: File;
@@ -108,6 +134,8 @@ export interface EprintFormValues {
 
   // Step 2: Supplementary Materials
   supplementaryMaterials?: SupplementaryMaterialInput[];
+  /** Datasets on Layers to link to this eprint, written after the eprint exists */
+  dataLinks?: DataLinkDraft[];
 
   // Cross-platform discovery (standard.site)
   /** Whether to create a site.standard.document record for cross-platform discovery */
@@ -367,6 +395,19 @@ const formSchema = z.object({
 
   // Step 2: Supplementary Materials
   supplementaryMaterials: z.array(supplementaryMaterialSchema).max(50).optional(),
+  dataLinks: z
+    .array(
+      z.object({
+        dataKind: z.string().min(1, 'Choose a kind of data').max(128),
+        dataKindUri: z.string().optional(),
+        dataKindName: z.string().optional(),
+        corpusRef: z.string().optional(),
+        description: z.string().max(10000).optional(),
+        paperSection: z.string().max(256).optional(),
+      })
+    )
+    .max(20)
+    .optional(),
 
   // Step 3: Metadata
   title: z.string().min(1, 'Title is required').max(500, 'Title too long'),
@@ -979,6 +1020,55 @@ export function SubmissionWizard({
                   : String(standardDocError),
             }
           );
+        }
+      }
+
+      // Write the Layers data links, now that the eprint has a URI.
+      //
+      // A dataLink record requires eprintUri, so this cannot be part of the
+      // submission write. It runs afterwards and never throws: an eprint that
+      // was created successfully must not be rolled back or left orphaned
+      // because a secondary link failed. The submitter is told what did not
+      // land so they can add it again from the eprint page.
+      const dataLinkDrafts = values.dataLinks ?? [];
+      if (dataLinkDrafts.length > 0) {
+        try {
+          submitLogger.info('Creating Layers data links', {
+            eprintUri: result.uri,
+            count: dataLinkDrafts.length,
+          });
+          const { created, failed } = await createLayersDataLinks(targetAgent ?? agent, {
+            eprintUri: result.uri,
+            eprintDid: values.usePaperPds ? values.paperDid : undefined,
+            dataLinks: dataLinkDrafts.map((link) => ({
+              dataKind: link.dataKind,
+              dataKindUri: link.dataKindUri,
+              corpusRef: link.corpusRef,
+              description: link.description,
+              paperSection: link.paperSection,
+            })),
+          });
+
+          if (failed.length > 0) {
+            submitLogger.warn('Some Layers data links were not created', { failed });
+            toast.warning(
+              failed.length === dataLinkDrafts.length
+                ? 'Your paper was saved, but the dataset links were not.'
+                : `Your paper was saved, but ${failed.length} of ${dataLinkDrafts.length} dataset links were not.`,
+              { description: 'You can add them again from the eprint page.' }
+            );
+          } else {
+            submitLogger.info('Layers data links created', { count: created.length });
+          }
+        } catch (dataLinkError) {
+          // Only an unauthenticated agent reaches here; per-record failures are
+          // reported in `failed` rather than thrown.
+          submitLogger.warn('Failed to create Layers data links; eprint was created successfully', {
+            error: dataLinkError instanceof Error ? dataLinkError.message : String(dataLinkError),
+          });
+          toast.warning('Your paper was saved, but the dataset links were not.', {
+            description: 'You can add them again from the eprint page.',
+          });
         }
       }
 

--- a/web/lib/atproto/index.ts
+++ b/web/lib/atproto/index.ts
@@ -29,6 +29,12 @@ export {
   // Standard.site records
   createStandardDocument,
   updateStandardDocument,
+  // Layers records
+  createLayersDataLinks,
+  LAYERS_DATA_KINDS,
+  type LayersDataLinkInput,
+  type CreateLayersDataLinksInput,
+  type CreateLayersDataLinksResult,
   // Record management
   deleteRecord,
   // Utilities

--- a/web/lib/atproto/record-creator.test.ts
+++ b/web/lib/atproto/record-creator.test.ts
@@ -24,6 +24,7 @@ import {
   buildAtUri,
   parseAtUri,
   createStandardDocument,
+  createLayersDataLinks,
   updateStandardDocument,
   deleteStandardDocumentsForEprint,
 } from './record-creator';
@@ -1184,5 +1185,159 @@ describe('updateStandardDocument', () => {
         title: 'Updated Title',
       })
     ).rejects.toThrow('Agent is not authenticated');
+  });
+});
+
+// =============================================================================
+// LAYERS DATA LINK TESTS
+// =============================================================================
+
+describe('createLayersDataLinks', () => {
+  const did = 'did:plc:test123';
+  const eprintUri = `at://${did}/pub.chive.eprint.submission/abc123`;
+
+  it('writes one dataLink record per dataset', async () => {
+    const agent = createMockAgent({ did });
+
+    const result = await createLayersDataLinks(agent, {
+      eprintUri,
+      dataLinks: [{ dataKind: 'corpus' }, { dataKind: 'annotation-layer' }],
+    });
+
+    expect(result.created).toHaveLength(2);
+    expect(result.failed).toEqual([]);
+    expect(agent.com.atproto.repo.createRecord).toHaveBeenCalledTimes(2);
+  });
+
+  it('writes into the Layers collection, not a Chive one', async () => {
+    const agent = createMockAgent({ did });
+
+    await createLayersDataLinks(agent, { eprintUri, dataLinks: [{ dataKind: 'corpus' }] });
+
+    expect(agent.com.atproto.repo.createRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ repo: did, collection: 'pub.layers.eprint.dataLink' })
+    );
+  });
+
+  it('carries the eprint URI, kind and timestamp the lexicon requires', async () => {
+    const agent = createMockAgent({ did });
+
+    await createLayersDataLinks(agent, { eprintUri, dataLinks: [{ dataKind: 'corpus' }] });
+
+    const { record } = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(record.$type).toBe('pub.layers.eprint.dataLink');
+    expect(record.eprintUri).toBe(eprintUri);
+    expect(record.dataKind).toBe('corpus');
+    expect(record.createdAt).toEqual(expect.any(String));
+  });
+
+  it('passes through the optional fields that were given', async () => {
+    const agent = createMockAgent({ did });
+
+    await createLayersDataLinks(agent, {
+      eprintUri,
+      dataLinks: [
+        {
+          dataKind: 'corpus',
+          dataKindUri: 'at://did:plc:graph/pub.chive.graph.node/corpus',
+          corpusRef: 'at://did:plc:author/pub.layers.corpus/xyz',
+          description: 'Sentences used in the main experiment.',
+          paperSection: 'Table 3',
+        },
+      ],
+    });
+
+    const { record } = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(record.dataKindUri).toBe('at://did:plc:graph/pub.chive.graph.node/corpus');
+    expect(record.corpusRef).toBe('at://did:plc:author/pub.layers.corpus/xyz');
+    expect(record.paperSection).toBe('Table 3');
+  });
+
+  it('omits optional fields rather than writing empty ones', async () => {
+    const agent = createMockAgent({ did });
+
+    await createLayersDataLinks(agent, { eprintUri, dataLinks: [{ dataKind: 'corpus' }] });
+
+    const { record } = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(record).not.toHaveProperty('paperSection');
+    expect(record).not.toHaveProperty('corpusRef');
+    expect(record).not.toHaveProperty('eprintDid');
+  });
+
+  it('reports a failed link instead of throwing, so a created eprint is never orphaned', async () => {
+    const agent = createMockAgent({ did });
+    (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('rate limited')
+    );
+
+    const result = await createLayersDataLinks(agent, {
+      eprintUri,
+      dataLinks: [{ dataKind: 'corpus' }],
+    });
+
+    expect(result.created).toEqual([]);
+    expect(result.failed).toEqual([{ dataKind: 'corpus', error: 'rate limited' }]);
+  });
+
+  it('keeps writing the rest of the batch after one link fails', async () => {
+    const agent = createMockAgent({ did });
+    (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('rate limited')
+    );
+
+    const result = await createLayersDataLinks(agent, {
+      eprintUri,
+      dataLinks: [{ dataKind: 'corpus' }, { dataKind: 'model-output' }],
+    });
+
+    expect(result.failed).toHaveLength(1);
+    expect(result.created).toHaveLength(1);
+  });
+
+  it('truncates a description to the length the lexicon allows', async () => {
+    const agent = createMockAgent({ did });
+
+    await createLayersDataLinks(agent, {
+      eprintUri,
+      dataLinks: [{ dataKind: 'corpus', description: 'x'.repeat(20000) }],
+    });
+
+    const { record } = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(record.description).toHaveLength(10000);
+  });
+
+  it('records the paper DID when the eprint lives in a paper account', async () => {
+    const agent = createMockAgent({ did });
+
+    await createLayersDataLinks(agent, {
+      eprintUri,
+      eprintDid: 'did:plc:paperaccount',
+      dataLinks: [{ dataKind: 'corpus' }],
+    });
+
+    const { record } = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(record.eprintDid).toBe('did:plc:paperaccount');
+  });
+
+  it('writes nothing when there are no links', async () => {
+    const agent = createMockAgent({ did });
+
+    const result = await createLayersDataLinks(agent, { eprintUri, dataLinks: [] });
+
+    expect(result).toEqual({ created: [], failed: [] });
+    expect(agent.com.atproto.repo.createRecord).not.toHaveBeenCalled();
+  });
+
+  it('refuses to write for an unauthenticated agent', async () => {
+    const agent = createMockAgent({ authenticated: false });
+
+    await expect(
+      createLayersDataLinks(agent, { eprintUri, dataLinks: [{ dataKind: 'corpus' }] })
+    ).rejects.toThrow('not authenticated');
   });
 });

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -2153,6 +2153,144 @@ export async function createStandardDocument(
 }
 
 /**
+ * The vocabulary Layers publishes for `dataKind`.
+ *
+ * @remarks
+ * These are the lexicon's `knownValues`, not an enum: Layers accepts any slug
+ * up to 128 characters, and the knowledge graph is the real vocabulary. This
+ * list is the fallback offered when no graph node has been chosen, so a
+ * submitter is never blocked on the graph being reachable.
+ *
+ * @public
+ */
+export const LAYERS_DATA_KINDS = [
+  'corpus',
+  'annotation-layer',
+  'model-output',
+  'gold-standard',
+  'evaluation-data',
+  'supplementary',
+  'replication',
+] as const;
+
+/**
+ * One dataset an author is linking to an eprint.
+ *
+ * @public
+ */
+export interface LayersDataLinkInput {
+  /** Data kind slug, from the knowledge graph node or the fallback vocabulary */
+  dataKind: string;
+  /** AT-URI of the knowledge graph node for the kind, when one was chosen */
+  dataKindUri?: string;
+  /** AT-URI of the Layers corpus this data lives in */
+  corpusRef?: string;
+  /** What the data is */
+  description?: string;
+  /** Where in the paper it belongs, such as `Table 3` */
+  paperSection?: string;
+}
+
+/**
+ * Input for {@link createLayersDataLinks}.
+ *
+ * @public
+ */
+export interface CreateLayersDataLinksInput {
+  /** AT-URI of the eprint the data belongs to */
+  eprintUri: string;
+  /** DID of the repository holding the eprint */
+  eprintDid?: string;
+  /** The datasets to link */
+  dataLinks: LayersDataLinkInput[];
+}
+
+/**
+ * The outcome of writing a batch of data links.
+ *
+ * @public
+ */
+export interface CreateLayersDataLinksResult {
+  /** AT-URIs of the records that were written */
+  created: string[];
+  /** The links that could not be written, each with the reason */
+  failed: Array<{ dataKind: string; error: string }>;
+}
+
+/**
+ * Write `pub.layers.eprint.dataLink` records into the author's PDS.
+ *
+ * @param agent - Authenticated ATProto Agent for the repo the records go into
+ * @param input - The eprint and the datasets to link to it
+ * @returns Which links were written and which were not
+ *
+ * @throws Error if the agent is not authenticated
+ *
+ * @remarks
+ * A data link needs the eprint's AT-URI, so it cannot be written in the same
+ * call as the submission. This runs after the eprint exists, and its failures
+ * are reported rather than thrown: an eprint that was created successfully must
+ * not be rolled back or orphaned because a secondary link failed. Each record
+ * is written independently for the same reason, so one bad link does not take
+ * the rest of the batch with it.
+ *
+ * The records are Layers' own lexicon written into the author's repository —
+ * the author's data, in the author's PDS, which Layers indexes from the
+ * firehose. Chive writes nothing to its own store here.
+ *
+ * @example
+ * ```typescript
+ * const eprint = await createEprintRecord(agent, eprintData);
+ * const { created, failed } = await createLayersDataLinks(agent, {
+ *   eprintUri: eprint.uri,
+ *   dataLinks: [{ dataKind: 'corpus', paperSection: 'Table 3' }],
+ * });
+ * ```
+ */
+export async function createLayersDataLinks(
+  agent: Agent,
+  input: CreateLayersDataLinksInput
+): Promise<CreateLayersDataLinksResult> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  const created: string[] = [];
+  const failed: Array<{ dataKind: string; error: string }> = [];
+
+  for (const link of input.dataLinks) {
+    const record = {
+      $type: 'pub.layers.eprint.dataLink',
+      eprintUri: input.eprintUri,
+      dataKind: link.dataKind,
+      createdAt: new Date().toISOString(),
+      ...(input.eprintDid && { eprintDid: input.eprintDid }),
+      ...(link.dataKindUri && { dataKindUri: link.dataKindUri }),
+      ...(link.corpusRef && { corpusRef: link.corpusRef }),
+      ...(link.description && { description: link.description.substring(0, 10000) }),
+      ...(link.paperSection && { paperSection: link.paperSection.substring(0, 256) }),
+    };
+
+    try {
+      const response = await agent.com.atproto.repo.createRecord({
+        repo: did,
+        collection: 'pub.layers.eprint.dataLink',
+        record,
+      });
+      created.push(response.data.uri);
+    } catch (error) {
+      failed.push({
+        dataKind: link.dataKind,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { created, failed };
+}
+
+/**
  * Find and delete every `site.standard.document` record in a repo that points
  * at a given eprint.
  *


### PR DESCRIPTION
## Summary

Submitters can now link a Layers dataset — a corpus, an annotation layer, a model output — to a paper while submitting it. Nothing in Chive referenced `pub.layers` before this.

Layers already defines the association as `pub.layers.eprint.dataLink`, so this writes that record rather than inventing a Chive-side equivalent. The records go into the author's own PDS, which is where they belong: they are the author's data, Layers indexes them from the firehose, and both services read the same record. Chive stores nothing.

**Ordering.** A dataLink requires `eprintUri`, so it cannot be part of the submission write — the wizard has always written one record at the end. The links are written afterwards, in a block modelled on the existing `standard.site` document write, and that block never throws. An eprint that was created successfully must not be rolled back or left orphaned because a secondary link failed. Each record is written independently for the same reason, so one rate-limited write does not take the rest of the batch with it. What did not land is reported to the submitter, who is told they can add it again from the eprint page.

**Vocabulary.** `dataKind` comes from `NodeAutocomplete` against the knowledge graph, the same way supplementary categories already do, and sets `dataKindUri` when a node resolves. The lexicon's seven `knownValues` are offered as a plain select underneath, shown only while no node has been chosen. They are `knownValues`, not an enum — Layers accepts any slug — so the graph is the real vocabulary and the fallback exists so a submitter is never blocked on the graph being reachable.

The controls live in the supplementary-materials step, alongside files and code/data repositories, rather than in a step of their own. Attaching a corpus is the same kind of act as attaching an appendix or a Zenodo DOI.

## Related Issues

INT-20 in the 0.8.0 backlog. Pairs with #170 (INT-21), which reads these records back onto the eprint page.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- `createLayersDataLinks`: 11 unit tests — one record per dataset, the Layers collection rather than a Chive one, the three required lexicon fields, optional fields passed through and omitted rather than written empty, description truncated at the lexicon's limit, the paper DID recorded for a paper-account eprint, a failed link reported instead of thrown, the rest of the batch continuing after a failure, an empty batch writing nothing, and an unauthenticated agent refused.
- The wizard section: 6 component tests — the section offered before anything is added, a row added with a sensible default kind, the full fallback vocabulary present when no graph node is chosen, the paper section recorded, a row removed without disturbing the others, and the kind of an existing row changed.
- Full frontend suite green (2600 tests). Compliance green (276 tests). Backend and web typechecks clean; web lint clean.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

The record write is the user's own browser agent writing to the user's own repository, which is what the wizard already does for every eprint and for `site.standard.document`. No Chive service writes anything, and Chive indexes none of these records.

### Breaking Changes

- [x] N/A — no breaking changes
