### PR TITLE
Authenticate the governance PDS writer so delegation and automatic proposals work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,11 +203,25 @@ TRUSTED_PROXY_COUNT=1
 # start so a fresh deployment does not serve an empty result for a day.
 GRAPH_ALGORITHM_INTERVAL_MS=86400000
 
+# --- Governance PDS ----------------------------------------------
+# Credentials for the account holding community-approved authority records.
+#
+# GRAPH_PDS_PASSWORD is the gate: set it and the indexer files automatic field
+# proposals into the governance repository and the API can grant and revoke
+# delegations; leave it unset and both are disabled, with grantDelegation and
+# revokeDelegation answering 503.
+#
+# This used to be gated on GRAPH_PDS_SIGNING_KEY instead, which no configuration
+# set and which the writer never read — it built an unauthenticated agent and
+# ignored the key. Governance PDS writing was dead in every checked-in config.
+# GRAPH_PDS_SIGNING_KEY and GOVERNANCE_SIGNING_KEY are both gone; nothing reads
+# them.
+#
+# The other three name the same account in every deployment and default to it.
+# GRAPH_PDS_PASSWORD=            # required to enable governance writes; no default
 # GRAPH_PDS_URL=https://governance.chive.pub
 # GRAPH_PDS_HANDLE=chive-governance.governance.chive.pub
-# GRAPH_PDS_PASSWORD=            # required; no default
-# GRAPH_PDS_SIGNING_KEY=            # required; no default
-# GOVERNANCE_SIGNING_KEY=            # required; no default
+# GRAPH_PDS_DID=did:plc:5wzpn4a4nbqtz3q45hyud6hd
 
 # --- Email -------------------------------------------------------
 # Read by an email path that nothing currently invokes (DEAD-7).

--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -6677,47 +6677,6 @@
         ],
         "type": "object"
       },
-      "pub.chive.eprint.listDataLinks.dataLinkView": {
-        "properties": {
-          "corpusRef": {
-            "format": "at-uri",
-            "type": "string"
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "dataKind": {
-            "description": "Data kind slug, as Layers records it",
-            "maxLength": 128,
-            "type": "string"
-          },
-          "dataKindUri": {
-            "description": "Knowledge graph node for the data kind, when Layers resolved one",
-            "format": "at-uri",
-            "type": "string"
-          },
-          "description": {
-            "maxLength": 10000,
-            "type": "string"
-          },
-          "paperSection": {
-            "description": "Which part of the paper the data belongs to, such as 'Table 3'",
-            "maxLength": 256,
-            "type": "string"
-          },
-          "uri": {
-            "description": "AT-URI of the dataLink record in its author's repository",
-            "format": "at-uri",
-            "type": "string"
-          }
-        },
-        "required": [
-          "uri",
-          "dataKind"
-        ],
-        "type": "object"
-      },
       "pub.chive.eprint.listRelatedWorks.relatedWorkView": {
         "properties": {
           "createdAt": {

--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -6677,6 +6677,47 @@
         ],
         "type": "object"
       },
+      "pub.chive.eprint.listDataLinks.dataLinkView": {
+        "properties": {
+          "corpusRef": {
+            "format": "at-uri",
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "dataKind": {
+            "description": "Data kind slug, as Layers records it",
+            "maxLength": 128,
+            "type": "string"
+          },
+          "dataKindUri": {
+            "description": "Knowledge graph node for the data kind, when Layers resolved one",
+            "format": "at-uri",
+            "type": "string"
+          },
+          "description": {
+            "maxLength": 10000,
+            "type": "string"
+          },
+          "paperSection": {
+            "description": "Which part of the paper the data belongs to, such as 'Table 3'",
+            "maxLength": 256,
+            "type": "string"
+          },
+          "uri": {
+            "description": "AT-URI of the dataLink record in its author's repository",
+            "format": "at-uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri",
+          "dataKind"
+        ],
+        "type": "object"
+      },
       "pub.chive.eprint.listRelatedWorks.relatedWorkView": {
         "properties": {
           "createdAt": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ import { createResiliencePolicy } from './services/common/resilience.js';
 import { DiscoveryService } from './services/discovery/discovery-service.js';
 import { EprintService } from './services/eprint/eprint-service.js';
 import { EdgeService } from './services/governance/edge-service.js';
+import { readGovernancePDSCredentials } from './services/governance/governance-pds-config.js';
+import { GovernancePDSWriter } from './services/governance/governance-pds-writer.js';
 import { NodeService } from './services/governance/node-service.js';
 import { TrustedEditorService } from './services/governance/trusted-editor-service.js';
 import { PersonalGraphService } from './services/graph/personal-graph-service.js';
@@ -463,6 +465,30 @@ function createServices(
   // never used its cache. Same Redis, same key space as the job.
   const graphAlgorithmCache = new GraphAlgorithmCache({ redis, logger });
 
+  // The governance PDS writer. Only the indexer ever built one, so in the API
+  // process `services.governancePdsWriter` was always undefined and both
+  // `grantDelegation` and `revokeDelegation` answered 503 on every call — the
+  // delegation surface was unreachable rather than merely unused.
+  const governanceCredentials = readGovernancePDSCredentials();
+  const governancePdsWriter = governanceCredentials
+    ? new GovernancePDSWriter({
+        graphPdsDid: governanceCredentials.graphPdsDid,
+        pdsUrl: governanceCredentials.pdsUrl,
+        handle: governanceCredentials.handle,
+        password: governanceCredentials.password,
+        pool: pgPool,
+        cache: redis,
+        logger,
+      })
+    : undefined;
+
+  if (!governancePdsWriter) {
+    logger.warn(
+      'Governance PDS writing is disabled: GRAPH_PDS_PASSWORD is unset. ' +
+        'grantDelegation and revokeDelegation will answer 503.'
+    );
+  }
+
   // The hydrator's cache is the point of it: without one it makes the same
   // appview request per page render. Redis is already here, so it gets one.
   const profileHydrator = new ProfileHydrator({ logger, cache: redis });
@@ -591,6 +617,7 @@ function createServices(
     importService,
     pdsSyncService,
     graphAlgorithmCache,
+    governancePdsWriter,
     profileHydrator,
     relevanceLogger,
     activityService,

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -52,6 +52,7 @@ import { CollectionService } from './services/collection/collection-service.js';
 import { createResiliencePolicy } from './services/common/resilience.js';
 import { EprintService } from './services/eprint/eprint-service.js';
 import { AutomaticProposalService } from './services/governance/automatic-proposal-service.js';
+import { readGovernancePDSCredentials } from './services/governance/governance-pds-config.js';
 import { GovernancePDSWriter } from './services/governance/governance-pds-writer.js';
 import { NodeService } from './services/governance/node-service.js';
 import { PersonalGraphService } from './services/graph/personal-graph-service.js';
@@ -75,7 +76,6 @@ import { TagManager } from './storage/neo4j/tag-manager.js';
 import { PostgreSQLAdapter } from './storage/postgresql/adapter.js';
 import { getDatabaseConfig } from './storage/postgresql/config.js';
 import { closePool, createPool } from './storage/postgresql/connection.js';
-import type { DID } from './types/atproto.js';
 
 /**
  * Indexer configuration loaded from environment variables.
@@ -110,10 +110,8 @@ interface IndexerConfig {
   // PLC Directory
   readonly plcDirectoryUrl: string;
 
-  // Graph PDS (optional for automatic proposals)
-  readonly graphPdsUrl?: string;
-  readonly graphPdsDid?: string;
-  readonly graphPdsSigningKey?: string;
+  // Graph PDS (optional for automatic proposals); see
+  // readGovernancePDSCredentials, which is the single gate both processes use.
 
   // Indexer settings
   readonly concurrency: number;
@@ -153,11 +151,6 @@ function loadConfig(): IndexerConfig {
 
     // PLC Directory
     plcDirectoryUrl: process.env.PLC_DIRECTORY_URL ?? 'https://plc.directory',
-
-    // Graph PDS (optional)
-    graphPdsUrl: process.env.GRAPH_PDS_URL,
-    graphPdsDid: process.env.GRAPH_PDS_DID,
-    graphPdsSigningKey: process.env.GRAPH_PDS_SIGNING_KEY,
 
     // Indexer settings
     concurrency: parseInt(process.env.INDEXER_CONCURRENCY ?? '10', 10),
@@ -458,13 +451,15 @@ async function main(): Promise<void> {
 
     logger.info('Citation extraction pipeline initialized');
 
-    // Create automatic proposal service if graph PDS is configured
+    // Create automatic proposal service if the governance account is configured
     let automaticProposalService: AutomaticProposalService | undefined;
-    if (config.graphPdsUrl && config.graphPdsDid && config.graphPdsSigningKey) {
+    const governanceCredentials = readGovernancePDSCredentials();
+    if (governanceCredentials) {
       const graphPdsWriter = new GovernancePDSWriter({
-        graphPdsDid: config.graphPdsDid as DID,
-        pdsUrl: config.graphPdsUrl,
-        signingKey: config.graphPdsSigningKey,
+        graphPdsDid: governanceCredentials.graphPdsDid,
+        pdsUrl: governanceCredentials.pdsUrl,
+        handle: governanceCredentials.handle,
+        password: governanceCredentials.password,
         pool: pgPool,
         cache: redis,
         logger,
@@ -475,13 +470,13 @@ async function main(): Promise<void> {
         graph: graphAdapter,
         logger,
         governancePdsWriter: graphPdsWriter,
-        graphPdsDid: config.graphPdsDid as DID,
+        graphPdsDid: governanceCredentials.graphPdsDid,
         tagManager,
       });
 
       logger.info('Automatic proposal service initialized', {
-        graphPdsDid: config.graphPdsDid,
-        graphPdsUrl: config.graphPdsUrl,
+        graphPdsDid: governanceCredentials.graphPdsDid,
+        graphPdsUrl: governanceCredentials.pdsUrl,
       });
 
       // Start field promotion job (daily check for tag-to-field promotions)

--- a/src/services/governance/governance-pds-config.ts
+++ b/src/services/governance/governance-pds-config.ts
@@ -1,0 +1,72 @@
+/**
+ * Configuration for writing to the Chive Governance PDS.
+ *
+ * @remarks
+ * The governance PDS holds community-approved authority records. Both the
+ * indexer (which files automatic proposals) and the API (which grants and
+ * revokes delegations) write to it, and both must agree on when writing is
+ * possible. This module is that agreement.
+ *
+ * @packageDocumentation
+ */
+
+import type { DID } from '../../types/atproto.js';
+
+/**
+ * Credentials for the governance account.
+ *
+ * @public
+ */
+export interface GovernancePDSCredentials {
+  /** Base URL of the PDS hosting the governance account */
+  pdsUrl: string;
+  /** DID of the governance repository */
+  graphPdsDid: DID;
+  /** Handle of the governance account */
+  handle: string;
+  /** App password for that account */
+  password: string;
+}
+
+/** Default PDS for the governance account. */
+const DEFAULT_PDS_URL = 'https://governance.chive.pub';
+
+/** Default DID of the governance repository. */
+const DEFAULT_GRAPH_PDS_DID = 'did:plc:5wzpn4a4nbqtz3q45hyud6hd';
+
+/** Default handle of the governance account. */
+const DEFAULT_HANDLE = 'chive-governance.governance.chive.pub';
+
+/**
+ * Read the governance PDS credentials from the environment.
+ *
+ * @returns The credentials, or null when the account password is unset
+ *
+ * @remarks
+ * Only the password has no default, and it is the one value that decides
+ * whether writing is possible: the URL, DID and handle all name the same
+ * account in every deployment, and `scripts/db/seed-governance-pds.ts` already
+ * treats them that way.
+ *
+ * This previously gated on `GRAPH_PDS_SIGNING_KEY`, which no configuration set
+ * and which the writer never used — it built an unauthenticated agent and
+ * ignored the key. Governance PDS writing was therefore dead everywhere, and
+ * `grantDelegation` and `revokeDelegation` answered 503 permanently.
+ *
+ * @public
+ */
+export function readGovernancePDSCredentials(
+  env: NodeJS.ProcessEnv = process.env
+): GovernancePDSCredentials | null {
+  const password = env.GRAPH_PDS_PASSWORD;
+  if (!password) {
+    return null;
+  }
+
+  return {
+    pdsUrl: env.GRAPH_PDS_URL ?? DEFAULT_PDS_URL,
+    graphPdsDid: (env.GRAPH_PDS_DID ?? DEFAULT_GRAPH_PDS_DID) as DID,
+    handle: env.GRAPH_PDS_HANDLE ?? DEFAULT_HANDLE,
+    password,
+  };
+}

--- a/src/services/governance/governance-pds-writer.ts
+++ b/src/services/governance/governance-pds-writer.ts
@@ -21,7 +21,7 @@
  * @public
  */
 
-import { Agent } from '@atproto/api';
+import { AtpAgent } from '@atproto/api';
 import type { Redis } from 'ioredis';
 import type { Pool } from 'pg';
 
@@ -100,7 +100,10 @@ export interface CreateRecordResult {
 export interface GovernancePDSWriterOptions {
   graphPdsDid: DID;
   pdsUrl: string;
-  signingKey: string;
+  /** Handle of the governance account on the PDS */
+  handle: string;
+  /** App password for that account */
+  password: string;
   pool: Pool;
   cache: Redis;
   logger: ILogger;
@@ -114,7 +117,8 @@ export interface GovernancePDSWriterOptions {
  * const writer = new GovernancePDSWriter({
  *   graphPdsDid: 'did:plc:chive-governance' as DID,
  *   pdsUrl: 'https://governance.chive.pub',
- *   signingKey: process.env.GOVERNANCE_SIGNING_KEY!,
+ *   handle: process.env.GRAPH_PDS_HANDLE!,
+ *   password: process.env.GRAPH_PDS_PASSWORD!,
  *   pool,
  *   cache: redis,
  *   logger,
@@ -141,31 +145,59 @@ export interface GovernancePDSWriterOptions {
 export class GovernancePDSWriter {
   private readonly graphPdsDid: DID;
   private readonly pdsUrl: string;
+  private readonly handle: string;
+  private readonly password: string;
   private readonly pool: Pool;
   private readonly logger: ILogger;
-  private agent: Agent | null = null;
+  private agent: AtpAgent | null = null;
+  private login: Promise<AtpAgent> | null = null;
 
   constructor(options: GovernancePDSWriterOptions) {
     this.graphPdsDid = options.graphPdsDid;
     this.pdsUrl = options.pdsUrl;
+    this.handle = options.handle;
+    this.password = options.password;
     this.pool = options.pool;
     this.logger = options.logger;
-
-    // Initialize agent (authentication handled per-operation if needed)
-    void this.initializeAgent(options.signingKey);
-  }
-
-  private initializeAgent(_signingKey: string): void {
-    this.agent = new Agent({ service: this.pdsUrl });
-
-    // For bootstrap operations (like automatic proposals), we may not need authentication
-    // The agent will be used to create records, but authentication may be handled differently
-    // depending on the PDS configuration
 
     this.logger.info('GovernancePDSWriter initialized', {
       graphPdsDid: this.graphPdsDid,
       pdsUrl: this.pdsUrl,
+      handle: this.handle,
     });
+  }
+
+  /**
+   * Get a session-bearing agent for the governance account.
+   *
+   * @returns An authenticated agent
+   *
+   * @remarks
+   * Authentication is deferred to the first write rather than done in the
+   * constructor: a PDS that is briefly unreachable at boot should not take the
+   * whole process down, and most requests never write to the governance
+   * repository at all.
+   *
+   * A failed login clears the cached promise so the next write retries instead
+   * of returning the same rejection forever. Concurrent writes share one login
+   * attempt.
+   */
+  private async getAgent(): Promise<AtpAgent> {
+    if (this.agent?.session) {
+      return this.agent;
+    }
+
+    this.login ??= (async () => {
+      const agent = new AtpAgent({ service: this.pdsUrl });
+      await agent.login({ identifier: this.handle, password: this.password });
+      this.agent = agent;
+      return agent;
+    })().catch((error: unknown) => {
+      this.login = null;
+      throw error;
+    });
+
+    return this.login;
   }
 
   /**
@@ -654,15 +686,9 @@ export class GovernancePDSWriter {
     rkey: string,
     record: unknown
   ): Promise<Result<CreateRecordResult, DatabaseError>> {
-    if (!this.agent) {
-      return {
-        ok: false,
-        error: new DatabaseError('WRITE', 'Agent not initialized'),
-      };
-    }
-
     try {
-      const response = await this.agent.com.atproto.repo.createRecord({
+      const agent = await this.getAgent();
+      const response = await agent.com.atproto.repo.createRecord({
         repo: this.graphPdsDid,
         collection,
         rkey,

--- a/tests/unit/services/governance/auto-proposals.test.ts
+++ b/tests/unit/services/governance/auto-proposals.test.ts
@@ -104,7 +104,8 @@ describe('AutomaticProposalService - checkAndCreateFieldProposals', () => {
     mockGovernancePdsWriter = new GovernancePDSWriter({
       graphPdsDid: GRAPH_PDS_DID,
       pdsUrl: 'https://governance.test',
-      signingKey: 'test-key',
+      handle: 'chive-governance.test',
+      password: 'test-password',
       pool: mockPool,
       cache: mockRedis,
       logger: mockLogger,

--- a/tests/unit/services/governance/automatic-proposal-service.test.ts
+++ b/tests/unit/services/governance/automatic-proposal-service.test.ts
@@ -47,7 +47,8 @@ describe('AutomaticProposalService', () => {
     mockGovernancePdsWriter = new GovernancePDSWriter({
       graphPdsDid,
       pdsUrl: 'https://governance.test',
-      signingKey: 'test-key',
+      handle: 'chive-governance.test',
+      password: 'test-password',
       pool: mockPool,
       cache: mockRedis,
       logger: mockLogger,

--- a/tests/unit/services/governance/governance-pds-config.test.ts
+++ b/tests/unit/services/governance/governance-pds-config.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+
+import { readGovernancePDSCredentials } from '../../../../src/services/governance/governance-pds-config.js';
+
+describe('readGovernancePDSCredentials', () => {
+  it('refuses to report credentials without a password', () => {
+    // The gate that matters. Everything else names the same account in every
+    // deployment; only the password decides whether writing is possible.
+    expect(readGovernancePDSCredentials({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it('treats an empty password as unset rather than as a credential', () => {
+    expect(
+      readGovernancePDSCredentials({ GRAPH_PDS_PASSWORD: '' } as NodeJS.ProcessEnv)
+    ).toBeNull();
+  });
+
+  it('falls back to the account every deployment shares', () => {
+    const credentials = readGovernancePDSCredentials({
+      GRAPH_PDS_PASSWORD: 'secret',
+    } as NodeJS.ProcessEnv);
+
+    expect(credentials).toEqual({
+      pdsUrl: 'https://governance.chive.pub',
+      graphPdsDid: 'did:plc:5wzpn4a4nbqtz3q45hyud6hd',
+      handle: 'chive-governance.governance.chive.pub',
+      password: 'secret',
+    });
+  });
+
+  it('lets a deployment point at another governance account', () => {
+    const credentials = readGovernancePDSCredentials({
+      GRAPH_PDS_PASSWORD: 'secret',
+      GRAPH_PDS_URL: 'https://governance.staging.chive.pub',
+      GRAPH_PDS_DID: 'did:plc:staginggovernance',
+      GRAPH_PDS_HANDLE: 'staging.governance.chive.pub',
+    } as NodeJS.ProcessEnv);
+
+    expect(credentials?.pdsUrl).toBe('https://governance.staging.chive.pub');
+    expect(credentials?.graphPdsDid).toBe('did:plc:staginggovernance');
+    expect(credentials?.handle).toBe('staging.governance.chive.pub');
+  });
+
+  it('does not gate on a signing key, which nothing sets and nothing used', () => {
+    // The old gate. Governance writing was dead in every checked-in config
+    // because of it, and the writer ignored the key even when it was supplied.
+    const credentials = readGovernancePDSCredentials({
+      GRAPH_PDS_SIGNING_KEY: 'a-key',
+    } as NodeJS.ProcessEnv);
+
+    expect(credentials).toBeNull();
+  });
+});

--- a/tests/unit/services/governance/governance-pds-writer-auth.test.ts
+++ b/tests/unit/services/governance/governance-pds-writer-auth.test.ts
@@ -1,0 +1,139 @@
+import type { Redis } from 'ioredis';
+import type { Pool } from 'pg';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GovernancePDSWriter } from '../../../../src/services/governance/governance-pds-writer.js';
+import type { DID, NSID } from '../../../../src/types/atproto.js';
+import type { ILogger } from '../../../../src/types/interfaces/logger.interface.js';
+
+const { mockLogin, mockCreateRecord, sessionRef } = vi.hoisted(() => ({
+  mockLogin: vi.fn(),
+  mockCreateRecord: vi.fn(),
+  sessionRef: { value: undefined as unknown },
+}));
+
+vi.mock('@atproto/api', () => ({
+  AtpAgent: class {
+    service: string;
+    com = { atproto: { repo: { createRecord: mockCreateRecord } } };
+
+    constructor(options: { service: string }) {
+      this.service = options.service;
+    }
+
+    get session() {
+      return sessionRef.value;
+    }
+
+    async login(credentials: { identifier: string; password: string }) {
+      await mockLogin(credentials);
+      sessionRef.value = { did: 'did:plc:governance' };
+    }
+  },
+}));
+
+const createMockLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+});
+
+const GRAPH_PDS_DID = 'did:plc:governance' as DID;
+const COLLECTION = 'pub.chive.graph.authorityRecord' as NSID;
+
+function build() {
+  return new GovernancePDSWriter({
+    graphPdsDid: GRAPH_PDS_DID,
+    pdsUrl: 'https://governance.test',
+    handle: 'chive-governance.test',
+    password: 'test-password',
+    pool: {} as unknown as Pool,
+    cache: {} as unknown as Redis,
+    logger: createMockLogger(),
+  });
+}
+
+describe('GovernancePDSWriter authentication', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionRef.value = undefined;
+    mockCreateRecord.mockResolvedValue({ data: { cid: 'bafyrecord' } });
+  });
+
+  it('does not touch the PDS until something is written', () => {
+    build();
+
+    // A governance PDS that is briefly down at boot must not take the process
+    // with it, and most requests never write to the repository at all.
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it('logs in with the governance account before writing', async () => {
+    const writer = build();
+
+    await writer.createProposalBootstrap(COLLECTION, 'rkey1', { label: 'Linguistics' });
+
+    expect(mockLogin).toHaveBeenCalledWith({
+      identifier: 'chive-governance.test',
+      password: 'test-password',
+    });
+    expect(mockCreateRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ repo: GRAPH_PDS_DID, collection: COLLECTION, rkey: 'rkey1' })
+    );
+  });
+
+  it('writes authenticated, so the record is actually accepted', async () => {
+    // The old writer built an unauthenticated agent and ignored the signing key
+    // it was handed, so every write would have been rejected had one been made.
+    const writer = build();
+
+    const result = await writer.createProposalBootstrap(COLLECTION, 'rkey1', { label: 'x' });
+
+    expect(result.ok).toBe(true);
+    expect(mockLogin).toHaveBeenCalledOnce();
+  });
+
+  it('reuses one session across writes', async () => {
+    const writer = build();
+
+    await writer.createProposalBootstrap(COLLECTION, 'rkey1', { label: 'a' });
+    await writer.createProposalBootstrap(COLLECTION, 'rkey2', { label: 'b' });
+
+    expect(mockLogin).toHaveBeenCalledOnce();
+    expect(mockCreateRecord).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares one login attempt between concurrent writes', async () => {
+    const writer = build();
+
+    await Promise.all([
+      writer.createProposalBootstrap(COLLECTION, 'rkey1', { label: 'a' }),
+      writer.createProposalBootstrap(COLLECTION, 'rkey2', { label: 'b' }),
+    ]);
+
+    expect(mockLogin).toHaveBeenCalledOnce();
+  });
+
+  it('reports a failed login as a write failure rather than throwing', async () => {
+    mockLogin.mockRejectedValueOnce(new Error('invalid password'));
+    const writer = build();
+
+    const result = await writer.createProposalBootstrap(COLLECTION, 'rkey1', { label: 'x' });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('retries the login on the next write instead of failing forever', async () => {
+    mockLogin.mockRejectedValueOnce(new Error('PDS unreachable'));
+    const writer = build();
+
+    const first = await writer.createProposalBootstrap(COLLECTION, 'rkey1', { label: 'x' });
+    const second = await writer.createProposalBootstrap(COLLECTION, 'rkey2', { label: 'y' });
+
+    expect(first.ok).toBe(false);
+    expect(second.ok).toBe(true);
+    expect(mockLogin).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Governance PDS writing was dead in every checked-in configuration. This makes it work.

Two separate faults were stacked on top of each other, and the second is the reason the first was never noticed:

1. **The gate demanded a credential nothing produces.** `GovernancePDSWriter` was built only when `GRAPH_PDS_URL && GRAPH_PDS_DID && GRAPH_PDS_SIGNING_KEY` were all set. No config file, compose file, workflow or secret sets `GRAPH_PDS_SIGNING_KEY`. The scripts that do successfully write to the governance PDS — `seed-governance-pds.ts`, `cleanup-governance-pds.ts` — authenticate with `GRAPH_PDS_PASSWORD` and an ordinary agent login. The writer was gated on a kind of credential this system does not use.

2. **The writer ignored the key anyway.** `initializeAgent(_signingKey)` discarded its argument and built an unauthenticated `Agent`. Had the key ever been set, every write would have been rejected by the PDS. The comment said authentication "may be handled differently depending on the PDS configuration"; it was not handled at all.

So the automatic field-proposal path never filed a proposal, and — because only the indexer ever constructed a writer, never the API — `services.governancePdsWriter` was permanently undefined in the API process, so `grantDelegation` and `revokeDelegation` answered 503 on every call. The delegation surface was unreachable rather than merely unused.

**What changed:**

- `GovernancePDSWriter` takes `handle` and `password` and logs in, the same way the working scripts do. Login is deferred to the first write, so a governance PDS that is briefly down at boot does not take the process with it and the ordinary request that never writes never pays for it. Concurrent writes share one login attempt, and a failed login clears the cached promise so the next write retries rather than returning the same rejection forever.
- `readGovernancePDSCredentials` is a single gate both processes use, so the indexer and the API can no longer disagree about whether governance writing is possible. Only the password has no default; the URL, DID and handle name the same account in every deployment, which is what `seed-governance-pds.ts` already assumed.
- The API process now constructs a writer, so the two delegation endpoints work when the account is configured. When it is not, startup logs a warning saying exactly which endpoints will answer 503 — the previous silence is what let this sit.
- `GRAPH_PDS_SIGNING_KEY` and `GOVERNANCE_SIGNING_KEY` are removed from `.env.example`. Nothing read either one.

## Related Issues

DEAD-4 in the 0.8.0 backlog.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- `readGovernancePDSCredentials`: 5 tests — no credentials without a password, an empty password treated as unset, the shared-account defaults, a deployment pointed at another governance account, and a regression check that a signing key alone no longer opens the gate.
- `GovernancePDSWriter` authentication: 7 tests — no PDS contact until something is written, login with the governance account before the first write, a write that actually carries a session, one session reused across writes, one login shared between concurrent writes, a failed login reported as a write failure rather than thrown, and a retry on the next write instead of failing forever.
- Full unit suite green (4624 tests), compliance green (276 tests), typecheck and lint clean, OpenAPI spec current.

Not tested against a live governance PDS: doing so needs the account password, which is deployment configuration rather than something available to CI.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

The governance PDS is Chive's own repository for community-approved authority records, not a user PDS. Writing to it is the documented design (`.claude/design/12-governance/chive-governance-pds.md`) and is what makes those records ATProto-native and portable. No user repository is touched.

### Breaking Changes

- [x] N/A — no breaking changes

Deployments that set `GRAPH_PDS_SIGNING_KEY` gained nothing from it and lose nothing by dropping it. To enable governance writing, set `GRAPH_PDS_PASSWORD`.
