### PR TITLE
Route admin and form requests through the traced API client

### DIFF
--- a/web/components/forms/did-autocomplete-input.test.tsx
+++ b/web/components/forms/did-autocomplete-input.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for the Chive-author branch of the DID autocomplete.
+ *
+ * @remarks
+ * These pin the label shown for a Chive author. The component previously read
+ * `hasEprints`, which `pub.chive.author.searchAuthors` does not return, so
+ * every Chive author was described as "Has Chive profile" whether or not they
+ * had eprints.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DidAutocompleteInput } from './did-autocomplete-input';
+
+const { mockSearchAuthors } = vi.hoisted(() => ({ mockSearchAuthors: vi.fn() }));
+
+vi.mock('@/lib/api/client', () => ({
+  api: {
+    pub: { chive: { author: { searchAuthors: mockSearchAuthors, getProfile: vi.fn() } } },
+  },
+}));
+
+function author(overrides: Record<string, unknown> = {}) {
+  return {
+    did: 'did:plc:alice',
+    handle: 'alice.bsky.social',
+    displayName: 'Alice',
+    ...overrides,
+  };
+}
+
+describe('DidAutocompleteInput Chive author results', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports how many eprints an author has', async () => {
+    mockSearchAuthors.mockResolvedValue({ data: { authors: [author({ eprintCount: 4 })] } });
+    const user = userEvent.setup();
+
+    render(<DidAutocompleteInput onSelect={vi.fn()} />);
+    await user.type(screen.getByRole('textbox'), 'alice');
+
+    expect(await screen.findByText('4 eprints on Chive')).toBeInTheDocument();
+  });
+
+  it('says one eprint in the singular', async () => {
+    mockSearchAuthors.mockResolvedValue({ data: { authors: [author({ eprintCount: 1 })] } });
+    const user = userEvent.setup();
+
+    render(<DidAutocompleteInput onSelect={vi.fn()} />);
+    await user.type(screen.getByRole('textbox'), 'alice');
+
+    expect(await screen.findByText('1 eprint on Chive')).toBeInTheDocument();
+  });
+
+  it('falls back to the profile label when an author has no eprints', async () => {
+    mockSearchAuthors.mockResolvedValue({ data: { authors: [author({ eprintCount: 0 })] } });
+    const user = userEvent.setup();
+
+    render(<DidAutocompleteInput onSelect={vi.fn()} />);
+    await user.type(screen.getByRole('textbox'), 'alice');
+
+    expect(await screen.findByText('Has Chive profile')).toBeInTheDocument();
+  });
+
+  it('falls back when the count is absent rather than showing NaN', async () => {
+    mockSearchAuthors.mockResolvedValue({ data: { authors: [author()] } });
+    const user = userEvent.setup();
+
+    render(<DidAutocompleteInput onSelect={vi.fn()} />);
+    await user.type(screen.getByRole('textbox'), 'alice');
+
+    expect(await screen.findByText('Has Chive profile')).toBeInTheDocument();
+  });
+
+  it('asks Chive through the typed client', async () => {
+    mockSearchAuthors.mockResolvedValue({ data: { authors: [author({ eprintCount: 2 })] } });
+    const user = userEvent.setup();
+
+    render(<DidAutocompleteInput onSelect={vi.fn()} />);
+    await user.type(screen.getByRole('textbox'), 'alice');
+
+    await screen.findByText('2 eprints on Chive');
+    expect(mockSearchAuthors).toHaveBeenCalledWith(
+      expect.objectContaining({ q: 'alice', limit: 8 }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+});

--- a/web/components/forms/did-autocomplete-input.tsx
+++ b/web/components/forms/did-autocomplete-input.tsx
@@ -18,7 +18,7 @@ import { logger } from '@/lib/observability';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { cn } from '@/lib/utils';
-import { getApiBaseUrl } from '@/lib/api/client';
+import { api } from '@/lib/api/client';
 import type { AuthorAffiliation } from './affiliation-input';
 
 const log = logger.child({ component: 'did-autocomplete-input' });
@@ -124,34 +124,27 @@ function useActorSearch() {
     setIsSearching(true);
     try {
       // Step 1: Search Chive authors first (users with eprints or profiles on Chive)
-      const baseUrl = getApiBaseUrl();
       let chiveActors: AtprotoActor[] = [];
 
       try {
-        const chiveResponse = await fetch(
-          `${baseUrl}/xrpc/pub.chive.author.searchAuthors?q=${encodeURIComponent(cleanQuery)}&limit=8`,
+        const chiveResponse = await api.pub.chive.author.searchAuthors(
+          { q: cleanQuery, limit: 8 },
           { signal: controller.signal }
         );
 
-        if (chiveResponse.ok) {
-          const chiveData = await chiveResponse.json();
-          chiveActors = (chiveData.authors ?? []).map(
-            (author: {
-              did: string;
-              handle?: string;
-              displayName?: string;
-              avatar?: string;
-              hasEprints: boolean;
-              hasProfile: boolean;
-            }) => ({
-              did: author.did,
-              handle: author.handle ?? author.did.split(':')[2]?.slice(0, 8) ?? 'unknown',
-              displayName: author.displayName,
-              avatar: author.avatar,
-              description: author.hasEprints ? 'Has eprints on Chive' : 'Has Chive profile',
-            })
-          );
-        }
+        chiveActors = (chiveResponse.data.authors ?? []).map((author) => ({
+          did: author.did,
+          handle: author.handle ?? author.did.split(':')[2]?.slice(0, 8) ?? 'unknown',
+          displayName: author.displayName,
+          avatar: author.avatar,
+          // `hasEprints` was read here and the lexicon does not declare it, so
+          // every Chive author was labelled "Has Chive profile" regardless.
+          // `eprintCount` is the field the API actually returns.
+          description:
+            author.eprintCount && author.eprintCount > 0
+              ? `${author.eprintCount} eprint${author.eprintCount === 1 ? '' : 's'} on Chive`
+              : 'Has Chive profile',
+        }));
       } catch {
         // Chive search failed, continue with Bluesky fallback
       }
@@ -240,19 +233,12 @@ function getInitials(name?: string, handle?: string): string {
  */
 async function fetchChiveProfile(did: string): Promise<ChiveProfile | null> {
   try {
-    const baseUrl = getApiBaseUrl();
-    const response = await fetch(
-      `${baseUrl}/xrpc/pub.chive.author.getProfile?did=${encodeURIComponent(did)}`,
+    const response = await api.pub.chive.author.getProfile(
+      { did },
       { signal: AbortSignal.timeout(3000) }
     );
 
-    if (!response.ok) {
-      return null;
-    }
-
-    const data = await response.json();
-    // Profile data is nested under 'profile' in the API response
-    const profile = data.profile;
+    const profile = response.data.profile;
     if (!profile) {
       return null;
     }
@@ -260,13 +246,11 @@ async function fetchChiveProfile(did: string): Promise<ChiveProfile | null> {
     return {
       orcid: profile.orcid ?? undefined,
       affiliations:
-        profile.affiliations?.map(
-          (aff: { name: string; rorId?: string; children?: AuthorAffiliation[] }) => ({
-            name: aff.name,
-            rorId: aff.rorId,
-            children: aff.children,
-          })
-        ) ?? undefined,
+        profile.affiliations?.map((aff) => ({
+          name: aff.name,
+          rorId: aff.rorId,
+          children: aff.children as AuthorAffiliation[] | undefined,
+        })) ?? undefined,
     };
   } catch {
     // Profile fetch is best-effort, don't fail selection

--- a/web/components/forms/facet-autocomplete.tsx
+++ b/web/components/forms/facet-autocomplete.tsx
@@ -24,6 +24,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { Layers, Search, Loader2, X } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 
+import { api } from '@/lib/api/client';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -486,40 +487,28 @@ async function searchFacetValues(
   const subkind = DIMENSION_SUBKINDS[dimension];
 
   try {
-    // Build search parameters
-    const params = new URLSearchParams({ query });
-    if (subkind) {
-      params.set('subkind', subkind);
-      params.set('kind', 'type');
-    } else {
-      // For dimensions without subkind, search all objects
-      params.set('kind', 'object');
-    }
-    params.set('status', 'established');
-    params.set('limit', '20');
+    const response = await api.pub.chive.graph.searchNodes({
+      query,
+      ...(subkind ? { subkind, kind: 'type' } : { kind: 'object' }),
+      status: 'established',
+      limit: 20,
+    });
 
-    const response = await fetch(`/xrpc/pub.chive.graph.searchNodes?${params.toString()}`);
-
-    if (!response.ok) {
-      console.debug('Facet search not available');
-      return [];
-    }
-
-    const data = await response.json();
-    return (data.nodes ?? []).map(
-      (node: { id: string; uri: string; label: string; description?: string; slug?: string }) => {
-        const slug = node.slug ?? node.id;
-        return {
-          id: slug,
-          slug,
-          uri: node.uri,
-          label: node.label,
-          description: node.description ?? null,
-          dimension,
-          usageCount: 0,
-        };
-      }
-    );
+    return (response.data.nodes ?? []).map((node) => {
+      // `node.slug` was read here, and the lexicon does not declare one, so it
+      // was always undefined and every suggestion fell back to the node UUID.
+      // `id` is the identifier the API actually returns.
+      const slug = node.id;
+      return {
+        id: slug,
+        slug,
+        uri: node.uri,
+        label: node.label,
+        description: node.description ?? null,
+        dimension,
+        usageCount: 0,
+      };
+    });
   } catch (error) {
     console.debug('Facet search failed:', error);
     return [];

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -344,6 +344,33 @@ function createFetchHandler(options: { authenticated: boolean }): typeof globalT
   };
 }
 
+/**
+ * An instrumented `fetch` for call sites the generated client cannot cover.
+ *
+ * @param options - Whether the request should carry the user's session
+ * @returns A `fetch` that adds correlation headers, logs, and throws `APIError`
+ *
+ * @remarks
+ * The generated client routes every call through {@link createFetchHandler},
+ * which is where request IDs, W3C traceparent headers, structured logging,
+ * Faro reporting and `APIError` all come from. A handful of call sites cannot
+ * use the generated client — the admin surface builds its own service-auth
+ * token per NSID — and those were calling `fetch` directly, so admin requests
+ * carried no trace headers and were invisible in tracing, and their failures
+ * surfaced as bare `Error` rather than `APIError`.
+ *
+ * This gives them the same pipeline. Callers supplying their own
+ * `Authorization` header should pass `authenticated: false`, since the header
+ * they set is preserved and the session lookup would only duplicate work.
+ *
+ * @public
+ */
+export function createInstrumentedFetch(options: {
+  authenticated: boolean;
+}): typeof globalThis.fetch {
+  return createFetchHandler(options);
+}
+
 // =============================================================================
 // API CLIENTS
 // =============================================================================

--- a/web/lib/hooks/use-admin.ts
+++ b/web/lib/hooks/use-admin.ts
@@ -13,7 +13,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { getApiBaseUrl } from '@/lib/api/client';
+import { createInstrumentedFetch, getApiBaseUrl } from '@/lib/api/client';
 import { getServiceAuthToken } from '@/lib/auth/service-auth';
 import { getCurrentAgent } from '@/lib/auth/oauth-client';
 
@@ -28,6 +28,19 @@ import { getCurrentAgent } from '@/lib/auth/oauth-client';
  * @param params - Optional query parameters
  * @returns Parsed JSON response
  */
+/**
+ * The admin surface's request pipeline.
+ *
+ * @remarks
+ * `authenticated: false` because these calls set their own `Authorization`
+ * header: the admin endpoints take a service-auth token scoped to the specific
+ * NSID being called, which the session-based path does not produce. Everything
+ * else — request IDs, traceparent, structured logging, Faro reporting and
+ * `APIError` — is shared with the generated client. These calls used raw
+ * `fetch` and so appeared nowhere in tracing.
+ */
+const adminRequest = createInstrumentedFetch({ authenticated: false });
+
 async function adminFetch<T>(nsid: string, params?: Record<string, string>): Promise<T> {
   const apiBase = getApiBaseUrl();
   const headers: Record<string, string> = {};
@@ -46,14 +59,7 @@ async function adminFetch<T>(nsid: string, params?: Record<string, string>): Pro
     }
   }
 
-  const response = await fetch(url.toString(), { headers });
-
-  if (!response.ok) {
-    const error = (await response.json().catch(() => ({ message: 'Request failed' }))) as {
-      message?: string;
-    };
-    throw new Error(error.message ?? `Admin API error: ${response.status}`);
-  }
+  const response = await adminRequest(url.toString(), { headers });
 
   return response.json() as Promise<T>;
 }
@@ -75,18 +81,11 @@ async function adminPost<T>(nsid: string, body: unknown): Promise<T> {
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  const response = await fetch(`${apiBase}/xrpc/${nsid}`, {
+  const response = await adminRequest(`${apiBase}/xrpc/${nsid}`, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),
   });
-
-  if (!response.ok) {
-    const error = (await response.json().catch(() => ({ message: 'Request failed' }))) as {
-      message?: string;
-    };
-    throw new Error(error.message ?? `Admin API error: ${response.status}`);
-  }
 
   return response.json() as Promise<T>;
 }

--- a/web/tests/unit/hooks/use-admin-pipeline.test.ts
+++ b/web/tests/unit/hooks/use-admin-pipeline.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the admin surface's request pipeline.
+ *
+ * @remarks
+ * The admin endpoints cannot use the generated client — they need a service-auth
+ * token scoped to the specific NSID being called — so they build their own
+ * requests. These tests pin the part that matters: those requests go through
+ * the same instrumented pipeline as every other API call, rather than raw
+ * `fetch`, which left admin traffic invisible in tracing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { createWrapper } from '@/tests/test-utils';
+import { APIError } from '@/lib/errors';
+
+const { mockInstrumentedFetch, mockCreateInstrumentedFetch, mockGetServiceAuthToken, mockAgent } =
+  vi.hoisted(() => {
+    const mockInstrumentedFetch = vi.fn();
+    return {
+      mockInstrumentedFetch,
+      mockCreateInstrumentedFetch: vi.fn(() => mockInstrumentedFetch),
+      mockGetServiceAuthToken: vi.fn(),
+      mockAgent: { did: 'did:plc:admin' },
+    };
+  });
+
+vi.mock('@/lib/api/client', () => ({
+  createInstrumentedFetch: mockCreateInstrumentedFetch,
+  getApiBaseUrl: () => 'https://api.test',
+}));
+
+vi.mock('@/lib/auth/service-auth', () => ({
+  getServiceAuthToken: mockGetServiceAuthToken,
+}));
+
+vi.mock('@/lib/auth/oauth-client', () => ({
+  getCurrentAgent: () => mockAgent,
+}));
+
+const { useAdminOverview, useAssignRole } = await import('@/lib/hooks/use-admin');
+
+// Captured at module load, before beforeEach clears the mock record.
+const pipelineOptions = mockCreateInstrumentedFetch.mock.calls[0]?.[0];
+
+function okResponse(body: unknown) {
+  return { json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+describe('admin request pipeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServiceAuthToken.mockResolvedValue('service-token');
+    mockInstrumentedFetch.mockResolvedValue(okResponse({ totalEprints: 3 }));
+  });
+
+  it('builds its requests on the instrumented pipeline, not raw fetch', () => {
+    // This is the whole point: correlation IDs, traceparent, structured logging,
+    // Faro reporting and APIError all live in that pipeline.
+    expect(pipelineOptions).toEqual({ authenticated: false });
+  });
+
+  it('carries a service-auth token scoped to the endpoint being called', async () => {
+    const { result } = renderHook(() => useAdminOverview(), { wrapper: createWrapper().Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGetServiceAuthToken).toHaveBeenCalledWith(mockAgent, 'pub.chive.admin.getOverview');
+    const [, init] = mockInstrumentedFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer service-token');
+  });
+
+  it('calls the endpoint named by the NSID', async () => {
+    const { result } = renderHook(() => useAdminOverview(), { wrapper: createWrapper().Wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url] = mockInstrumentedFetch.mock.calls[0] as [string];
+    expect(url).toBe('https://api.test/xrpc/pub.chive.admin.getOverview');
+  });
+
+  it('surfaces the pipeline APIError rather than flattening it to Error', async () => {
+    // Callers can branch on status now; before, every failure was a bare Error
+    // carrying only a message.
+    mockInstrumentedFetch.mockRejectedValue(
+      new APIError('Forbidden', 403, '/xrpc/pub.chive.admin.getOverview')
+    );
+
+    const { result } = renderHook(() => useAdminOverview(), { wrapper: createWrapper().Wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(APIError);
+    expect((result.current.error as APIError).statusCode).toBe(403);
+  });
+
+  it('sends mutations as JSON through the same pipeline', async () => {
+    mockInstrumentedFetch.mockResolvedValue(okResponse({ success: true }));
+
+    const { result } = renderHook(() => useAssignRole(), { wrapper: createWrapper().Wrapper });
+    result.current.mutate({ did: 'did:plc:someone', role: 'moderator' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = mockInstrumentedFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.test/xrpc/pub.chive.admin.assignRole');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toEqual({
+      did: 'did:plc:someone',
+      role: 'moderator',
+    });
+  });
+});

--- a/web/tests/unit/hooks/use-admin-pipeline.test.ts
+++ b/web/tests/unit/hooks/use-admin-pipeline.test.ts
@@ -20,7 +20,9 @@ const { mockInstrumentedFetch, mockCreateInstrumentedFetch, mockGetServiceAuthTo
     const mockInstrumentedFetch = vi.fn();
     return {
       mockInstrumentedFetch,
-      mockCreateInstrumentedFetch: vi.fn(() => mockInstrumentedFetch),
+      mockCreateInstrumentedFetch: vi.fn(
+        (_options: { authenticated: boolean }) => mockInstrumentedFetch
+      ),
       mockGetServiceAuthToken: vi.fn(),
       mockAgent: { did: 'did:plc:admin' },
     };

--- a/web/tests/unit/hooks/use-admin.test.ts
+++ b/web/tests/unit/hooks/use-admin.test.ts
@@ -24,6 +24,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('@/lib/api/client', () => ({
   getApiBaseUrl: () => 'https://api.chive.test',
+  // The admin hooks now build their requests on the shared instrumented
+  // pipeline rather than raw fetch. This stands in for it, keeping the same
+  // contract the real one has: a non-ok response throws an APIError carrying
+  // the server's message, so the suite still exercises the error paths through
+  // the stubbed global fetch below.
+  createInstrumentedFetch:
+    () =>
+    async (...args: Parameters<typeof globalThis.fetch>) => {
+      const response = await globalThis.fetch(...args);
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as { message?: string };
+        throw new APIError(
+          body.message ?? 'An unknown error occurred',
+          response.status,
+          typeof args[0] === 'string' ? args[0] : undefined
+        );
+      }
+      return response;
+    },
 }));
 
 vi.mock('@/lib/auth/service-auth', () => ({
@@ -37,6 +56,8 @@ vi.mock('@/lib/auth/oauth-client', () => ({
 // ---------------------------------------------------------------------------
 // Import after mocks are established
 // ---------------------------------------------------------------------------
+
+import { APIError } from '@/lib/errors';
 
 import {
   adminKeys,
@@ -265,7 +286,9 @@ describe('adminFetch (via query hooks)', () => {
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(result.current.error?.message).toBe('Request failed');
+    // The shared pipeline's wording. The admin surface used to say "Request
+    // failed" here, which was its own phrasing for the same condition.
+    expect(result.current.error?.message).toBe('An unknown error occurred');
   });
 
   it('propagates error when getServiceAuthToken throws', async () => {


### PR DESCRIPTION
## Summary

The whole admin surface hand-rolled `fetch`, and so did a handful of components calling Chive's own XRPC. Those requests carried no correlation headers, so admin traffic was invisible in tracing; their failures surfaced as bare `Error` rather than `APIError`, so callers could not branch on status; and their responses were cast to a claimed type with no schema behind it.

The generated client routes every call through one instrumented handler — request ID, W3C `traceparent`, structured request logging, Faro reporting, `APIError` on non-ok. This exports that handler as `createInstrumentedFetch` and puts the outliers on it.

**Admin.** `use-admin.ts` cannot use the generated client: its endpoints take a service-auth token scoped to the specific NSID being called, which the session path does not produce. It now builds its requests on the instrumented pipeline with `authenticated: false` and keeps setting its own `Authorization` header. Roughly forty call sites gain tracing and typed errors without any of them changing. The admin-specific fallback message "Request failed" is gone, replaced by the pipeline's wording for the same condition.

**Own-XRPC form fetches.** Three calls to Chive's own API moved onto the typed client — `pub.chive.author.searchAuthors`, `pub.chive.author.getProfile` and `pub.chive.graph.searchNodes`. External APIs (Crossref, DBLP, arXiv, the Bluesky AppView) keep their own `fetch`; they are not Chive's API and have nothing to gain from Chive's pipeline.

**Two bugs the types caught immediately.** Both hand-rolled call sites were reading fields the lexicon does not declare and the server never sends:

- `did-autocomplete-input.tsx` read `author.hasEprints`, which is always `undefined`, so **every** Chive author was labelled "Has Chive profile" whether or not they had eprints. The API returns `eprintCount`; the label now reports the actual number.
- `facet-autocomplete.tsx` read `node.slug`, also always `undefined`, so every facet suggestion's `id` and `slug` silently fell back to the node UUID. `id` is the identifier the API returns.

Neither was reachable through the typed client, which is the argument for this change rather than a side note to it.

## Related Issues

FE-10 in the 0.8.0 backlog.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- Admin pipeline: 5 new tests — requests built on the instrumented pipeline rather than raw `fetch`, a service-auth token scoped to the endpoint being called, the URL derived from the NSID, `APIError` surfacing with its status intact, and mutations posting JSON through the same path.
- The existing 38-test admin suite still passes, now exercising the pipeline's error contract rather than the hook's own.
- DID autocomplete: 5 new tests — the eprint count reported, the singular form, the fallback when the count is zero, the fallback when it is absent (rather than rendering `NaN`), and the call going through the typed client.
- Full frontend suite green (2593 tests). Typecheck and lint clean.

## Screenshots

None; the visible change is a label that now reads "4 eprints on Chive" where it previously always read "Has Chive profile".

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Read-path only; no data flow changed.

### Breaking Changes

- [x] N/A — no breaking changes

One behavioural note for anyone matching on error text: admin failures with an unparseable body now say "An unknown error occurred" rather than "Request failed", matching the rest of the client.

### Not addressed here

`adminFetch<T>` still returns `response.json() as Promise<T>` — the generic is the caller's claim, not a validated shape. Fixing that properly means either moving the admin endpoints onto the generated client (which needs the service-auth token threaded through it) or adding runtime validation at forty call sites. Worth its own ticket; the tracing and error handling are what made this one urgent.
