### PR TITLE
Follow the cursor so lists that claim to be complete are complete

### DIFF
--- a/web/lib/api/paginate.test.ts
+++ b/web/lib/api/paginate.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { fetchAllPages } from './paginate';
+
+const { mockWarn } = vi.hoisted(() => ({ mockWarn: vi.fn() }));
+
+vi.mock('@/lib/observability', () => ({
+  logger: { warn: mockWarn, info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+describe('fetchAllPages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a single page unchanged when there is no cursor', async () => {
+    const result = await fetchAllPages(async () => ({ items: [1, 2, 3] }));
+
+    expect(result).toEqual({ items: [1, 2, 3], truncated: false });
+  });
+
+  it('follows the cursor past the first page', async () => {
+    // The bug this exists for: a user with more than one page of collections
+    // used to see only the first.
+    const pages = [{ items: [1, 2], cursor: 'a' }, { items: [3, 4], cursor: 'b' }, { items: [5] }];
+    let call = 0;
+
+    const result = await fetchAllPages(async () => pages[call++]);
+
+    expect(result.items).toEqual([1, 2, 3, 4, 5]);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('passes each page its predecessor cursor', async () => {
+    const seen: Array<string | undefined> = [];
+    const pages = [{ items: [1], cursor: 'a' }, { items: [2], cursor: 'b' }, { items: [3] }];
+    let call = 0;
+
+    await fetchAllPages(async (cursor) => {
+      seen.push(cursor);
+      return pages[call++];
+    });
+
+    expect(seen).toEqual([undefined, 'a', 'b']);
+  });
+
+  it('stops at the ceiling rather than walking forever', async () => {
+    let page = 0;
+    const result = await fetchAllPages(async () => ({ items: [1], cursor: `p${page++}` }), {
+      maxPages: 3,
+    });
+
+    expect(result.items).toHaveLength(3);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('says out loud that it truncated, so a cap is never silent', async () => {
+    let page = 0;
+    await fetchAllPages(async () => ({ items: [1], cursor: `p${page++}` }), {
+      maxPages: 2,
+      label: 'collections',
+    });
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining('incomplete'),
+      expect.objectContaining({ label: 'collections', items: 2 })
+    );
+  });
+
+  it('does not warn when the walk finished on its own', async () => {
+    await fetchAllPages(async () => ({ items: [1] }), { label: 'collections' });
+
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('stops when a server repeats a cursor instead of looping on it', async () => {
+    // Not the ceiling: this terminates immediately and is not a truncation.
+    const result = await fetchAllPages(async () => ({ items: [1], cursor: 'same' }), {
+      maxPages: 100,
+    });
+
+    expect(result.items).toEqual([1, 1]);
+    expect(result.truncated).toBe(false);
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('stops on an empty page even when a cursor comes with it', async () => {
+    const result = await fetchAllPages(async () => ({ items: [], cursor: 'next' }));
+
+    expect(result).toEqual({ items: [], truncated: false });
+  });
+
+  it('lets a failure propagate rather than returning a partial list as complete', async () => {
+    let call = 0;
+    await expect(
+      fetchAllPages(async () => {
+        if (call++ === 1) throw new Error('network');
+        return { items: [1], cursor: 'a' };
+      })
+    ).rejects.toThrow('network');
+  });
+});

--- a/web/lib/api/paginate.ts
+++ b/web/lib/api/paginate.ts
@@ -1,0 +1,99 @@
+/**
+ * Cursor pagination for endpoints whose callers want the whole set.
+ *
+ * @remarks
+ * The endpoints are cursor-paginated, so a user with more than a hundred
+ * collections, mutes or personal graph nodes simply stopped seeing them at a
+ * hundred, with nothing in the UI saying so. This module follows the cursor
+ * instead, and when it does hit a ceiling it says so rather than presenting a
+ * truncated list as a complete one.
+ *
+ * @packageDocumentation
+ */
+
+import { logger } from '@/lib/observability';
+
+/** One page of a cursor-paginated response. */
+export interface Page<T> {
+  items: T[];
+  cursor?: string;
+}
+
+/** What {@link fetchAllPages} returns. */
+export interface AllPages<T> {
+  /** Every item fetched, in page order */
+  items: T[];
+  /** Whether the ceiling stopped the walk before the cursor ran out */
+  truncated: boolean;
+}
+
+/**
+ * The default ceiling, in pages.
+ *
+ * @remarks
+ * At the usual page size of 100 this is 5,000 items — far past any real
+ * collection list, and low enough that a server returning a cursor forever
+ * cannot hang a page.
+ */
+const DEFAULT_MAX_PAGES = 50;
+
+/**
+ * Walk a cursor-paginated endpoint to the end.
+ *
+ * @param fetchPage - Fetches one page, given the previous page's cursor
+ * @param options - Ceiling and a label for the warning log
+ * @returns Every item, and whether the ceiling cut the walk short
+ *
+ * @remarks
+ * Stops when the endpoint returns no cursor, returns the same cursor twice (a
+ * server bug that would otherwise loop forever), or returns an empty page. A
+ * walk cut short by the ceiling logs a warning naming the label, because a cap
+ * nobody can see is indistinguishable from complete data.
+ *
+ * @example
+ * ```typescript
+ * const { items, truncated } = await fetchAllPages(async (cursor) => {
+ *   const response = await api.pub.chive.collection.listByOwner({ did, limit: 100, cursor });
+ *   return { items: response.data.collections, cursor: response.data.cursor };
+ * }, { label: 'collections' });
+ * ```
+ *
+ * @public
+ */
+export async function fetchAllPages<T>(
+  fetchPage: (cursor: string | undefined) => Promise<Page<T>>,
+  options?: { maxPages?: number; label?: string }
+): Promise<AllPages<T>> {
+  const maxPages = options?.maxPages ?? DEFAULT_MAX_PAGES;
+  const items: T[] = [];
+  const seenCursors = new Set<string>();
+
+  let cursor: string | undefined;
+  let pages = 0;
+
+  while (pages < maxPages) {
+    const page = await fetchPage(cursor);
+    pages += 1;
+    items.push(...page.items);
+
+    if (!page.cursor || page.items.length === 0) {
+      return { items, truncated: false };
+    }
+
+    // A server that hands back the cursor it was given would otherwise loop
+    // until the ceiling, fetching the same page every time.
+    if (seenCursors.has(page.cursor)) {
+      return { items, truncated: false };
+    }
+    seenCursors.add(page.cursor);
+    cursor = page.cursor;
+  }
+
+  logger.warn('Pagination ceiling reached; results are incomplete', {
+    label: options?.label ?? 'unknown',
+    pages,
+    items: items.length,
+  });
+
+  return { items, truncated: true };
+}

--- a/web/lib/hooks/use-citations.ts
+++ b/web/lib/hooks/use-citations.ts
@@ -29,7 +29,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { APIError } from '@/lib/errors';
-import { authApi, getApiBaseUrl } from '@/lib/api/client';
+import { api, authApi } from '@/lib/api/client';
+import { fetchAllPages } from '@/lib/api/paginate';
 import { createLogger } from '@/lib/observability/logger';
 
 const logger = createLogger({ context: { component: 'use-citations' } });
@@ -189,24 +190,26 @@ export function useEprintCitations(eprintUri: string, options: UseCitationsOptio
         : citationKeys.forEprintWithSource(eprintUri, source),
     queryFn: async (): Promise<ListCitationsResponse> => {
       try {
-        // Use direct fetch since the generated XRPC client may not include this
-        // endpoint yet (backend is being developed in parallel).
-        const searchParams = new URLSearchParams({ eprintUri, limit: '100' });
-        if (source !== 'all') {
-          searchParams.set('source', source);
-        }
-        const baseUrl = getApiBaseUrl();
-        const url = `${baseUrl}/xrpc/pub.chive.eprint.listCitations?${searchParams.toString()}`;
-        const response = await fetch(url);
-        if (!response.ok) {
-          const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
-          throw new APIError(
-            typeof body['message'] === 'string' ? body['message'] : 'Failed to fetch citations',
-            response.status,
-            'pub.chive.eprint.listCitations'
-          );
-        }
-        return (await response.json()) as ListCitationsResponse;
+        // The comment here said the generated client "may not include this
+        // endpoint yet". It does, and the typed client brings the tracing and
+        // error handling the raw fetch lacked.
+        //
+        // A well-cited paper has more than a hundred references, and the
+        // citation list presents itself as the complete set.
+        const { items } = await fetchAllPages(
+          async (cursor) => {
+            const response = await api.pub.chive.eprint.listCitations({
+              eprintUri,
+              limit: 100,
+              ...(source !== 'all' ? { source } : {}),
+              ...(cursor ? { cursor } : {}),
+            });
+            return { items: response.data.citations, cursor: response.data.cursor };
+          },
+          { label: 'eprint.listCitations' }
+        );
+
+        return { citations: items, total: items.length } as unknown as ListCitationsResponse;
       } catch (error) {
         if (error instanceof APIError) throw error;
         throw new APIError(

--- a/web/lib/hooks/use-collections-pagination.test.ts
+++ b/web/lib/hooks/use-collections-pagination.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests that a user's own collection list is complete.
+ *
+ * @remarks
+ * `useMyCollections` asked for one page of 100 and returned it. A user with
+ * more than a hundred collections saw the first hundred, with nothing in the
+ * UI indicating there were more.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { createWrapper } from '@/tests/test-utils';
+
+const { mockListByOwner } = vi.hoisted(() => ({ mockListByOwner: vi.fn() }));
+
+vi.mock('@/lib/api/client', () => ({
+  api: { pub: { chive: {} } },
+  authApi: { pub: { chive: { collection: { listByOwner: mockListByOwner } } } },
+}));
+
+vi.mock('@/lib/auth/oauth-client', () => ({ getCurrentAgent: () => null }));
+
+const { useMyCollections } = await import('./use-collections');
+
+const DID = 'did:plc:owner';
+
+function collection(id: number) {
+  return { uri: `at://${DID}/pub.chive.collection.list/${id}`, name: `Collection ${id}` };
+}
+
+describe('useMyCollections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a single page unchanged', async () => {
+    mockListByOwner.mockResolvedValue({ data: { collections: [collection(1)] } });
+
+    const { result } = renderHook(() => useMyCollections(DID), {
+      wrapper: createWrapper().Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.collections).toHaveLength(1);
+  });
+
+  it('follows the cursor so a user past 100 collections sees them all', async () => {
+    mockListByOwner
+      .mockResolvedValueOnce({
+        data: { collections: [collection(1), collection(2)], cursor: 'p1' },
+      })
+      .mockResolvedValueOnce({ data: { collections: [collection(3)] } });
+
+    const { result } = renderHook(() => useMyCollections(DID), {
+      wrapper: createWrapper().Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.collections).toHaveLength(3);
+    expect(mockListByOwner).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes the cursor back on the following request', async () => {
+    mockListByOwner
+      .mockResolvedValueOnce({ data: { collections: [collection(1)], cursor: 'p1' } })
+      .mockResolvedValueOnce({ data: { collections: [collection(2)] } });
+
+    const { result } = renderHook(() => useMyCollections(DID), {
+      wrapper: createWrapper().Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListByOwner).toHaveBeenNthCalledWith(1, { did: DID, limit: 100 });
+    expect(mockListByOwner).toHaveBeenNthCalledWith(2, { did: DID, limit: 100, cursor: 'p1' });
+  });
+
+  it('does not ask again when the first page is the last', async () => {
+    mockListByOwner.mockResolvedValue({ data: { collections: [collection(1)] } });
+
+    const { result } = renderHook(() => useMyCollections(DID), {
+      wrapper: createWrapper().Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListByOwner).toHaveBeenCalledOnce();
+  });
+});

--- a/web/lib/hooks/use-collections.ts
+++ b/web/lib/hooks/use-collections.ts
@@ -35,6 +35,7 @@ import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from '@tansta
 
 import { APIError } from '@/lib/errors';
 import { api, authApi } from '@/lib/api/client';
+import { fetchAllPages } from '@/lib/api/paginate';
 import { createLogger } from '@/lib/observability/logger';
 import { getCurrentAgent } from '@/lib/auth/oauth-client';
 import {
@@ -298,8 +299,23 @@ export function useMyCollections(did: string, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: collectionKeys.myCollections(did),
     queryFn: async (): Promise<ListCollectionsResponse> => {
-      const response = await authApi.pub.chive.collection.listByOwner({ did, limit: 100 });
-      return response.data as unknown as ListCollectionsResponse;
+      // A user's own collection list is meant to be complete. Asking for one
+      // page of 100 meant a user's collections simply stopped at 100 with
+      // nothing saying so.
+      const { items } = await fetchAllPages(
+        async (cursor) => {
+          const response = await authApi.pub.chive.collection.listByOwner({
+            did,
+            limit: 100,
+            ...(cursor ? { cursor } : {}),
+          });
+          const page = response.data as unknown as ListCollectionsResponse & { cursor?: string };
+          return { items: page.collections ?? [], cursor: page.cursor };
+        },
+        { label: 'collections.listByOwner' }
+      );
+
+      return { collections: items } as unknown as ListCollectionsResponse;
     },
     enabled: !!did && (options?.enabled ?? true),
     staleTime: 2 * 60 * 1000,

--- a/web/lib/hooks/use-edges.ts
+++ b/web/lib/hooks/use-edges.ts
@@ -31,6 +31,7 @@ import {
   PubChiveGraphGetNode,
   PubChiveGraphListNodes,
 } from '@/lib/api/client';
+import { fetchAllPages } from '@/lib/api/paginate';
 import type { OutputSchema as ListEdgesOutput } from '@/lib/api/generated/types/pub/chive/graph/listEdges';
 
 // =============================================================================
@@ -395,15 +396,22 @@ export function useNodeChildren(nodeUri: string, options: UseEdgeOptions = {}) {
   return useQuery({
     queryKey: edgeKeys.children(nodeUri),
     queryFn: async (): Promise<ConnectedNodesResponse> => {
-      const response = await api.pub.chive.graph.listEdges({
-        limit: 100,
-        sourceUri: nodeUri,
-        relationSlug: 'narrower',
-        status: 'established',
-      });
+      const { items: childEdges } = await fetchAllPages(
+        async (cursor) => {
+          const response = await api.pub.chive.graph.listEdges({
+            limit: 100,
+            sourceUri: nodeUri,
+            relationSlug: 'narrower',
+            status: 'established',
+            ...(cursor ? { cursor } : {}),
+          });
+          return { items: response.data.edges, cursor: response.data.cursor };
+        },
+        { label: 'graph.listEdges.nodeChildren' }
+      );
 
       // Extract unique target URIs and fetch nodes
-      const targetUris = [...new Set(response.data.edges.map((e: GraphEdge) => e.targetUri))];
+      const targetUris = [...new Set(childEdges.map((e: GraphEdge) => e.targetUri))];
 
       // Fetch each node (could be optimized with batch endpoint)
       const nodes: GraphNode[] = [];
@@ -417,7 +425,7 @@ export function useNodeChildren(nodeUri: string, options: UseEdgeOptions = {}) {
         }
       }
 
-      return { nodes, edges: response.data.edges };
+      return { nodes, edges: childEdges };
     },
     enabled: !!nodeUri && (options.enabled ?? true),
     staleTime: 5 * 60 * 1000,

--- a/web/lib/hooks/use-endorsement-data.ts
+++ b/web/lib/hooks/use-endorsement-data.ts
@@ -12,6 +12,7 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNodesBySubkind, useNode, type GraphNode } from './use-nodes';
 import { api } from '../api/client';
+import { fetchAllPages } from '../api/paginate';
 
 /**
  * Endorsement type with related data.
@@ -82,16 +83,22 @@ export function useEndorsementCategories() {
       const allEdges: Array<{ sourceUri: string; targetUri: string }> = [];
       for (const type of typesData.nodes) {
         try {
-          const response = await api.pub.chive.graph.listEdges({
-            sourceUri: type.uri,
-            relationSlug: 'relates-to',
-            status: 'established',
-            limit: 100,
-          });
-          if (response.data?.edges) {
-            for (const edge of response.data.edges) {
-              allEdges.push({ sourceUri: edge.sourceUri, targetUri: edge.targetUri });
-            }
+          const { items } = await fetchAllPages(
+            async (cursor) => {
+              const response = await api.pub.chive.graph.listEdges({
+                sourceUri: type.uri,
+                relationSlug: 'relates-to',
+                status: 'established',
+                limit: 100,
+                ...(cursor ? { cursor } : {}),
+              });
+              return { items: response.data?.edges ?? [], cursor: response.data?.cursor };
+            },
+            { label: 'graph.listEdges.endorsementKinds' }
+          );
+
+          for (const edge of items) {
+            allEdges.push({ sourceUri: edge.sourceUri, targetUri: edge.targetUri });
           }
         } catch {
           // Continue if edge query fails

--- a/web/lib/hooks/use-field.ts
+++ b/web/lib/hooks/use-field.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
 
+import { fetchAllPages } from '@/lib/api/paginate';
 import { api } from '@/lib/api/client';
 import { APIError } from '@/lib/errors';
 import type { EprintSummary } from '@/lib/api/schema';
@@ -322,15 +323,21 @@ export function useFieldChildren(fieldUri: string, options: UseFieldChildrenOpti
     queryKey: fieldKeys.children(fieldUri),
     queryFn: async (): Promise<FieldSummaryNode[]> => {
       try {
-        const response = await api.pub.chive.graph.listEdges({
-          limit: 100,
-          sourceUri: fieldUri,
-          relationSlug: 'narrower',
-          status: 'established',
-        });
-        const data = response.data;
-        // Extract target nodes from edges
-        const edges = data?.edges ?? [];
+        // A broad field has more than a hundred children, and the tree shows
+        // itself as the complete set of them.
+        const { items: edges } = await fetchAllPages(
+          async (cursor) => {
+            const response = await api.pub.chive.graph.listEdges({
+              limit: 100,
+              sourceUri: fieldUri,
+              relationSlug: 'narrower',
+              status: 'established',
+              ...(cursor ? { cursor } : {}),
+            });
+            return { items: response.data?.edges ?? [], cursor: response.data?.cursor };
+          },
+          { label: 'graph.listEdges.fieldChildren' }
+        );
         const targetIds = edges
           .map((edge) => edge.targetUri.split('/').pop())
           .filter(Boolean) as string[];

--- a/web/lib/hooks/use-muted-authors.ts
+++ b/web/lib/hooks/use-muted-authors.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { fetchAllPages } from '@/lib/api/paginate';
 import { useCurrentUser, useAgent } from '@/lib/auth';
 import { createMuteRecord, deleteMuteRecord } from '@/lib/atproto/record-creator';
 import type { MuteRecord } from '@/lib/atproto/record-creator';
@@ -60,18 +61,25 @@ export function useMutedAuthors() {
     queryFn: async (): Promise<MutedAuthorsData> => {
       if (isAuthenticated && agent) {
         try {
-          // TODO: Only fetches the first 100 mute records. Users with 100+
-          // mutes would need cursor-based pagination across multiple requests.
-          const response = await agent.com.atproto.repo.listRecords({
-            repo: agent.did!,
-            collection: 'pub.chive.actor.mute',
-            limit: 100,
-          });
+          // A partial mute list is worse than none: an author the user muted
+          // past the hundredth record would silently reappear in their feed.
+          const { items } = await fetchAllPages(
+            async (cursor) => {
+              const response = await agent.com.atproto.repo.listRecords({
+                repo: agent.did!,
+                collection: 'pub.chive.actor.mute',
+                limit: 100,
+                ...(cursor ? { cursor } : {}),
+              });
+              return { items: response.data.records, cursor: response.data.cursor };
+            },
+            { label: 'actor.mute' }
+          );
 
           const records = new Map<string, string>();
           const dids = new Set<string>();
 
-          for (const record of response.data.records) {
+          for (const record of items) {
             const value = record.value as MuteRecord;
             records.set(value.subjectDid, record.uri);
             dids.add(value.subjectDid);

--- a/web/lib/hooks/use-node-edges.ts
+++ b/web/lib/hooks/use-node-edges.ts
@@ -34,6 +34,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { api } from '@/lib/api/client';
+import { fetchAllPages } from '@/lib/api/paginate';
 import { APIError } from '@/lib/errors';
 
 // =============================================================================
@@ -126,19 +127,35 @@ function extractNodeId(uri: string): string {
  */
 async function fetchAndResolveEdges(nodeUri: string): Promise<NodeEdgesResult> {
   // Fetch outbound and inbound edges in parallel
-  const [outboundResponse, inboundResponse] = await Promise.all([
-    api.pub.chive.graph.listEdges({
-      sourceUri: nodeUri,
-      limit: 100,
-    }),
-    api.pub.chive.graph.listEdges({
-      targetUri: nodeUri,
-      limit: 100,
-    }),
+  // A node in a well-populated part of the graph has more than a hundred
+  // edges, and the panel presents itself as showing all of them.
+  const [outbound, inbound] = await Promise.all([
+    fetchAllPages(
+      async (cursor) => {
+        const response = await api.pub.chive.graph.listEdges({
+          sourceUri: nodeUri,
+          limit: 100,
+          ...(cursor ? { cursor } : {}),
+        });
+        return { items: response.data.edges ?? [], cursor: response.data.cursor };
+      },
+      { label: 'graph.listEdges.outbound' }
+    ),
+    fetchAllPages(
+      async (cursor) => {
+        const response = await api.pub.chive.graph.listEdges({
+          targetUri: nodeUri,
+          limit: 100,
+          ...(cursor ? { cursor } : {}),
+        });
+        return { items: response.data.edges ?? [], cursor: response.data.cursor };
+      },
+      { label: 'graph.listEdges.inbound' }
+    ),
   ]);
 
-  const outboundEdges = outboundResponse.data.edges ?? [];
-  const inboundEdges = inboundResponse.data.edges ?? [];
+  const outboundEdges = outbound.items;
+  const inboundEdges = inbound.items;
 
   // Deduplicate by edge URI
   const edgeMap = new Map<

--- a/web/lib/hooks/use-personal-graph.ts
+++ b/web/lib/hooks/use-personal-graph.ts
@@ -37,6 +37,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { APIError } from '@/lib/errors';
 import { authApi } from '@/lib/api/client';
+import { fetchAllPages } from '@/lib/api/paginate';
 import { createLogger } from '@/lib/observability/logger';
 import { getCurrentAgent } from '@/lib/auth/oauth-client';
 import {
@@ -154,12 +155,25 @@ export function usePersonalNodes(did: string, options?: { subkind?: string; enab
     queryKey: personalGraphKeys.nodes(did, { subkind: options?.subkind }),
     queryFn: async (): Promise<ListPersonalNodesResponse> => {
       try {
-        const params: { limit: number; subkind?: string } = { limit: 100 };
-        if (options?.subkind) {
-          params.subkind = options.subkind;
-        }
-        const response = await authApi.pub.chive.graph.listPersonalNodes(params);
-        return response.data as unknown as ListPersonalNodesResponse;
+        const { items } = await fetchAllPages(
+          async (cursor) => {
+            const params: { limit: number; subkind?: string; cursor?: string } = { limit: 100 };
+            if (options?.subkind) {
+              params.subkind = options.subkind;
+            }
+            if (cursor) {
+              params.cursor = cursor;
+            }
+            const response = await authApi.pub.chive.graph.listPersonalNodes(params);
+            const page = response.data as unknown as ListPersonalNodesResponse & {
+              cursor?: string;
+            };
+            return { items: page.nodes ?? [], cursor: page.cursor };
+          },
+          { label: 'graph.listPersonalNodes' }
+        );
+
+        return { nodes: items } as unknown as ListPersonalNodesResponse;
       } catch (error) {
         if (error instanceof APIError) throw error;
         throw new APIError(


### PR DESCRIPTION
## Summary

Nine hooks asked for `limit: 100` and returned whatever came back. The endpoints they call are cursor-paginated, so a user with more than a hundred collections, mutes, personal graph nodes or citations simply stopped seeing them at a hundred — and nothing in the UI said so. A truncated list presented as a complete one is worse than an obviously incomplete one, because there is nothing to notice.

`fetchAllPages` follows the cursor to the end. It stops when the endpoint returns no cursor, returns an empty page, or repeats a cursor it already gave (a server bug that would otherwise loop forever), and it has a ceiling of 50 pages so a misbehaving endpoint cannot hang a page render. **A walk cut short by the ceiling logs a warning naming the caller** — a cap nobody can see is indistinguishable from complete data, which is the whole failure being fixed here.

Applied to:

- `useMyCollections` — the dashboard's own list of the user's collections, the case in the backlog.
- `useMutedAuthors` — a partial mute list is the worst of these: an author muted past the hundredth record silently reappears in the feed. This also closes the `TODO` sitting on that call.
- `usePersonalNodes` — a user's personal graph.
- `useNodeEdges` (outbound and inbound), `useNodeChildren`, `useFieldChildren` — a node in a well-populated part of the graph has more than a hundred edges, and the panels present themselves as showing all of them.
- `useEndorsementData` — the relates-to edges behind endorsement kinds.
- `useCitations` — a well-cited paper has more than a hundred references.

The citations hook also moves off raw `fetch` onto the typed client. Its comment claimed "the generated XRPC client may not include this endpoint yet"; it does, and has for some time.

## Related Issues

FE-8 in the 0.8.0 backlog, including the two mute-cap `TODO`s it names as the same root cause.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- `fetchAllPages`: 9 tests — a single page returned unchanged, the cursor followed past the first page, each page given its predecessor's cursor, the ceiling stopping the walk, the truncation warning fired with its label, no warning when the walk finished on its own, a repeated cursor terminating rather than looping, an empty page ending the walk even when a cursor comes with it, and a mid-walk failure propagating rather than a partial list being returned as complete.
- `useMyCollections`: 4 tests — a single page unchanged, a second page fetched and concatenated, the cursor passed back on the following request, and no second request when the first page is the last.
- Full frontend suite green (2627 tests). Typecheck clean; lint clean apart from two `CosmikConnectionMapping` warnings that predate this branch.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Read-path only. The mute list is read from the user's own PDS via `listRecords`, as before; only the pagination changed.

### Breaking Changes

- [x] N/A — no breaking changes

A user who has more than one page of any of these now causes more than one request where there used to be exactly one. That is the point, and these are all cached queries with a two-to-five minute `staleTime`.
