### PR TITLE
Allow the browser to reach the PDS and resolvers that sign-in depends on

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -36,10 +36,33 @@ const nextConfig: NextConfig = {
     // `script-src` still carries 'unsafe-inline': Next.js inlines its own
     // bootstrap and hydration payloads, and removing it requires per-request
     // nonces threaded through the app. That is worth doing and is not done
-    // here. Everything else in this policy is enforceable today and closes the
-    // injection paths that do not depend on running script — an injected
-    // `<base>`, a retargeted form post, an embedded object, or the page being
-    // framed by somebody else's site.
+    // here. The rest closes the injection paths that do not depend on running
+    // script — an injected `<base>`, a retargeted form post, an embedded
+    // object, or the page being framed by somebody else's site.
+    //
+    // `connect-src` is deliberately `https:` rather than a host list, and this
+    // is a property of the protocol rather than a shortcut. An ATProto client
+    // running in the browser talks to hosts it discovers at runtime and cannot
+    // know in advance:
+    //
+    //   - the user's own PDS, whose hostname comes out of their DID document.
+    //     Every record this app writes — eprints, reviews, mutes, Layers data
+    //     links — is a direct browser-to-PDS `com.atproto.repo.*` call. The set
+    //     of PDS hosts is open by design; anyone may run one.
+    //   - handle resolution, which reads DNS over `https://dns.google` and
+    //     falls back to the public AppView.
+    //   - `plc.directory`, for the DID document that names the PDS.
+    //   - the OAuth authorization server, which is the user's PDS again.
+    //
+    // A previous version of this policy allowed only `'self'` and the Chive
+    // API. That silently blocked all four, so sign-in failed at handle
+    // resolution and every record write would have been refused. CSP has no
+    // way to express "any host this document later learns about", so a host
+    // list cannot be made correct here; narrowing it again would break sign-in
+    // again. What `https:` still buys is real: no plaintext-HTTP exfiltration
+    // channel, and no non-HTTP scheme. The controls that actually contain XSS
+    // in this policy are `script-src`, `object-src`, `base-uri` and
+    // `form-action`, and they are unaffected.
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
     const isDev = process.env.NODE_ENV !== 'production';
 
@@ -50,7 +73,7 @@ const nextConfig: NextConfig = {
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",
-      `connect-src 'self' ${apiUrl}${isDev ? ' ws: wss:' : ''}`,
+      `connect-src 'self' ${apiUrl} https: wss:${isDev ? ' ws: http://localhost:*' : ''}`,
       // PDF.js runs its renderer in a blob worker.
       "worker-src 'self' blob:",
       "object-src 'none'",

--- a/web/tests/unit/config/csp.test.ts
+++ b/web/tests/unit/config/csp.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the frontend Content-Security-Policy.
+ *
+ * @remarks
+ * These exist because a `connect-src` of `'self' <api>` shipped to production
+ * and broke sign-in. An ATProto client in the browser connects to hosts it
+ * learns at runtime — the user's PDS, a DoH resolver, `plc.directory` — so a
+ * host list cannot be correct here. The point of these tests is that narrowing
+ * it back fails loudly in CI rather than quietly at a user's login screen.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import nextConfig from '../../../next.config';
+
+/** Pull one directive out of the policy the config produces. */
+async function directive(name: string): Promise<string> {
+  const headers = await nextConfig.headers!();
+  const entry = headers.flatMap((h) => h.headers).find((h) => h.key === 'Content-Security-Policy');
+  expect(entry, 'no CSP header').toBeDefined();
+
+  const found = entry!.value
+    .split(';')
+    .map((d) => d.trim())
+    .find((d) => d === name || d.startsWith(`${name} `));
+  expect(found, `no ${name} directive`).toBeDefined();
+  return found!;
+}
+
+const originalEnv = process.env.NODE_ENV;
+
+describe('Content-Security-Policy', () => {
+  beforeEach(() => {
+    // @ts-expect-error NODE_ENV is readonly in the Next types, writable at runtime
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    // @ts-expect-error see above
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  describe('connect-src', () => {
+    it('allows any HTTPS origin, because the PDS host is not known in advance', async () => {
+      // Every record this app writes is a browser-to-PDS call, and the PDS
+      // comes from the user's DID document. Anyone may run one.
+      expect(await directive('connect-src')).toMatch(/(^|\s)https:(\s|$)/);
+    });
+
+    it('still allows the app origin', async () => {
+      expect(await directive('connect-src')).toContain("'self'");
+    });
+
+    it('allows secure websockets', async () => {
+      expect(await directive('connect-src')).toMatch(/(^|\s)wss:(\s|$)/);
+    });
+
+    it('does not open plaintext HTTP in production', async () => {
+      // What `https:` still buys: no cleartext exfiltration channel.
+      const connect = await directive('connect-src');
+      expect(connect).not.toMatch(/(^|\s)http:(\s|$)/);
+      expect(connect).not.toMatch(/(^|\s)ws:(\s|$)/);
+    });
+  });
+
+  describe('the directives that actually contain XSS', () => {
+    it('forbids plugins and embedded objects', async () => {
+      expect(await directive('object-src')).toBe("object-src 'none'");
+    });
+
+    it('pins the document base URI', async () => {
+      expect(await directive('base-uri')).toBe("base-uri 'self'");
+    });
+
+    it('stops a form being retargeted at another origin', async () => {
+      expect(await directive('form-action')).toBe("form-action 'self'");
+    });
+
+    it('refuses to be framed', async () => {
+      expect(await directive('frame-ancestors')).toBe("frame-ancestors 'none'");
+    });
+
+    it('does not allow eval in production', async () => {
+      expect(await directive('script-src')).not.toContain("'unsafe-eval'");
+    });
+
+    it('keeps a default-src fallback of self', async () => {
+      expect(await directive('default-src')).toBe("default-src 'self'");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Sign-in is broken in production. `Failed to resolve identity: <handle>` on every attempt.

The Content-Security-Policy added in 0.10.0 set `connect-src 'self' https://chive.pub/api`. That is too narrow to run an ATProto client. The browser talks to hosts it discovers at runtime, and the policy blocked all of them:

- **The user's own PDS.** Its hostname comes out of their DID document. Every record this app writes — eprints, reviews, mutes, the Layers data links added in 0.11.0 — is a direct browser-to-PDS `com.atproto.repo.*` call, and there are 84 of them in `record-creator.ts`. The OAuth authorization server is that same host.
- **Handle resolution**, which reads DNS over `https://dns.google` and falls back to the public AppView at `public.api.bsky.app`.
- **`plc.directory`**, for the DID document that names the PDS.
- **Every external autocomplete** — Crossref, DBLP, arXiv, ORCID, ROR, OpenAlex and the rest.

Both resolution paths are healthy upstream; `dns.google` and the AppView each return `did:plc:34mbm5v3umztwvvgnttvcz6e` for the handle in the report. Nothing was wrong except that the browser was not allowed to ask.

So the reported symptoms — login, handle resolution, autocomplete — are three faces of one cause, and record writes would have failed the same way for anyone who got past sign-in.

`connect-src` is now `https: wss:` alongside `'self'` and the API. **This cannot be tightened back into a host list.** CSP has no way to express "any host this document later learns about", and the set of PDS hosts is open by design — anyone may run one. What `https:` still buys is real: no plaintext-HTTP exfiltration channel and no non-HTTP scheme. The directives that actually contain XSS in this policy — `script-src`, `object-src`, `base-uri`, `form-action`, `frame-ancestors` — are untouched.

I got this wrong in 0.10.0. That changelog entry said "Everything else is enforced", which was not true of `connect-src`: it was not enforcing a boundary, it was breaking the application. The reasoning error was treating an ATProto client like an app with a fixed backend.

## Related Issues

Reported from production against v0.11.0. Introduced in v0.10.0.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- 10 tests over the policy the config actually produces, not over a copy of it. Four pin `connect-src` (HTTPS allowed, `'self'` kept, `wss:` allowed, no plaintext `http:`/`ws:` in production); six pin the directives that do the XSS work, so widening `connect-src` cannot be mistaken for relaxing the policy generally.
- **The tests were verified against the failure.** Reverting `next.config.ts` to the exact policy that shipped fails two of them; restoring the fix passes all ten. A narrowing regression now fails in CI instead of at a user's login screen.
- Confirmed the rendered production policy: `connect-src 'self' https://chive.pub/api https: wss:`.
- Confirmed upstream health independently, so the diagnosis does not rest on the policy alone: `dns.google` DoH and `public.api.bsky.app` both resolve the reported handle correctly.
- Full frontend suite green (2647 tests). Typecheck clean.

Not verified in a real browser: the Chrome extension was not connected in this session. The chain is deterministic — the policy is confirmed served, the code paths provably fetch `dns.google` and `public.api.bsky.app`, and neither matches the directive — but a browser check after deploy is still worth doing, and the verification steps are below.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

No data flow changed. The browser-to-PDS writes this unblocks are the user writing to their own repository, which is the intended architecture; no Chive service writes anything.

### Breaking Changes

- [x] N/A — no breaking changes

## After deploy

Sign in at https://chive.pub with a handle and confirm it resolves. Then check the header directly:

```bash
curl -sI https://chive.pub/ | grep -i content-security-policy
```

`connect-src` must contain `https:`.
