### PR TITLE
Release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-30
+
+### Fixed
+
+- **Sign-in failed with `Failed to resolve identity`, and record writes would have failed the same way.** The Content-Security-Policy introduced in 0.10.0 set `connect-src` to the app origin and the Chive API, which is too narrow to run an ATProto client: the browser connects to hosts it discovers at runtime, and the policy blocked all of them. Handle resolution reads DNS over `https://dns.google` and falls back to the public AppView; `plc.directory` supplies the DID document naming the PDS; the OAuth authorization server is that PDS; and every record the app writes — eprints, reviews, mutes, Layers data links — is a direct browser-to-PDS `com.atproto.repo.*` call. External autocompletes against Crossref, DBLP, arXiv, ORCID and ROR were blocked for the same reason. `connect-src` now allows `https:` and `wss:`, which is the narrowest form that works: the set of PDS hosts is open by design and CSP cannot express "any host this document later learns about". Plaintext HTTP and non-HTTP schemes remain blocked, and `script-src`, `object-src`, `base-uri`, `form-action` and `frame-ancestors` are unchanged.
+
+  The 0.10.0 entry describing that policy said everything other than `script-src` was enforced. That was wrong of `connect-src`, which was not enforcing a boundary but breaking the application.
+
 ## [0.11.0] - 2026-08-29
 
 ### Added
@@ -883,7 +891,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/chive-pub/chive/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/chive-pub/chive/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/chive-pub/chive/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/chive-pub/chive/compare/v0.8.1...v0.9.0

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -36,10 +36,33 @@ const nextConfig: NextConfig = {
     // `script-src` still carries 'unsafe-inline': Next.js inlines its own
     // bootstrap and hydration payloads, and removing it requires per-request
     // nonces threaded through the app. That is worth doing and is not done
-    // here. Everything else in this policy is enforceable today and closes the
-    // injection paths that do not depend on running script — an injected
-    // `<base>`, a retargeted form post, an embedded object, or the page being
-    // framed by somebody else's site.
+    // here. The rest closes the injection paths that do not depend on running
+    // script — an injected `<base>`, a retargeted form post, an embedded
+    // object, or the page being framed by somebody else's site.
+    //
+    // `connect-src` is deliberately `https:` rather than a host list, and this
+    // is a property of the protocol rather than a shortcut. An ATProto client
+    // running in the browser talks to hosts it discovers at runtime and cannot
+    // know in advance:
+    //
+    //   - the user's own PDS, whose hostname comes out of their DID document.
+    //     Every record this app writes — eprints, reviews, mutes, Layers data
+    //     links — is a direct browser-to-PDS `com.atproto.repo.*` call. The set
+    //     of PDS hosts is open by design; anyone may run one.
+    //   - handle resolution, which reads DNS over `https://dns.google` and
+    //     falls back to the public AppView.
+    //   - `plc.directory`, for the DID document that names the PDS.
+    //   - the OAuth authorization server, which is the user's PDS again.
+    //
+    // A previous version of this policy allowed only `'self'` and the Chive
+    // API. That silently blocked all four, so sign-in failed at handle
+    // resolution and every record write would have been refused. CSP has no
+    // way to express "any host this document later learns about", so a host
+    // list cannot be made correct here; narrowing it again would break sign-in
+    // again. What `https:` still buys is real: no plaintext-HTTP exfiltration
+    // channel, and no non-HTTP scheme. The controls that actually contain XSS
+    // in this policy are `script-src`, `object-src`, `base-uri` and
+    // `form-action`, and they are unaffected.
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
     const isDev = process.env.NODE_ENV !== 'production';
 
@@ -50,7 +73,7 @@ const nextConfig: NextConfig = {
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",
-      `connect-src 'self' ${apiUrl}${isDev ? ' ws: wss:' : ''}`,
+      `connect-src 'self' ${apiUrl} https: wss:${isDev ? ' ws: http://localhost:*' : ''}`,
       // PDF.js runs its renderer in a blob worker.
       "worker-src 'self' blob:",
       "object-src 'none'",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/tests/unit/config/csp.test.ts
+++ b/web/tests/unit/config/csp.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the frontend Content-Security-Policy.
+ *
+ * @remarks
+ * These exist because a `connect-src` of `'self' <api>` shipped to production
+ * and broke sign-in. An ATProto client in the browser connects to hosts it
+ * learns at runtime — the user's PDS, a DoH resolver, `plc.directory` — so a
+ * host list cannot be correct here. The point of these tests is that narrowing
+ * it back fails loudly in CI rather than quietly at a user's login screen.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import nextConfig from '../../../next.config';
+
+/** Pull one directive out of the policy the config produces. */
+async function directive(name: string): Promise<string> {
+  const headers = await nextConfig.headers!();
+  const entry = headers.flatMap((h) => h.headers).find((h) => h.key === 'Content-Security-Policy');
+  expect(entry, 'no CSP header').toBeDefined();
+
+  const found = entry!.value
+    .split(';')
+    .map((d) => d.trim())
+    .find((d) => d === name || d.startsWith(`${name} `));
+  expect(found, `no ${name} directive`).toBeDefined();
+  return found!;
+}
+
+const originalEnv = process.env.NODE_ENV;
+
+describe('Content-Security-Policy', () => {
+  beforeEach(() => {
+    // @ts-expect-error NODE_ENV is readonly in the Next types, writable at runtime
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    // @ts-expect-error see above
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  describe('connect-src', () => {
+    it('allows any HTTPS origin, because the PDS host is not known in advance', async () => {
+      // Every record this app writes is a browser-to-PDS call, and the PDS
+      // comes from the user's DID document. Anyone may run one.
+      expect(await directive('connect-src')).toMatch(/(^|\s)https:(\s|$)/);
+    });
+
+    it('still allows the app origin', async () => {
+      expect(await directive('connect-src')).toContain("'self'");
+    });
+
+    it('allows secure websockets', async () => {
+      expect(await directive('connect-src')).toMatch(/(^|\s)wss:(\s|$)/);
+    });
+
+    it('does not open plaintext HTTP in production', async () => {
+      // What `https:` still buys: no cleartext exfiltration channel.
+      const connect = await directive('connect-src');
+      expect(connect).not.toMatch(/(^|\s)http:(\s|$)/);
+      expect(connect).not.toMatch(/(^|\s)ws:(\s|$)/);
+    });
+  });
+
+  describe('the directives that actually contain XSS', () => {
+    it('forbids plugins and embedded objects', async () => {
+      expect(await directive('object-src')).toBe("object-src 'none'");
+    });
+
+    it('pins the document base URI', async () => {
+      expect(await directive('base-uri')).toBe("base-uri 'self'");
+    });
+
+    it('stops a form being retargeted at another origin', async () => {
+      expect(await directive('form-action')).toBe("form-action 'self'");
+    });
+
+    it('refuses to be framed', async () => {
+      expect(await directive('frame-ancestors')).toBe("frame-ancestors 'none'");
+    });
+
+    it('does not allow eval in production', async () => {
+      expect(await directive('script-src')).not.toContain("'unsafe-eval'");
+    });
+
+    it('keeps a default-src fallback of self', async () => {
+      expect(await directive('default-src')).toBe("default-src 'self'");
+    });
+  });
+});


### PR DESCRIPTION
Hotfix for a production sign-in outage. Users could not log in: `Failed to resolve identity` on every attempt.

### Fixed

- **Sign-in failed with `Failed to resolve identity`, and record writes would have failed the same way.** The Content-Security-Policy introduced in 0.10.0 set `connect-src` to the app origin and the Chive API, which is too narrow to run an ATProto client: the browser connects to hosts it discovers at runtime, and the policy blocked all of them. Handle resolution reads DNS over `https://dns.google` and falls back to the public AppView; `plc.directory` supplies the DID document naming the PDS; the OAuth authorization server is that PDS; and every record the app writes — eprints, reviews, mutes, Layers data links — is a direct browser-to-PDS `com.atproto.repo.*` call. External autocompletes against Crossref, DBLP, arXiv, ORCID and ROR were blocked for the same reason. `connect-src` now allows `https:` and `wss:`, which is the narrowest form that works: the set of PDS hosts is open by design and CSP cannot express "any host this document later learns about". Plaintext HTTP and non-HTTP schemes remain blocked, and `script-src`, `object-src`, `base-uri`, `form-action` and `frame-ancestors` are unchanged.

  The 0.10.0 entry describing that policy said everything other than `script-src` was enforced. That was wrong of `connect-src`, which was not enforcing a boundary but breaking the application.

## Impact

Wider than the reported symptoms. Sign-in, handle resolution and the external autocompletes were visibly broken; record writes would have failed the same way for anyone with a live session, since eprint submission, reviews, mutes and Layers data links are all direct browser-to-PDS calls.

Introduced in v0.10.0, reported against v0.11.0.

## Verification

- 10 tests over the policy the config actually produces. They were checked against the failure: reverting `next.config.ts` to the exact policy that shipped fails two of them, so a future narrowing fails in CI rather than at a user's login screen.
- Upstream health confirmed independently, so the diagnosis does not rest on reading the policy: `dns.google` and `public.api.bsky.app` both resolve the reported handle correctly. Nothing was wrong except that the browser was not permitted to ask.
- Rendered production policy: `connect-src 'self' https://chive.pub/api https: wss:`.
- Full frontend suite green (2647 tests); staging CI green on #177.

## After deploy

Sign in at https://chive.pub and confirm the handle resolves, then:

```bash
curl -sI https://chive.pub/ | grep -i content-security-policy
curl -sf https://chive.pub/api/health | jq -r .version
```

`connect-src` must contain `https:`, and the version must read `0.11.1`.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` - 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

No data flow changed. The browser-to-PDS writes this unblocks are the user writing to their own repository.

### Breaking Changes

- [x] N/A - no breaking changes
