### PR TITLE
Release 0.12.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,6 +248,46 @@ GRAPH_ALGORITHM_INTERVAL_MS=86400000
 # Defaults to https://chive.pub when unset.
 NEXT_PUBLIC_SITE_URL=https://chive.pub
 
+# Chive deployment the MCP server reads from.
+#
+# `pnpm mcp` serves Chive's public read API to an agent over stdio: search,
+# resolve-by-identifier, citations and reviews. It is a client of the same
+# unauthenticated XRPC any browser calls, so it holds no credentials and can be
+# pointed at any deployment.
+#
+# Defaults to https://api.chive.pub when unset.
+CHIVE_API_URL=https://api.chive.pub
+
+# AT-URI of this deployment's site.standard.publication record.
+#
+# Served at /.well-known/site.standard.publication, which is how a
+# standard.site reader discovers the publication an eprint belongs to.
+#
+# There is no default. The endpoint used to answer
+# `at://<CHIVE_SERVICE_DID>/site.standard.publication/self` unconditionally,
+# and that URI could not resolve: no such record exists in the service
+# repository, and `self` is not a legal record key for a lexicon whose key is
+# `tid`. Unset, the endpoint now answers 404 — an unconfigured publication,
+# rather than a broken one.
+#
+# Setting this requires first creating the record in the service repository,
+# which needs write access to that PDS.
+# CHIVE_PUBLICATION_URI=            # no default
+
+# Observe the high-volume foreign collections on the firehose.
+#
+# Chive watches a small set of other applications' lexicons so the backlink
+# plugins can turn references to an eprint into backlinks. Those records are
+# forwarded to plugins and never indexed as Chive records.
+#
+# This flag adds `app.bsky.feed.post` to that set. It is off by default because
+# it is the entire Bluesky timeline: millions of records a day against Chive's
+# thousands. Enabling it means the indexer reads the whole network rather than a
+# niche namespace, which is a capacity decision rather than a filter tweak.
+#
+# Defaults to false.
+FIREHOSE_OBSERVE_HIGH_VOLUME=false
+
 # Base URL of the Layers AppView, without a trailing slash.
 #
 # Chive federates the read of pub.layers.eprint.dataLink records rather than

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -21,10 +21,12 @@ runs:
           sudo apt-get install -y build-essential python3
         fi
 
+    # No `version:` here on purpose. action-setup then reads `packageManager`
+    # from package.json, so CI runs the exact pnpm the repo pins rather than
+    # whatever the latest 10.x happens to be that day. Pinning the version in
+    # two places is how they drift apart.
     - name: Setup pnpm
       uses: pnpm/action-setup@v3
-      with:
-        version: 10
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -43,17 +43,23 @@ runs:
       if: contains(inputs.services, 'neo4j') || inputs.services == 'all'
       shell: bash
       run: |
+        # Neo4j is the slowest of the four to accept connections, and 90s was
+        # not enough headroom on a loaded runner: the E2E job failed on it
+        # while the same commit passed on another run. A wait that is too short
+        # fails the build for runner weather rather than for a defect, so this
+        # is generous. It costs nothing when Neo4j is ready early, because the
+        # loop exits on the first success.
         echo "Waiting for Neo4j to be ready..."
-        for i in {1..45}; do
+        for i in {1..120}; do
           if docker compose -f docker/docker-compose.yml exec -T neo4j \
              cypher-shell -u neo4j -p chive_test_password 'RETURN 1' 2>/dev/null; then
-            echo "Neo4j is ready"
+            echo "Neo4j is ready after $((i * 2))s"
             exit 0
           fi
-          echo "Attempt $i/45 - Neo4j not ready yet..."
+          echo "Attempt $i/120 - Neo4j not ready yet..."
           sleep 2
         done
-        echo "ERROR: Neo4j failed to start within 90 seconds"
+        echo "ERROR: Neo4j failed to start within 240 seconds"
         docker compose -f docker/docker-compose.yml logs neo4j
         exit 1
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,16 @@
 # batch of tooling bumps, and the two workspaces that hold their own manifests
 # are covered explicitly, since Dependabot does not follow pnpm workspaces from
 # the root.
+#
+# Every update targets `staging`, not `main`. Work reaches production through
+# staging in this repository, and a dependency bump is not an exception: a PR
+# opened against `main` cannot be merged by the normal flow, so the nine that
+# were open had simply accumulated there unmergeable.
 version: 2
 
 updates:
   - package-ecosystem: npm
+    target-branch: staging
     directory: /
     schedule:
       interval: weekly
@@ -27,6 +33,7 @@ updates:
     labels: [dependencies, security]
 
   - package-ecosystem: npm
+    target-branch: staging
     directory: /web
     schedule:
       interval: weekly
@@ -40,6 +47,7 @@ updates:
     labels: [dependencies, frontend]
 
   - package-ecosystem: npm
+    target-branch: staging
     directory: /docs
     schedule:
       interval: weekly
@@ -55,6 +63,7 @@ updates:
   # Workflow actions pin to tags that go stale and are a supply-chain surface in
   # their own right.
   - package-ecosystem: github-actions
+    target-branch: staging
     directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,102 +224,101 @@ jobs:
           echo "All compliance tests must pass (100% required for ATProto data sovereignty)." >> $GITHUB_STEP_SUMMARY
 
   # ==============================================================================
-  # Stage 5: E2E Tests (DISABLED - re-enable when infrastructure is ready)
+  # Stage 5: E2E Tests
   # ==============================================================================
+  #
+  # Only the unauthenticated project runs here. It covers the sign-in and
+  # landing pages — 24 tests, about two minutes — and is green.
+  #
+  # The authenticated project is 487 tests and takes hours on one worker, which
+  # is too slow to gate every pull request and has not been triaged end to end.
+  # Enabling it needs its own pass: a decision about sharding, and a review of
+  # what currently fails. Running the part that is known good is worth more
+  # than running nothing, which is what happened while the whole job sat
+  # commented out.
 
-  # e2e-tests:
-  #   name: E2E Tests (${{ matrix.browser }})
-  #   runs-on: ubuntu-latest
-  #   needs: [integration-tests]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       browser: ${{ github.event_name == 'pull_request' && fromJSON('["chromium"]') || fromJSON('["chromium", "firefox", "webkit"]') }}
-  #
-  #   services:
-  #     postgres:
-  #       image: postgres:16-alpine
-  #       env:
-  #         POSTGRES_DB: chive_test
-  #         POSTGRES_USER: chive
-  #         POSTGRES_PASSWORD: chive_test_password
-  #       ports:
-  #         - 5432:5432
-  #       options: >-
-  #         --health-cmd pg_isready
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
-  #
-  #     redis:
-  #       image: redis:7-alpine
-  #       ports:
-  #         - 6379:6379
-  #       options: >-
-  #         --health-cmd "redis-cli ping"
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
-  #
-  #   env:
-  #     POSTGRES_HOST: localhost
-  #     POSTGRES_PORT: 5432
-  #     POSTGRES_USER: chive
-  #     POSTGRES_PASSWORD: chive_test_password
-  #     POSTGRES_DB: chive_test
-  #     DATABASE_URL: postgresql://chive:chive_test_password@localhost:5432/chive_test
-  #     REDIS_URL: redis://localhost:6379
-  #     ELASTICSEARCH_URL: http://localhost:9200
-  #     NEO4J_URI: bolt://localhost:7687
-  #     NEO4J_USER: neo4j
-  #     NEO4J_PASSWORD: chive_test_password
-  #     DISABLE_RATE_LIMITING: 'true'
-  #
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/setup-node-pnpm
-  #     - uses: ./.github/actions/start-services
-  #
-  #     - name: Cache Playwright browsers
-  #       uses: actions/cache@v4
-  #       id: playwright-cache
-  #       with:
-  #         path: ~/.cache/ms-playwright
-  #         key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-  #
-  #     - name: Install Playwright browsers
-  #       if: steps.playwright-cache.outputs.cache-hit != 'true'
-  #       run: |
-  #         # Always install chromium (needed for setup:auth project)
-  #         pnpm exec playwright install --with-deps chromium
-  #         # Install matrix browser if different from chromium
-  #         if [ "${{ matrix.browser }}" != "chromium" ]; then
-  #           pnpm exec playwright install --with-deps ${{ matrix.browser }}
-  #         fi
-  #
-  #     - name: Install Playwright dependencies (cached)
-  #       if: steps.playwright-cache.outputs.cache-hit == 'true'
-  #       run: |
-  #         pnpm exec playwright install-deps chromium
-  #         if [ "${{ matrix.browser }}" != "chromium" ]; then
-  #           pnpm exec playwright install-deps ${{ matrix.browser }}
-  #         fi
-  #
-  #     - name: Run database migrations
-  #       run: pnpm db:migrate:up
-  #
-  #     - name: Run E2E tests
-  #       run: pnpm test:e2e --project="${{ matrix.browser }}:*"
-  #
-  #     - name: Upload Playwright report
-  #       if: always()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: playwright-report-${{ matrix.browser }}
-  #         path: |
-  #           playwright-report/
-  #           tests/e2e/test-results/
-  #         retention-days: 14
+  e2e-tests:
+    name: E2E Tests (unauthenticated)
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: chive_test
+          POSTGRES_USER: chive
+          POSTGRES_PASSWORD: chive_test_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: chive
+      POSTGRES_PASSWORD: chive_test_password
+      POSTGRES_DB: chive_test
+      DATABASE_URL: postgresql://chive:chive_test_password@localhost:5432/chive_test
+      PGHOST: localhost
+      PGPORT: 5432
+      PGUSER: chive
+      PGPASSWORD: chive_test_password
+      PGDATABASE: chive_test
+      REDIS_URL: redis://localhost:6379
+      ELASTICSEARCH_URL: http://localhost:9200
+      NEO4J_URI: bolt://localhost:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: chive_test_password
+      ADMIN_DIDS: did:plc:test-admin-did
+      DISABLE_RATE_LIMITING: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node-pnpm
+      - uses: ./.github/actions/start-services
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm test:e2e --project="chromium:unauthenticated"
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            tests/e2e/test-results/
+          retention-days: 14
 
   # ==============================================================================
   # Stage 6: Build Verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-31
+
+Chive now reads and writes other applications' lexicons against what those applications actually publish. Several of the records it was already emitting turned out to be invalid, and several it was already subscribed to were never reaching it.
+
+### Added
+
+- **Leaflet documents and comments are read for references to eprints.** Leaflet's schemas are vendored under `lexicons/vendor/leaflet/`, taken from its own lexicon repository. A document reaches an eprint by four routes and all four are followed: a comment's `subject`, a `website` block's `src`, an inline richtext link, and a `standardSitePost` block naming an eprint directly.
+- **standard.site documents that describe an eprint are recorded as backlinks**, whoever wrote them. This is also the mapping that lets a reference addressed to a _document_ — a standard.site recommend, an embedded document block — resolve to the work it ultimately means.
+- **Talks and presentations appear as backlinks.** A `community.lexicon.calendar.event` naming an eprint among its URIs is evidence the work was presented, and where. Cancelled and postponed events are skipped.
+- **`pub.chive.site.citationLink`**, a typed document-to-work link for `site.standard.document`'s reserved `links` union, with a CiTO-style vocabulary. A consumer that knows CiTO can read a Chive citation without knowing anything about Chive. Opt-in.
+- **The Bluesky post announcing an eprint is recorded on its standard.site document** as `bskyPostRef`, which makes the post's reply thread findable as the paper's off-platform discussion.
+- **An MCP server over the public read API** (`pnpm mcp`): search, resolve-by-identifier, citations and reviews. It calls the same unauthenticated XRPC a browser does, so it holds no credentials and can be pointed at any deployment. Every tool is read-only.
+- **Tangled repositories are a first-class code artifact.** A repository hosted there is an ATProto record, so `codeRepository` gains `recordUri` alongside `url` — an address on the network rather than at one web host.
+- The external identifier resolver is documented for other applications at `docs/api-reference/resolving-identifiers.md`.
+
+### Fixed
+
+- **The firehose filter was dropping seven of the twenty collections Chive indexes.** Its NSID validator required every segment to be lowercase. An NSID is a domain authority followed by a name, and only the authority is a domain label; the name segment is where camelCase lives. With strict validation on — which is what the indexing service sets — `pub.chive.eprint.userTag`, `eprint.relatedWork`, `annotation.entityLink`, `collaboration.inviteAcceptance`, `actor.profileConfig` and both graph proposal types were rejected before the processor saw them. Each is in the indexed set, each has a handler, and the PDS scanner backfills each; only the live firehose path refused them, silently. The name rule now matches the grammar `@atproto/syntax` implements.
+- **Five registered backlink plugins could never be called.** The event processor already forwarded foreign records to the plugin bus, and the plugins already subscribed; the filter rejected every collection outside `pub.chive.*` upstream. Cosmik backlinks, connections, follows and link removals, and Margin annotations were constructed, subscribed, and unreachable.
+- **Every `site.standard.document` Chive had written was invalid.** The lexicon requires `site` and `publishedAt`; neither was written. `content` was an object where the schema has an open union, and `visibility` and `createdAt` are not properties at all. No standard.site consumer could accept such a record, which is why the cross-platform discovery this feature promised never appeared. Documents now carry the required fields and a `path`, so `site` + `path` is the canonical URL of the eprint page — which is how a reader verifies that document and page describe the same work.
+- Deleting an eprint still finds its documents. The lookup matched the invented `content.uri`; it now matches `path` and the legacy field both, because documents already in users' repositories carry the old shape. Updating one repairs it in place.
+- **`/.well-known/site.standard.publication` advertised a record that cannot exist.** The collection is absent from the service repository, and `self` is not a legal record key for a lexicon whose key is `tid`. It is now `CHIVE_PUBLICATION_URI`, and unset the endpoint answers 404 — an unconfigured publication rather than a broken one.
+- **The Leaflet plugin matched no record that any repository holds.** It tracked `xyz.leaflet.list`, an NSID Leaflet does not publish, and parsed an invented shape; its `shouldProcess` filtered on a `visibility` field that does not exist, so even repointed it would have skipped everything.
+- **The sign-in field had no accessible name.** `FormControl` passes `id` and `aria-*` to its child; `HandleInput` accepted none of them and forwarded none, so the label never associated and a screen reader announced an unlabelled text box on the first field of the login page.
+- **The autocompletes could not be operated from a keyboard.** Around twenty of them, of which two implemented the combobox pattern; the shared base implemented none of it and `node-autocomplete` — behind every knowledge-graph field — handled Escape and no other key. A keyboard user could open a list of suggestions and had no way to reach one. Both now implement the pattern: arrow keys, Home, End, Enter, Escape, with `aria-activedescendant` and marked-up options.
+- **Cancelling an admin operation did not stop it.** `startOperation` returns an AbortSignal that the governance sync and DID sync handlers dropped, so the work ran to completion and reported success against a cancelled operation.
+- **`triggerBackfill` recorded operations nothing ran.** It called `startOperation` and returned, leaving an operation pending forever. It now names the endpoint that does the work for the requested type.
+- The Helm chart still set the governance PDS DID to `did:plc:chive-governance`, which is not a PLC identifier. Every other configuration was corrected in 0.10.0; a Helm deployment would have carried it. A test now sweeps every tracked config rather than the ones someone remembers.
+- Integration tests ran under Vitest's 5-second default while talking to four datastores, so a slow runner failed the build with no defect behind it. The datastore-backed suite gets 30 seconds; the unit suite keeps the 5-second default.
+- A type error in a test file removed the generated code reference from the documentation site, and the only symptom was a link check naming every page that pointed at the missing section.
+
+### Changed
+
+- Dependency updates target `staging`. Work reaches production through staging here, so nine dependency PRs had accumulated against a branch the normal flow cannot merge them into.
+- `traefik` and the PDS image are pinned in production compose, to the versions production already runs. `latest` meant a `compose pull` could replace the ingress every request passes through without anyone choosing to.
+- The README names the plugins that actually register. It advertised GitHub, ORCID, DOI registration and Wikidata — the four that are written and not constructed by any service.
+- A clean clone can typecheck: `pnpm lexicons:generate` is documented as the step that must precede it.
+- E2E runs in CI again, for the unauthenticated project. Seventeen assertions of the form `expect(true).toBe(true)` now assert something.
+
 ## [0.11.1] - 2026-08-30
 
 ### Fixed
@@ -891,7 +930,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/chive-pub/chive/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/chive-pub/chive/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/chive-pub/chive/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/chive-pub/chive/compare/v0.9.0...v0.10.0

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ cd chive
 # Install dependencies
 pnpm install
 
+# Generate the lexicon types.
+#
+# `src/lexicons/generated/` and `web/lib/api/generated/` are gitignored and
+# built from `lexicons/`, so on a fresh clone they do not exist yet and
+# `pnpm typecheck` fails with "Cannot find module" until this has run.
+pnpm lexicons:generate
+
 # Start the development database stack
 ./scripts/start-test-stack.sh
 
@@ -192,12 +199,19 @@ pnpm db:migrate:down
 
 Chive uses a hybrid plugin architecture with dependency injection (TSyringe) and event hooks (EventEmitter2).
 
-Plugins run in isolated sandboxes with declared permissions. Built-in plugins include:
+Plugins run in isolated sandboxes with declared permissions. The plugins the
+running services register today are:
 
-- GitHub integration
-- ORCID linking
-- DOI registration
-- Wikidata field import
+- arXiv, PsyArXiv, LingBuzz and Semantics Archive preprint metadata
+- OpenReview review metadata
+- Cosmik backlinks, connections, follows and link removals
+- Margin notes and replies
+
+`src/plugins/builtin/` holds more than are registered — GitHub, ORCID, DOI
+registration, Wikidata, Crossref, OpenAlex, ROR, Zenodo, Figshare, Dryad, OSF,
+Software Heritage and others are written but not constructed by any service.
+This list names the ones that actually run; the others are wired up as the
+integrations they belong to are finished.
 
 See [docs.chive.pub](https://docs.chive.pub) for plugin development details.
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -19,35 +19,39 @@
 # Prevents unbounded log growth (we've hit 12GB single-file incidents).
 # 50MB per file × 3 files = 150MB max per container.
 x-logging: &default-logging
-  driver: "json-file"
+  driver: 'json-file'
   options:
-    max-size: "50m"
-    max-file: "3"
+    max-size: '50m'
+    max-file: '3'
 
 services:
   # ---------------------------------------------------------------------------
   # Reverse Proxy - Traefik (auto-SSL with Let's Encrypt)
   # ---------------------------------------------------------------------------
   traefik:
-    image: traefik:latest
+    # Pinned to what production is already running. `latest` meant the next
+    # `compose pull` could swap the ingress for a new major without anyone
+    # choosing to, and Traefik is the single point every request passes
+    # through. Upgrade by changing this line deliberately.
+    image: traefik:v3.7.12
     container_name: chive-traefik
     restart: unless-stopped
     logging: *default-logging
     command:
-      - "--api.dashboard=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-      - "--entrypoints.websecure.address=:443"
-      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
-      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
-      - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
-      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
-      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
-      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - '--api.dashboard=true'
+      - '--providers.docker=true'
+      - '--providers.docker.exposedbydefault=false'
+      - '--entrypoints.web.address=:80'
+      - '--entrypoints.websecure.address=:443'
+      - '--entrypoints.web.http.redirections.entrypoint.to=websecure'
+      - '--entrypoints.web.http.redirections.entrypoint.scheme=https'
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true'
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web'
+      - '--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}'
+      - '--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json'
     ports:
-      - "80:80"
-      - "443:443"
+      - '80:80'
+      - '443:443'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik_certs:/letsencrypt
@@ -87,23 +91,24 @@ services:
           cpus: '0.25'
           memory: 256M
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3001/"]
+      test: ['CMD', 'wget', '-q', '--spider', 'http://127.0.0.1:3001/']
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
     labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.web.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.web.entrypoints=websecure"
-      - "traefik.http.routers.web.tls.certresolver=letsencrypt"
-      - "traefik.http.services.web.loadbalancer.server.port=3001"
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.web.rule=Host(`${DOMAIN}`)'
+      - 'traefik.http.routers.web.entrypoints=websecure'
+      - 'traefik.http.routers.web.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.web.loadbalancer.server.port=3001'
 
   # ---------------------------------------------------------------------------
   # Governance PDS (Bluesky PDS for community governance records)
   # ---------------------------------------------------------------------------
   governance-pds:
-    image: ghcr.io/bluesky-social/pds:latest
+    # Pinned for the same reason; this holds the governance repository.
+    image: ghcr.io/bluesky-social/pds:0.4.208
     container_name: chive-governance-pds
     restart: unless-stopped
     logging: *default-logging
@@ -133,17 +138,17 @@ services:
           cpus: '0.1'
           memory: 256M
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000/xrpc/_health"]
+      test: ['CMD', 'wget', '-q', '--spider', 'http://127.0.0.1:3000/xrpc/_health']
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
     labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.governance-pds.rule=Host(`governance.${DOMAIN}`)"
-      - "traefik.http.routers.governance-pds.entrypoints=websecure"
-      - "traefik.http.routers.governance-pds.tls.certresolver=letsencrypt"
-      - "traefik.http.services.governance-pds.loadbalancer.server.port=3000"
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.governance-pds.rule=Host(`governance.${DOMAIN}`)'
+      - 'traefik.http.routers.governance-pds.entrypoints=websecure'
+      - 'traefik.http.routers.governance-pds.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.governance-pds.loadbalancer.server.port=3000'
 
   # ---------------------------------------------------------------------------
   # Chive Documentation (Docusaurus)
@@ -170,7 +175,7 @@ services:
           cpus: '0.1'
           memory: 64M
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -S -O /dev/null http://127.0.0.1:80/ 2>&1 | grep -q 'HTTP/'"]
+      test: ['CMD-SHELL', "wget -q -S -O /dev/null http://127.0.0.1:80/ 2>&1 | grep -q 'HTTP/'"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -178,11 +183,11 @@ services:
     profiles:
       - docs
     labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.docs.rule=Host(`docs.${DOMAIN}`)"
-      - "traefik.http.routers.docs.entrypoints=websecure"
-      - "traefik.http.routers.docs.tls.certresolver=letsencrypt"
-      - "traefik.http.services.docs.loadbalancer.server.port=80"
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.docs.rule=Host(`docs.${DOMAIN}`)'
+      - 'traefik.http.routers.docs.entrypoints=websecure'
+      - 'traefik.http.routers.docs.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.docs.loadbalancer.server.port=80'
 
   # ---------------------------------------------------------------------------
   # GROBID - PDF Reference Extraction
@@ -192,7 +197,7 @@ services:
     container_name: chive-grobid
     restart: unless-stopped
     logging: *default-logging
-    entrypoint: ["/tini", "-s", "--"]
+    entrypoint: ['/tini', '-s', '--']
     command:
       - /bin/bash
       - -c
@@ -215,7 +220,7 @@ services:
           cpus: '0.25'
           memory: 2G
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8070'"]
+      test: ['CMD-SHELL', "bash -c 'echo > /dev/tcp/localhost/8070'"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -227,7 +232,12 @@ services:
   chive-migrate:
     image: chive:${CHIVE_VERSION:-latest}
     container_name: chive-migrate
-    command: ["sh", "-c", "node node_modules/node-pg-migrate/bin/node-pg-migrate up --migrations-dir dist/src/storage/postgresql/migrations --ignore-pattern '.*\\.(map|d\\.ts)$'"]
+    command:
+      [
+        'sh',
+        '-c',
+        "node node_modules/node-pg-migrate/bin/node-pg-migrate up --migrations-dir dist/src/storage/postgresql/migrations --ignore-pattern '.*\\.(map|d\\.ts)$'",
+      ]
     env_file:
       - .env.production
     environment:
@@ -237,7 +247,7 @@ services:
         condition: service_healthy
     networks:
       - chive-network
-    restart: "no"
+    restart: 'no'
     logging: *default-logging
 
   # ---------------------------------------------------------------------------
@@ -246,7 +256,7 @@ services:
   chive-es-setup:
     image: chive:${CHIVE_VERSION:-latest}
     container_name: chive-es-setup
-    command: ["node", "--enable-source-maps", "dist/scripts/db/setup-elasticsearch.js"]
+    command: ['node', '--enable-source-maps', 'dist/scripts/db/setup-elasticsearch.js']
     env_file:
       - .env.production
     depends_on:
@@ -254,7 +264,7 @@ services:
         condition: service_healthy
     networks:
       - chive-network
-    restart: "no"
+    restart: 'no'
     logging: *default-logging
 
   # ---------------------------------------------------------------------------
@@ -263,7 +273,7 @@ services:
   chive-neo4j-setup:
     image: chive:${CHIVE_VERSION:-latest}
     container_name: chive-neo4j-setup
-    command: ["node", "--enable-source-maps", "dist/scripts/db/setup-neo4j.js"]
+    command: ['node', '--enable-source-maps', 'dist/scripts/db/setup-neo4j.js']
     env_file:
       - .env.production
     depends_on:
@@ -271,7 +281,7 @@ services:
         condition: service_healthy
     networks:
       - chive-network
-    restart: "no"
+    restart: 'no'
     logging: *default-logging
 
   # ---------------------------------------------------------------------------
@@ -316,29 +326,29 @@ services:
           cpus: '0.5'
           memory: 512M
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
     labels:
-      - "traefik.enable=true"
+      - 'traefik.enable=true'
       # API subdomain route
-      - "traefik.http.routers.api.rule=Host(`api.${DOMAIN}`)"
-      - "traefik.http.routers.api.entrypoints=websecure"
-      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
-      - "traefik.http.services.api.loadbalancer.server.port=3000"
+      - 'traefik.http.routers.api.rule=Host(`api.${DOMAIN}`)'
+      - 'traefik.http.routers.api.entrypoints=websecure'
+      - 'traefik.http.routers.api.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.api.loadbalancer.server.port=3000'
       # Path-based route for /api on main domain (used by Next.js frontend)
-      - "traefik.http.routers.api-path.rule=Host(`${DOMAIN}`) && PathPrefix(`/api`)"
-      - "traefik.http.routers.api-path.entrypoints=websecure"
-      - "traefik.http.routers.api-path.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.api-path.service=api"
-      - "traefik.http.middlewares.api-strip.stripprefix.prefixes=/api"
-      - "traefik.http.routers.api-path.middlewares=api-strip,api-ratelimit"
+      - 'traefik.http.routers.api-path.rule=Host(`${DOMAIN}`) && PathPrefix(`/api`)'
+      - 'traefik.http.routers.api-path.entrypoints=websecure'
+      - 'traefik.http.routers.api-path.tls.certresolver=letsencrypt'
+      - 'traefik.http.routers.api-path.service=api'
+      - 'traefik.http.middlewares.api-strip.stripprefix.prefixes=/api'
+      - 'traefik.http.routers.api-path.middlewares=api-strip,api-ratelimit'
       # Rate limiting middleware
-      - "traefik.http.middlewares.api-ratelimit.ratelimit.average=2000"
-      - "traefik.http.middlewares.api-ratelimit.ratelimit.burst=500"
-      - "traefik.http.routers.api.middlewares=api-ratelimit"
+      - 'traefik.http.middlewares.api-ratelimit.ratelimit.average=2000'
+      - 'traefik.http.middlewares.api-ratelimit.ratelimit.burst=500'
+      - 'traefik.http.routers.api.middlewares=api-ratelimit'
       # Block /metrics from the public internet.
       #
       # The Prometheus scrape endpoint is unauthenticated by default so an
@@ -355,13 +365,13 @@ services:
       # Setting METRICS_TOKEN additionally enforces a bearer token at the
       # application layer; this is the network half of the same control, and
       # does not depend on that variable being set.
-      - "traefik.http.routers.api-metrics.rule=(Host(`api.${DOMAIN}`) && Path(`/metrics`)) || (Host(`${DOMAIN}`) && Path(`/api/metrics`))"
-      - "traefik.http.routers.api-metrics.priority=200"
-      - "traefik.http.routers.api-metrics.entrypoints=websecure"
-      - "traefik.http.routers.api-metrics.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.api-metrics.service=api"
-      - "traefik.http.middlewares.metrics-deny.ipallowlist.sourcerange=127.0.0.1/32"
-      - "traefik.http.routers.api-metrics.middlewares=metrics-deny"
+      - 'traefik.http.routers.api-metrics.rule=(Host(`api.${DOMAIN}`) && Path(`/metrics`)) || (Host(`${DOMAIN}`) && Path(`/api/metrics`))'
+      - 'traefik.http.routers.api-metrics.priority=200'
+      - 'traefik.http.routers.api-metrics.entrypoints=websecure'
+      - 'traefik.http.routers.api-metrics.tls.certresolver=letsencrypt'
+      - 'traefik.http.routers.api-metrics.service=api'
+      - 'traefik.http.middlewares.metrics-deny.ipallowlist.sourcerange=127.0.0.1/32'
+      - 'traefik.http.routers.api-metrics.middlewares=metrics-deny'
 
   # ---------------------------------------------------------------------------
   # Chive Indexer (Firehose Consumer)
@@ -371,7 +381,7 @@ services:
     container_name: chive-indexer
     restart: unless-stopped
     logging: *default-logging
-    command: ["node", "--enable-source-maps", "dist/src/indexer.js"]
+    command: ['node', '--enable-source-maps', 'dist/src/indexer.js']
     env_file:
       - .env.production
     environment:
@@ -406,7 +416,7 @@ services:
     # past the watchdog's tolerance, so a wedged firehose is detected here
     # instead of being silently reported "healthy".
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3001/health"]
+      test: ['CMD-SHELL', 'wget -q -O /dev/null http://127.0.0.1:3001/health']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -425,44 +435,44 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-chive}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       # Performance tuning for small server
-      POSTGRES_INITDB_ARGS: "--data-checksums"
+      POSTGRES_INITDB_ARGS: '--data-checksums'
     command:
-      - "postgres"
-      - "-c"
-      - "shared_buffers=256MB"
-      - "-c"
-      - "effective_cache_size=768MB"
-      - "-c"
-      - "maintenance_work_mem=64MB"
-      - "-c"
-      - "checkpoint_completion_target=0.9"
-      - "-c"
-      - "wal_buffers=8MB"
-      - "-c"
-      - "default_statistics_target=100"
-      - "-c"
-      - "random_page_cost=1.1"
-      - "-c"
-      - "effective_io_concurrency=200"
-      - "-c"
-      - "work_mem=8MB"
-      - "-c"
-      - "huge_pages=off"
-      - "-c"
-      - "min_wal_size=1GB"
-      - "-c"
-      - "max_wal_size=4GB"
-      - "-c"
-      - "max_connections=100"
-      - "-c"
-      - "log_statement=none"
-      - "-c"
-      - "log_min_duration_statement=1000"
+      - 'postgres'
+      - '-c'
+      - 'shared_buffers=256MB'
+      - '-c'
+      - 'effective_cache_size=768MB'
+      - '-c'
+      - 'maintenance_work_mem=64MB'
+      - '-c'
+      - 'checkpoint_completion_target=0.9'
+      - '-c'
+      - 'wal_buffers=8MB'
+      - '-c'
+      - 'default_statistics_target=100'
+      - '-c'
+      - 'random_page_cost=1.1'
+      - '-c'
+      - 'effective_io_concurrency=200'
+      - '-c'
+      - 'work_mem=8MB'
+      - '-c'
+      - 'huge_pages=off'
+      - '-c'
+      - 'min_wal_size=1GB'
+      - '-c'
+      - 'max_wal_size=4GB'
+      - '-c'
+      - 'max_connections=100'
+      - '-c'
+      - 'log_statement=none'
+      - '-c'
+      - 'log_min_duration_statement=1000'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
       # Bind to localhost only for SSH tunnel access (admin scripts)
-      - "127.0.0.1:5432:5432"
+      - '127.0.0.1:5432:5432'
     networks:
       - chive-network
     deploy:
@@ -474,7 +484,7 @@ services:
           cpus: '0.5'
           memory: 512M
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-chive} -d ${POSTGRES_DB:-chive}"]
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-chive} -d ${POSTGRES_DB:-chive}']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -489,26 +499,26 @@ services:
     restart: unless-stopped
     logging: *default-logging
     command:
-      - "redis-server"
-      - "--maxmemory"
-      - "256mb"
-      - "--maxmemory-policy"
-      - "allkeys-lru"
-      - "--appendonly"
-      - "yes"
-      - "--appendfsync"
-      - "everysec"
-      - "--save"
-      - "900 1"
-      - "--save"
-      - "300 10"
-      - "--save"
-      - "60 10000"
+      - 'redis-server'
+      - '--maxmemory'
+      - '256mb'
+      - '--maxmemory-policy'
+      - 'allkeys-lru'
+      - '--appendonly'
+      - 'yes'
+      - '--appendfsync'
+      - 'everysec'
+      - '--save'
+      - '900 1'
+      - '--save'
+      - '300 10'
+      - '--save'
+      - '60 10000'
     volumes:
       - redis_data:/data
     ports:
       # Bind to localhost only for SSH tunnel access (admin scripts)
-      - "127.0.0.1:6379:6379"
+      - '127.0.0.1:6379:6379'
     networks:
       - chive-network
     deploy:
@@ -520,7 +530,7 @@ services:
           cpus: '0.1'
           memory: 128M
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ['CMD', 'redis-cli', 'ping']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -542,7 +552,7 @@ services:
       - xpack.security.enabled=false
       - xpack.security.enrollment.enabled=false
       # Heap: 1.5GB (50% of 3GB container)
-      - "ES_JAVA_OPTS=-Xms1536m -Xmx1536m"
+      - 'ES_JAVA_OPTS=-Xms1536m -Xmx1536m'
       - cluster.name=chive-cluster
       - bootstrap.memory_lock=true
       - cluster.routing.allocation.disk.threshold_enabled=true
@@ -568,7 +578,11 @@ services:
         soft: 65536
         hard: 65536
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=30s || exit 1"]
+      test:
+        [
+          'CMD-SHELL',
+          'curl -sf http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=30s || exit 1',
+        ]
       interval: 30s
       timeout: 30s
       retries: 5
@@ -610,7 +624,7 @@ services:
           cpus: '0.25'
           memory: 512M
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:7474 || exit 1"]
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:7474 || exit 1']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -647,7 +661,11 @@ services:
       - loki
     healthcheck:
       # Alloy image doesn't include wget/curl, use bash TCP
-      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/12345 && echo -e \"GET /-/ready HTTP/1.0\\r\\n\\r\\n\" >&3 && grep -q \"200 OK\" <&3'"]
+      test:
+        [
+          'CMD-SHELL',
+          "bash -c 'exec 3<>/dev/tcp/localhost/12345 && echo -e \"GET /-/ready HTTP/1.0\\r\\n\\r\\n\" >&3 && grep -q \"200 OK\" <&3'",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -655,12 +673,12 @@ services:
     profiles:
       - observability
     labels:
-      - "traefik.enable=true"
+      - 'traefik.enable=true'
       # Faro collector endpoint (frontend telemetry)
-      - "traefik.http.routers.faro.rule=Host(`faro.${DOMAIN}`)"
-      - "traefik.http.routers.faro.entrypoints=websecure"
-      - "traefik.http.routers.faro.tls.certresolver=letsencrypt"
-      - "traefik.http.services.faro.loadbalancer.server.port=12347"
+      - 'traefik.http.routers.faro.rule=Host(`faro.${DOMAIN}`)'
+      - 'traefik.http.routers.faro.entrypoints=websecure'
+      - 'traefik.http.routers.faro.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.faro.loadbalancer.server.port=12347'
 
   # ---------------------------------------------------------------------------
   # Tempo - Distributed Tracing Backend
@@ -686,7 +704,7 @@ services:
           cpus: '0.1'
           memory: 256M
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3200/ready"]
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3200/ready']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -718,7 +736,7 @@ services:
           cpus: '0.1'
           memory: 256M
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3100/ready"]
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3100/ready']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -736,12 +754,12 @@ services:
     restart: unless-stopped
     logging: *default-logging
     command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
-      - "--storage.tsdb.path=/prometheus"
-      - "--storage.tsdb.retention.time=7d"
-      - "--web.enable-remote-write-receiver"
-      - "--web.console.libraries=/etc/prometheus/console_libraries"
-      - "--web.console.templates=/etc/prometheus/consoles"
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=7d'
+      - '--web.enable-remote-write-receiver'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
     volumes:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
@@ -756,7 +774,7 @@ services:
           cpus: '0.1'
           memory: 256M
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/healthy"]
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:9090/-/healthy']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -796,7 +814,7 @@ services:
       - loki
       - prometheus
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/api/health']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -804,11 +822,11 @@ services:
     profiles:
       - observability
     labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.grafana.rule=Host(`grafana.${DOMAIN}`)"
-      - "traefik.http.routers.grafana.entrypoints=websecure"
-      - "traefik.http.routers.grafana.tls.certresolver=letsencrypt"
-      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.grafana.rule=Host(`grafana.${DOMAIN}`)'
+      - 'traefik.http.routers.grafana.entrypoints=websecure'
+      - 'traefik.http.routers.grafana.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.grafana.loadbalancer.server.port=3000'
 
 # =============================================================================
 # Volumes

--- a/docs/api-reference/resolving-identifiers.md
+++ b/docs/api-reference/resolving-identifiers.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 6
+---
+
+# Resolving external identifiers
+
+Chive answers one question for the rest of the ATProto scholarly ecosystem:
+**given a DOI, arXiv ID or ORCID, what is the AT-URI?**
+
+This is `pub.chive.resolve.byExternalId`. It is unauthenticated, cacheable, and
+intended for other applications to call. Semble, Margin and Lea all hold
+references to works by external identifier; this is how those become AT-URIs
+that address a record on the network.
+
+## Endpoint
+
+```text
+GET https://api.chive.pub/xrpc/pub.chive.resolve.byExternalId
+```
+
+| Parameter    | Required | Description                                                |
+| ------------ | -------- | ---------------------------------------------------------- |
+| `system`     | yes      | `doi`, `arxiv`, `orcid`, `ror`, `isbn`, `pmid`, `wikidata` |
+| `identifier` | yes      | The identifier itself, with no resolver prefix             |
+
+Pass `10.1000/abc`, not `https://doi.org/10.1000/abc`.
+
+## Response
+
+```json
+{
+  "found": true,
+  "entityType": "eprint",
+  "uri": "at://did:plc:author/pub.chive.eprint.submission/3k5abc",
+  "cid": "bafyrei..."
+}
+```
+
+`entityType` is `eprint`, `author` or `graphNode`. A knowledge-graph node is
+returned when the identifier names a concept, institution or venue rather than
+a work — a ROR ID resolves to the institution node, for instance.
+
+When nothing matches:
+
+```json
+{ "found": false }
+```
+
+**`found: false` means Chive does not index that identifier, not that the work
+does not exist.** Chive indexes eprints submitted to it and the authority
+records its community has approved. A DOI absent here may be present anywhere
+else.
+
+## Examples
+
+```bash
+# A DOI
+curl -s 'https://api.chive.pub/xrpc/pub.chive.resolve.byExternalId?system=doi&identifier=10.1000/abc'
+
+# An ORCID, resolving to an author
+curl -s 'https://api.chive.pub/xrpc/pub.chive.resolve.byExternalId?system=orcid&identifier=0000-0002-1825-0097'
+```
+
+Once you hold the AT-URI, read the record from the author's PDS with
+`com.atproto.repo.getRecord`, or from Chive's index with
+`pub.chive.eprint.getSubmission`. Reading it from the PDS is the more durable
+choice: that repository is where the record lives, and Chive is one index of it
+among however many come later.
+
+## Notes for callers
+
+- **No authentication.** Anonymous rate limits apply; see
+  [Authentication](./authentication.md).
+- **Cache the answer.** An identifier's AT-URI changes only if the record is
+  deleted and resubmitted, which is rare.
+- **One identifier per call.** There is no batch form. If you need one, it is
+  worth asking for rather than looping — say so in an issue.

--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -16,6 +16,185 @@
         ],
         "type": "object"
       },
+      "com.atproto.label.defs.label": {
+        "description": "Metadata tag on an atproto resource (eg, repo or record).",
+        "properties": {
+          "cid": {
+            "description": "Optionally, CID specifying the specific version of 'uri' resource this label applies to.",
+            "format": "cid",
+            "type": "string"
+          },
+          "cts": {
+            "description": "Timestamp when this label was created.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "exp": {
+            "description": "Timestamp at which this label expires (no longer applies).",
+            "format": "date-time",
+            "type": "string"
+          },
+          "neg": {
+            "description": "If true, this is a negation label, overwriting a previous label.",
+            "type": "boolean"
+          },
+          "sig": {
+            "description": "Signature of dag-cbor encoded label.",
+            "format": "byte",
+            "type": "string"
+          },
+          "src": {
+            "description": "DID of the actor who created this label.",
+            "format": "did",
+            "type": "string"
+          },
+          "uri": {
+            "description": "AT URI of the record, repository (account), or other resource that this label applies to.",
+            "format": "uri",
+            "type": "string"
+          },
+          "val": {
+            "description": "The short string name of the value or type of this label.",
+            "maxLength": 128,
+            "type": "string"
+          },
+          "ver": {
+            "description": "The AT Protocol version of the label object.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "src",
+          "uri",
+          "val",
+          "cts"
+        ],
+        "type": "object"
+      },
+      "com.atproto.label.defs.labelValue": {
+        "enum": [
+          "!hide",
+          "!warn",
+          "!no-unauthenticated",
+          "porn",
+          "sexual",
+          "nudity",
+          "graphic-media",
+          "bot"
+        ],
+        "type": "string"
+      },
+      "com.atproto.label.defs.labelValueDefinition": {
+        "description": "Declares a label value and its expected interpretations and behaviors.",
+        "properties": {
+          "adultOnly": {
+            "description": "Does the user need to have adult content enabled in order to configure this label?",
+            "type": "boolean"
+          },
+          "blurs": {
+            "description": "What should this label hide in the UI, if applied? 'content' hides all of the target; 'media' hides the images/video/audio; 'none' hides nothing.",
+            "enum": [
+              "content",
+              "media",
+              "none"
+            ],
+            "type": "string"
+          },
+          "defaultSetting": {
+            "default": "warn",
+            "description": "The default setting for this label.",
+            "enum": [
+              "ignore",
+              "warn",
+              "hide"
+            ],
+            "type": "string"
+          },
+          "identifier": {
+            "description": "The value of the label being defined. Must only include lowercase ascii and the '-' character ([a-z-]+).",
+            "maxLength": 100,
+            "type": "string"
+          },
+          "locales": {
+            "items": {
+              "$ref": "#/components/schemas/com.atproto.label.defs.labelValueDefinitionStrings"
+            },
+            "type": "array"
+          },
+          "severity": {
+            "description": "How should a client visually convey this label? 'inform' means neutral and informational; 'alert' means negative and warning; 'none' means show nothing.",
+            "enum": [
+              "inform",
+              "alert",
+              "none"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "identifier",
+          "severity",
+          "blurs",
+          "locales"
+        ],
+        "type": "object"
+      },
+      "com.atproto.label.defs.labelValueDefinitionStrings": {
+        "description": "Strings which describe the label in the UI, localized into a specific language.",
+        "properties": {
+          "description": {
+            "description": "A longer description of what the label means and why it might be applied.",
+            "maxLength": 100000,
+            "type": "string"
+          },
+          "lang": {
+            "description": "The code of the language these strings are written in.",
+            "format": "language",
+            "type": "string"
+          },
+          "name": {
+            "description": "A short human-readable name for the label.",
+            "maxLength": 640,
+            "type": "string"
+          }
+        },
+        "required": [
+          "lang",
+          "name",
+          "description"
+        ],
+        "type": "object"
+      },
+      "com.atproto.label.defs.selfLabel": {
+        "description": "Metadata tag on an atproto record, published by the author within the record. Note that schemas should use #selfLabels, not #selfLabel.",
+        "properties": {
+          "val": {
+            "description": "The short string name of the value or type of this label.",
+            "maxLength": 128,
+            "type": "string"
+          }
+        },
+        "required": [
+          "val"
+        ],
+        "type": "object"
+      },
+      "com.atproto.label.defs.selfLabels": {
+        "description": "Metadata tags on an atproto record, published by the author within the record.",
+        "properties": {
+          "values": {
+            "items": {
+              "$ref": "#/components/schemas/com.atproto.label.defs.selfLabel"
+            },
+            "maxItems": 10,
+            "type": "array"
+          }
+        },
+        "required": [
+          "values"
+        ],
+        "type": "object"
+      },
       "com.atproto.repo.applyWrites.create": {
         "description": "Operation which creates a new record.",
         "properties": {
@@ -7288,6 +7467,7 @@
               "paperswithcode",
               "codeberg",
               "sourcehut",
+              "tangled",
               "software_heritage",
               "colab",
               "kaggle",
@@ -7297,6 +7477,11 @@
           },
           "platformUri": {
             "description": "AT-URI to platform node (subkind=platform-code)",
+            "format": "at-uri",
+            "type": "string"
+          },
+          "recordUri": {
+            "description": "AT-URI of the repository record when the host is an ATProto application, such as sh.tangled.repo. Addresses the repository on the network rather than at one web host, so it survives the host moving or disappearing.",
             "format": "at-uri",
             "type": "string"
           },
@@ -13538,6 +13723,83 @@
         "description": "Strikethrough text formatting facet",
         "type": "object"
       },
+      "pub.chive.site.citationLink": {
+        "description": "A typed citation from the containing document to another work.",
+        "properties": {
+          "context": {
+            "description": "Where in the document the citation occurs, or a short quotation of the citing sentence.",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "relation": {
+            "description": "How the document relates to the cited work. Open by design: `knownValues` names the relations Chive emits, and a consumer meeting an unfamiliar one should treat it as a plain citation rather than discard the link.",
+            "enum": [
+              "cites",
+              "extends",
+              "disputes",
+              "replicates",
+              "usesDataFrom",
+              "usesMethodIn",
+              "reviews"
+            ],
+            "maxLength": 128,
+            "type": "string"
+          },
+          "target": {
+            "$ref": "#/components/schemas/pub.chive.site.citationLink.target"
+          }
+        },
+        "required": [
+          "relation",
+          "target"
+        ],
+        "type": "object"
+      },
+      "pub.chive.site.citationLink.target": {
+        "description": "Identification of a cited work. At least one identifier should be present; `title` alone identifies a work no machine can resolve, which is why it is not sufficient on its own.",
+        "properties": {
+          "authors": {
+            "items": {
+              "maxLength": 200,
+              "type": "string"
+            },
+            "maxItems": 50,
+            "type": "array"
+          },
+          "doi": {
+            "description": "DOI, without a resolver prefix.",
+            "maxLength": 200,
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 1000,
+            "type": "string"
+          },
+          "uri": {
+            "description": "AT-URI of the cited work, when it lives on the network.",
+            "format": "at-uri",
+            "type": "string"
+          },
+          "url": {
+            "format": "uri",
+            "maxLength": 1000,
+            "type": "string"
+          },
+          "venue": {
+            "maxLength": 500,
+            "type": "string"
+          },
+          "year": {
+            "maximum": 3000,
+            "minimum": 1000,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
       "pub.chive.tag.getDetail.promotionTarget": {
         "description": "Target of tag promotion",
         "properties": {
@@ -13937,104 +14199,283 @@
       },
       "site.standard.document": {
         "properties": {
-          "content": {
-            "$ref": "#/components/schemas/site.standard.document.contentRef"
+          "bskyPostRef": {
+            "$ref": "#/components/schemas/com.atproto.repo.strongRef"
           },
-          "createdAt": {
-            "format": "date-time",
+          "content": {
+            "oneOf": []
+          },
+          "contributors": {
+            "items": {
+              "$ref": "#/components/schemas/site.standard.document.contributor"
+            },
+            "type": "array"
+          },
+          "coverImage": {
+            "description": "Image to used for thumbnail or cover image. Less than 1MB is size.",
+            "format": "binary",
+            "maxLength": 1000000,
             "type": "string"
           },
           "description": {
-            "description": "Brief description or abstract",
-            "maxLength": 2000,
+            "description": "A brief description or excerpt from the document.",
+            "maxLength": 30000,
             "type": "string"
           },
-          "title": {
-            "description": "Title of the document",
-            "maxLength": 500,
+          "labels": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/com.atproto.label.defs.selfLabels"
+              }
+            ]
+          },
+          "links": {
+            "oneOf": []
+          },
+          "path": {
+            "description": "Combine with site or publication url to construct a canonical URL to the document. Prepend with a leading slash.",
             "type": "string"
           },
-          "updatedAt": {
+          "publishedAt": {
+            "description": "Timestamp of the documents publish time.",
             "format": "date-time",
             "type": "string"
           },
-          "visibility": {
-            "default": "public",
-            "enum": [
-              "public",
-              "private",
-              "unlisted"
-            ],
+          "site": {
+            "description": "Points to a publication record (at://) or a publication url (https://) for loose documents. Avoid trailing slashes.",
+            "format": "uri",
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "maxLength": 1280,
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "textContent": {
+            "description": "Plaintext representation of the documents contents. Should not contain markdown or other formatting.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Title of the document.",
+            "maxLength": 5000,
+            "type": "string"
+          },
+          "updatedAt": {
+            "description": "Timestamp of the documents last edit.",
+            "format": "date-time",
             "type": "string"
           }
         },
         "required": [
+          "site",
           "title",
-          "createdAt"
+          "publishedAt"
         ],
         "type": "object"
       },
-      "site.standard.document.contentRef": {
+      "site.standard.document.contributor": {
         "properties": {
-          "cid": {
-            "description": "CID of the content record for verification",
-            "format": "cid",
+          "did": {
+            "format": "did",
             "type": "string"
           },
-          "uri": {
-            "description": "AT-URI of the platform-specific content record",
+          "displayName": {
+            "maxLength": 1000,
+            "type": "string"
+          },
+          "role": {
+            "maxLength": 1000,
+            "type": "string"
+          }
+        },
+        "required": [
+          "did"
+        ],
+        "type": "object"
+      },
+      "site.standard.graph.recommend": {
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "document": {
+            "description": "AT-URI reference to the document record being recommended (ex: at://did:plc:abc123/site.standard.document/xyz789).",
             "format": "at-uri",
             "type": "string"
           }
         },
         "required": [
-          "uri"
+          "document",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "site.standard.graph.subscription": {
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "publication": {
+            "description": "AT-URI reference to the publication record being subscribed to (ex: at://did:plc:abc123/site.standard.publication/xyz789).",
+            "format": "at-uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "publication"
         ],
         "type": "object"
       },
       "site.standard.publication": {
         "properties": {
-          "avatar": {
-            "description": "Square image identifying the publication (256x256 minimum)",
+          "basicTheme": {
+            "$ref": "#/components/schemas/site.standard.theme.basic"
+          },
+          "description": {
+            "description": "Brief description of the publication.",
+            "maxLength": 30000,
+            "type": "string"
+          },
+          "icon": {
+            "description": "Square image to identify the publication. Should be at least 256x256.",
             "format": "binary",
             "maxLength": 1000000,
             "type": "string"
           },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "description": {
-            "description": "Brief description of the publication",
-            "maxLength": 1000,
-            "type": "string"
+          "labels": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/com.atproto.label.defs.selfLabels"
+              }
+            ]
           },
           "name": {
-            "description": "Name of the publication",
-            "maxLength": 100,
+            "description": "Name of the publication.",
+            "maxLength": 5000,
             "type": "string"
           },
-          "theme": {
-            "$ref": "#/components/schemas/site.standard.publication.theme"
+          "preferences": {
+            "$ref": "#/components/schemas/site.standard.publication.preferences"
+          },
+          "url": {
+            "description": "Base publication url (ex: https://standard.site). The canonical document URL is formed by combining this value with the document path.",
+            "format": "uri",
+            "type": "string"
           }
         },
         "required": [
-          "name",
-          "createdAt"
+          "url",
+          "name"
         ],
         "type": "object"
       },
-      "site.standard.publication.theme": {
+      "site.standard.publication.preferences": {
         "properties": {
-          "accentColor": {
-            "description": "Accent color in hex format",
-            "type": "string"
-          },
-          "primaryColor": {
-            "description": "Primary brand color in hex format",
-            "type": "string"
+          "showInDiscover": {
+            "default": true,
+            "description": "Boolean which decides whether the publication should appear in discovery feeds.",
+            "type": "boolean"
           }
         },
+        "type": "object"
+      },
+      "site.standard.theme.basic": {
+        "properties": {
+          "accent": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/site.standard.theme.color.rgb"
+              }
+            ]
+          },
+          "accentForeground": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/site.standard.theme.color.rgb"
+              }
+            ]
+          },
+          "background": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/site.standard.theme.color.rgb"
+              }
+            ]
+          },
+          "foreground": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/site.standard.theme.color.rgb"
+              }
+            ]
+          }
+        },
+        "required": [
+          "background",
+          "foreground",
+          "accent",
+          "accentForeground"
+        ],
+        "type": "object"
+      },
+      "site.standard.theme.color.rgb": {
+        "properties": {
+          "b": {
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "g": {
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "r": {
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "r",
+          "g",
+          "b"
+        ],
+        "type": "object"
+      },
+      "site.standard.theme.color.rgba": {
+        "properties": {
+          "a": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "b": {
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "g": {
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "r": {
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "r",
+          "g",
+          "b",
+          "a"
+        ],
         "type": "object"
       }
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/docs/reference/lexicons.md
+++ b/docs/reference/lexicons.md
@@ -1,6 +1,6 @@
 # Lexicons reference
 
-Chive uses the `pub.chive.*` namespace for all AT Protocol lexicons. These lexicons define 23 record types, 128 queries, and 49 procedures across 24 namespaces. All records are stored in user-controlled PDSes and indexed by the Chive AppView via the ATProto firehose.
+Chive uses the `pub.chive.*` namespace for all AT Protocol lexicons. These lexicons define 23 record types, 128 queries, and 49 procedures across 25 namespaces. All records are stored in user-controlled PDSes and indexed by the Chive AppView via the ATProto firehose.
 
 For the ATProto lexicon specification, see the [Lexicon Guide](https://atproto.com/guides/lexicon).
 
@@ -31,6 +31,7 @@ For the ATProto lexicon specification, see the [Lexicon Guide](https://atproto.c
 | `pub.chive.resolve.*`       | External identifier resolution (DOI, arXiv) to AT URIs     |
 | `pub.chive.review.*`        | Document-level reviews and entity links                    |
 | `pub.chive.richtext.*`      | Shared rich text definitions and facets                    |
+| `pub.chive.site.*`          | Extensions to standard.site's open unions                  |
 | `pub.chive.sync.*`          | PDS synchronization and staleness checking                 |
 | `pub.chive.tag.*`           | User-generated tags and tag search                         |
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -85,6 +85,7 @@ const sidebars: SidebarsConfig = {
         'api-reference/overview',
         'api-reference/authentication',
         'api-reference/xrpc-endpoints',
+        'api-reference/resolving-identifiers',
         'api-reference/admin-endpoints',
         'api-reference/rest-endpoints',
         {

--- a/k8s/helm/chive/values.yaml
+++ b/k8s/helm/chive/values.yaml
@@ -10,7 +10,7 @@ global:
   environment: production
 
   # Image registry (leave empty for Docker Hub)
-  imageRegistry: ""
+  imageRegistry: ''
 
   # Image pull secrets (for private registries)
   imagePullSecrets: []
@@ -34,11 +34,11 @@ appview:
 
   resources:
     requests:
-      cpu: "200m"
-      memory: "256Mi"
+      cpu: '200m'
+      memory: '256Mi'
     limits:
-      cpu: "1000m"
-      memory: "1Gi"
+      cpu: '1000m'
+      memory: '1Gi'
 
   # Horizontal Pod Autoscaler
   autoscaling:
@@ -98,16 +98,16 @@ indexer:
 
   command:
     - node
-    - "--enable-source-maps"
+    - '--enable-source-maps'
     - dist/indexer.js
 
   resources:
     requests:
-      cpu: "250m"
-      memory: "512Mi"
+      cpu: '250m'
+      memory: '512Mi'
     limits:
-      cpu: "1000m"
-      memory: "1Gi"
+      cpu: '1000m'
+      memory: '1Gi'
 
   # PDB for indexer
   pdb:
@@ -133,11 +133,11 @@ frontend:
 
   resources:
     requests:
-      cpu: "100m"
-      memory: "128Mi"
+      cpu: '100m'
+      memory: '128Mi'
     limits:
-      cpu: "500m"
-      memory: "512Mi"
+      cpu: '500m'
+      memory: '512Mi'
 
   autoscaling:
     enabled: false
@@ -153,8 +153,8 @@ ingress:
   className: nginx
 
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    cert-manager.io/cluster-issuer: 'letsencrypt-prod'
+    nginx.ingress.kubernetes.io/proxy-body-size: '100m'
 
   hosts:
     - host: chive.example.com
@@ -193,11 +193,11 @@ postgresql:
       size: 10Gi
     resources:
       requests:
-        cpu: "250m"
-        memory: "512Mi"
+        cpu: '250m'
+        memory: '512Mi'
       limits:
-        cpu: "2000m"
-        memory: "1Gi"
+        cpu: '2000m'
+        memory: '1Gi'
 
 redis:
   enabled: true
@@ -208,24 +208,24 @@ redis:
       size: 5Gi
     resources:
       requests:
-        cpu: "100m"
-        memory: "128Mi"
+        cpu: '100m'
+        memory: '128Mi'
       limits:
-        cpu: "500m"
-        memory: "300Mi"
+        cpu: '500m'
+        memory: '300Mi'
 
 elasticsearch:
   enabled: true
   replicas: 1
   minimumMasterNodes: 1
-  esJavaOpts: "-Xmx512m -Xms512m"
+  esJavaOpts: '-Xmx512m -Xms512m'
   resources:
     requests:
-      cpu: "500m"
-      memory: "768Mi"
+      cpu: '500m'
+      memory: '768Mi'
     limits:
-      cpu: "2000m"
-      memory: "1Gi"
+      cpu: '2000m'
+      memory: '1Gi'
   volumeClaimTemplate:
     resources:
       requests:
@@ -237,11 +237,11 @@ neo4j:
     edition: community
     resources:
       requests:
-        cpu: "250m"
-        memory: "512Mi"
+        cpu: '250m'
+        memory: '512Mi'
       limits:
-        cpu: "1000m"
-        memory: "1Gi"
+        cpu: '1000m'
+        memory: '1Gi'
   volumes:
     data:
       mode: defaultStorageClass
@@ -255,39 +255,44 @@ neo4j:
 config:
   # ATProto configuration
   atproto:
-    relayUrl: "wss://bsky.network"
-    pdsUrl: "https://bsky.social"
-    graphPdsDid: "did:plc:chive-governance"
+    relayUrl: 'wss://bsky.network'
+    pdsUrl: 'https://bsky.social'
+    # The real governance repository. `did:plc:chive-governance` is not a PLC
+    # identifier — a PLC DID is 24 base32 characters — so it resolved to
+    # nothing and the governance sync imported an empty graph. Every other
+    # config was corrected in 0.10.0; this chart was missed, and a Helm
+    # deployment would still have carried the invalid value.
+    graphPdsDid: 'did:plc:5wzpn4a4nbqtz3q45hyud6hd'
 
   # Application
   logLevel: info
   rateLimitFailMode: closed
-  stalenessThresholdMs: "604800000"
+  stalenessThresholdMs: '604800000'
 
   # OpenTelemetry
   otel:
     enabled: true
-    endpoint: "http://otel-collector:4318"
+    endpoint: 'http://otel-collector:4318'
 
 # =============================================================================
 # Secrets
 # =============================================================================
 secrets:
   # If using existing secrets, set name here
-  existingSecret: ""
+  existingSecret: ''
 
   # Or provide values directly (not recommended for production)
   # These will be ignored if existingSecret is set
-  postgresPassword: ""
-  neo4jAuth: ""
-  jwtSecret: ""
-  sessionSecret: ""
+  postgresPassword: ''
+  neo4jAuth: ''
+  jwtSecret: ''
+  sessionSecret: ''
 
 # =============================================================================
 # Service Monitor (for Prometheus)
 # =============================================================================
 serviceMonitor:
   enabled: false
-  namespace: ""
+  namespace: ''
   interval: 30s
   scrapeTimeout: 10s

--- a/lexicons/com/atproto/label/defs.json
+++ b/lexicons/com/atproto/label/defs.json
@@ -1,0 +1,153 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.label.defs",
+  "defs": {
+    "label": {
+      "type": "object",
+      "description": "Metadata tag on an atproto resource (eg, repo or record).",
+      "required": ["src", "uri", "val", "cts"],
+      "properties": {
+        "ver": {
+          "type": "integer",
+          "description": "The AT Protocol version of the label object."
+        },
+        "src": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the actor who created this label."
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "AT URI of the record, repository (account), or other resource that this label applies to."
+        },
+        "cid": {
+          "type": "string",
+          "format": "cid",
+          "description": "Optionally, CID specifying the specific version of 'uri' resource this label applies to."
+        },
+        "val": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "The short string name of the value or type of this label."
+        },
+        "neg": {
+          "type": "boolean",
+          "description": "If true, this is a negation label, overwriting a previous label."
+        },
+        "cts": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp when this label was created."
+        },
+        "exp": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp at which this label expires (no longer applies)."
+        },
+        "sig": {
+          "type": "bytes",
+          "description": "Signature of dag-cbor encoded label."
+        }
+      }
+    },
+    "selfLabels": {
+      "type": "object",
+      "description": "Metadata tags on an atproto record, published by the author within the record.",
+      "required": ["values"],
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "#selfLabel" },
+          "maxLength": 10
+        }
+      }
+    },
+    "selfLabel": {
+      "type": "object",
+      "description": "Metadata tag on an atproto record, published by the author within the record. Note that schemas should use #selfLabels, not #selfLabel.",
+      "required": ["val"],
+      "properties": {
+        "val": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "The short string name of the value or type of this label."
+        }
+      }
+    },
+    "labelValueDefinition": {
+      "type": "object",
+      "description": "Declares a label value and its expected interpretations and behaviors.",
+      "required": ["identifier", "severity", "blurs", "locales"],
+      "properties": {
+        "identifier": {
+          "type": "string",
+          "description": "The value of the label being defined. Must only include lowercase ascii and the '-' character ([a-z-]+).",
+          "maxLength": 100,
+          "maxGraphemes": 100
+        },
+        "severity": {
+          "type": "string",
+          "description": "How should a client visually convey this label? 'inform' means neutral and informational; 'alert' means negative and warning; 'none' means show nothing.",
+          "knownValues": ["inform", "alert", "none"]
+        },
+        "blurs": {
+          "type": "string",
+          "description": "What should this label hide in the UI, if applied? 'content' hides all of the target; 'media' hides the images/video/audio; 'none' hides nothing.",
+          "knownValues": ["content", "media", "none"]
+        },
+        "defaultSetting": {
+          "type": "string",
+          "description": "The default setting for this label.",
+          "knownValues": ["ignore", "warn", "hide"],
+          "default": "warn"
+        },
+        "adultOnly": {
+          "type": "boolean",
+          "description": "Does the user need to have adult content enabled in order to configure this label?"
+        },
+        "locales": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "#labelValueDefinitionStrings" }
+        }
+      }
+    },
+    "labelValueDefinitionStrings": {
+      "type": "object",
+      "description": "Strings which describe the label in the UI, localized into a specific language.",
+      "required": ["lang", "name", "description"],
+      "properties": {
+        "lang": {
+          "type": "string",
+          "description": "The code of the language these strings are written in.",
+          "format": "language"
+        },
+        "name": {
+          "type": "string",
+          "description": "A short human-readable name for the label.",
+          "maxGraphemes": 64,
+          "maxLength": 640
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of what the label means and why it might be applied.",
+          "maxGraphemes": 10000,
+          "maxLength": 100000
+        }
+      }
+    },
+    "labelValue": {
+      "type": "string",
+      "knownValues": [
+        "!hide",
+        "!warn",
+        "!no-unauthenticated",
+        "porn",
+        "sexual",
+        "nudity",
+        "graphic-media",
+        "bot"
+      ]
+    }
+  }
+}

--- a/lexicons/pub/chive/eprint/submission.json
+++ b/lexicons/pub/chive/eprint/submission.json
@@ -200,7 +200,7 @@
           "publicationStatusSlug": {
             "type": "ref",
             "ref": "pub.chive.defs#publicationStatus",
-            "description": "Publication status slug for display fallback. The Lexicon spec allows `default` only on primitive types, not on a ref, so the `default: preprint` that used to sit here was never applied — a record omitting this field got nothing, not a preprint. Removing it changes no behaviour and stops the schema promising one it does not keep; consumers supply their own fallback."
+            "description": "Publication status slug for display fallback. The Lexicon spec allows `default` only on primitive types, not on a ref, so the `default: preprint` that used to sit here was never applied \u2014 a record omitting this field got nothing, not a preprint. Removing it changes no behaviour and stops the schema promising one it does not keep; consumers supply their own fallback."
           },
           "paperTypeUri": {
             "type": "string",
@@ -573,6 +573,7 @@
             "paperswithcode",
             "codeberg",
             "sourcehut",
+            "tangled",
             "software_heritage",
             "colab",
             "kaggle",
@@ -591,6 +592,11 @@
         "swhid": {
           "type": "string",
           "description": "Software Heritage Identifier"
+        },
+        "recordUri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "AT-URI of the repository record when the host is an ATProto application, such as sh.tangled.repo. Addresses the repository on the network rather than at one web host, so it survives the host moving or disappearing."
         }
       }
     },

--- a/lexicons/pub/chive/site/citationLink.json
+++ b/lexicons/pub/chive/site/citationLink.json
@@ -1,0 +1,79 @@
+{
+  "lexicon": 1,
+  "id": "pub.chive.site.citationLink",
+  "revision": 1,
+  "description": "A typed link from a standard.site document to a work it cites. Written into the reserved `links` union of `site.standard.document`, which the standard.site lexicon leaves open for extensions like this one. The relation vocabulary follows CiTO (the Citation Typing Ontology), so a consumer that knows CiTO can read these without knowing anything about Chive.",
+  "defs": {
+    "main": {
+      "type": "object",
+      "description": "A typed citation from the containing document to another work.",
+      "required": ["relation", "target"],
+      "properties": {
+        "relation": {
+          "type": "string",
+          "description": "How the document relates to the cited work. Open by design: `knownValues` names the relations Chive emits, and a consumer meeting an unfamiliar one should treat it as a plain citation rather than discard the link.",
+          "knownValues": [
+            "cites",
+            "extends",
+            "disputes",
+            "replicates",
+            "usesDataFrom",
+            "usesMethodIn",
+            "reviews"
+          ],
+          "maxLength": 128
+        },
+        "target": {
+          "type": "ref",
+          "ref": "#target",
+          "description": "The work being cited."
+        },
+        "context": {
+          "type": "string",
+          "description": "Where in the document the citation occurs, or a short quotation of the citing sentence.",
+          "maxLength": 2000
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "description": "Identification of a cited work. At least one identifier should be present; `title` alone identifies a work no machine can resolve, which is why it is not sufficient on its own.",
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "maxLength": 1000
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "AT-URI of the cited work, when it lives on the network."
+        },
+        "doi": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "DOI, without a resolver prefix."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "maxLength": 1000
+        },
+        "authors": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 200 },
+          "maxLength": 50
+        },
+        "year": {
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 3000
+        },
+        "venue": {
+          "type": "string",
+          "maxLength": 500
+        }
+      }
+    }
+  }
+}

--- a/lexicons/site/standard/document.json
+++ b/lexicons/site/standard/document.json
@@ -1,61 +1,115 @@
 {
-  "lexicon": 1,
   "id": "site.standard.document",
   "defs": {
     "main": {
-      "type": "record",
       "key": "tid",
-      "description": "A document record for long-form content discovery.",
+      "type": "record",
       "record": {
         "type": "object",
-        "required": ["title", "createdAt"],
+        "required": ["site", "title", "publishedAt"],
         "properties": {
+          "path": {
+            "type": "string",
+            "description": "Combine with site or publication url to construct a canonical URL to the document. Prepend with a leading slash."
+          },
+          "site": {
+            "type": "string",
+            "format": "uri",
+            "description": "Points to a publication record (at://) or a publication url (https://) for loose documents. Avoid trailing slashes."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 1280,
+              "maxGraphemes": 128
+            },
+            "description": "Array of strings used to tag or categorize the document. Avoid prepending tags with hashtags."
+          },
+          "links": {
+            "refs": [],
+            "type": "union",
+            "description": "Array of values describing relationships between this document and external resources"
+          },
           "title": {
             "type": "string",
-            "maxLength": 500,
-            "description": "Title of the document"
+            "maxLength": 5000,
+            "description": "Title of the document.",
+            "maxGraphemes": 500
           },
-          "description": {
-            "type": "string",
-            "maxLength": 2000,
-            "description": "Brief description or abstract"
+          "labels": {
+            "refs": ["com.atproto.label.defs#selfLabels"],
+            "type": "union",
+            "description": "Self-label values for this post. Effectively content warnings."
           },
           "content": {
-            "type": "ref",
-            "ref": "#contentRef",
-            "description": "Reference to platform-specific content record"
-          },
-          "visibility": {
-            "type": "string",
-            "knownValues": ["public", "private", "unlisted"],
-            "default": "public"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "datetime"
+            "refs": [],
+            "type": "union",
+            "closed": false,
+            "description": "Open union used to define the record's content. Each entry must specify a $type and may be extended with other lexicons to support additional content formats."
           },
           "updatedAt": {
             "type": "string",
-            "format": "datetime"
+            "format": "datetime",
+            "description": "Timestamp of the documents last edit."
+          },
+          "coverImage": {
+            "type": "blob",
+            "accept": ["image/*"],
+            "maxSize": 1000000,
+            "description": "Image to used for thumbnail or cover image. Less than 1MB is size."
+          },
+          "bskyPostRef": {
+            "ref": "com.atproto.repo.strongRef",
+            "type": "ref",
+            "description": "Strong reference to a Bluesky post. Useful to keep track of comments off-platform."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 30000,
+            "description": "A brief description or excerpt from the document.",
+            "maxGraphemes": 3000
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp of the documents publish time."
+          },
+          "textContent": {
+            "type": "string",
+            "description": "Plaintext representation of the documents contents. Should not contain markdown or other formatting."
+          },
+          "contributors": {
+            "type": "array",
+            "items": {
+              "ref": "#contributor",
+              "type": "ref"
+            }
           }
         }
-      }
+      },
+      "description": "A document record representing a published article, blog post, or other content. Documents can belong to a publication or exist independently."
     },
-    "contentRef": {
+    "contributor": {
       "type": "object",
-      "required": ["uri"],
+      "required": ["did"],
       "properties": {
-        "uri": {
+        "did": {
           "type": "string",
-          "format": "at-uri",
-          "description": "AT-URI of the platform-specific content record"
+          "format": "did"
         },
-        "cid": {
+        "role": {
           "type": "string",
-          "format": "cid",
-          "description": "CID of the content record for verification"
+          "maxLength": 1000,
+          "maxGraphemes": 100
+        },
+        "displayName": {
+          "type": "string",
+          "maxLength": 1000,
+          "maxGraphemes": 100
         }
       }
     }
-  }
+  },
+  "lexicon": 1
 }

--- a/lexicons/site/standard/graph/recommend.json
+++ b/lexicons/site/standard/graph/recommend.json
@@ -1,0 +1,26 @@
+{
+  "id": "site.standard.graph.recommend",
+  "defs": {
+    "main": {
+      "key": "tid",
+      "type": "record",
+      "record": {
+        "type": "object",
+        "required": ["document", "createdAt"],
+        "properties": {
+          "document": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI reference to the document record being recommended (ex: at://did:plc:abc123/site.standard.document/xyz789)."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      },
+      "description": "Record declaring a recommendation of a document."
+    }
+  },
+  "lexicon": 1
+}

--- a/lexicons/site/standard/graph/subscription.json
+++ b/lexicons/site/standard/graph/subscription.json
@@ -1,0 +1,26 @@
+{
+  "id": "site.standard.graph.subscription",
+  "defs": {
+    "main": {
+      "key": "tid",
+      "type": "record",
+      "record": {
+        "type": "object",
+        "required": ["publication"],
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "publication": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI reference to the publication record being subscribed to (ex: at://did:plc:abc123/site.standard.publication/xyz789)."
+          }
+        }
+      },
+      "description": "Record declaring a subscription to a publication."
+    }
+  },
+  "lexicon": 1
+}

--- a/lexicons/site/standard/publication.json
+++ b/lexicons/site/standard/publication.json
@@ -1,54 +1,65 @@
 {
-  "lexicon": 1,
   "id": "site.standard.publication",
   "defs": {
     "main": {
+      "key": "tid",
       "type": "record",
-      "key": "self",
-      "description": "A publication identity record for a publishing platform or author.",
       "record": {
         "type": "object",
-        "required": ["name", "createdAt"],
+        "required": ["url", "name"],
         "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Base publication url (ex: https://standard.site). The canonical document URL is formed by combining this value with the document path."
+          },
+          "icon": {
+            "type": "blob",
+            "accept": ["image/*"],
+            "maxSize": 1000000,
+            "description": "Square image to identify the publication. Should be at least 256x256."
+          },
           "name": {
             "type": "string",
-            "maxLength": 100,
-            "description": "Name of the publication"
+            "maxLength": 5000,
+            "description": "Name of the publication.",
+            "maxGraphemes": 500
+          },
+          "labels": {
+            "refs": ["com.atproto.label.defs#selfLabels"],
+            "type": "union",
+            "description": "Self-label values for this publication. Effectively content warnings."
+          },
+          "basicTheme": {
+            "ref": "site.standard.theme.basic",
+            "type": "ref",
+            "description": "Simplified publication theme for tools and apps to utilize when displaying content."
           },
           "description": {
             "type": "string",
-            "maxLength": 1000,
-            "description": "Brief description of the publication"
+            "maxLength": 30000,
+            "description": "Brief description of the publication.",
+            "maxGraphemes": 3000
           },
-          "avatar": {
-            "type": "blob",
-            "accept": ["image/png", "image/jpeg", "image/webp"],
-            "maxSize": 1000000,
-            "description": "Square image identifying the publication (256x256 minimum)"
-          },
-          "theme": {
+          "preferences": {
+            "ref": "#preferences",
             "type": "ref",
-            "ref": "#theme"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "datetime"
+            "description": "Object containing platform specific preferences (with a few shared properties)."
           }
         }
-      }
+      },
+      "description": "A publication record representing a blog, website, or content platform. Publications serve as containers for documents and define the overall branding and settings."
     },
-    "theme": {
+    "preferences": {
       "type": "object",
       "properties": {
-        "primaryColor": {
-          "type": "string",
-          "description": "Primary brand color in hex format"
-        },
-        "accentColor": {
-          "type": "string",
-          "description": "Accent color in hex format"
+        "showInDiscover": {
+          "type": "boolean",
+          "default": true,
+          "description": "Boolean which decides whether the publication should appear in discovery feeds."
         }
       }
     }
-  }
+  },
+  "lexicon": 1
 }

--- a/lexicons/site/standard/theme/basic.json
+++ b/lexicons/site/standard/theme/basic.json
@@ -1,0 +1,37 @@
+{
+  "id": "site.standard.theme.basic",
+  "defs": {
+    "main": {
+      "key": "tid",
+      "type": "record",
+      "record": {
+        "type": "object",
+        "required": ["background", "foreground", "accent", "accentForeground"],
+        "properties": {
+          "accent": {
+            "refs": ["site.standard.theme.color#rgb"],
+            "type": "union",
+            "description": "Color used for links and button backgrounds."
+          },
+          "background": {
+            "refs": ["site.standard.theme.color#rgb"],
+            "type": "union",
+            "description": "Color used for content background."
+          },
+          "foreground": {
+            "refs": ["site.standard.theme.color#rgb"],
+            "type": "union",
+            "description": "Color used for content text."
+          },
+          "accentForeground": {
+            "refs": ["site.standard.theme.color#rgb"],
+            "type": "union",
+            "description": "Color used for button text."
+          }
+        }
+      },
+      "description": "A simplified theme definition for publications, providing basic color customization for content display across different platforms and applications."
+    }
+  },
+  "lexicon": 1
+}

--- a/lexicons/site/standard/theme/color.json
+++ b/lexicons/site/standard/theme/color.json
@@ -1,0 +1,53 @@
+{
+  "id": "site.standard.theme.color",
+  "defs": {
+    "rgb": {
+      "type": "object",
+      "required": ["r", "g", "b"],
+      "properties": {
+        "b": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        },
+        "g": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        },
+        "r": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        }
+      }
+    },
+    "rgba": {
+      "type": "object",
+      "required": ["r", "g", "b", "a"],
+      "properties": {
+        "a": {
+          "type": "integer",
+          "maximum": 100,
+          "minimum": 0
+        },
+        "b": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        },
+        "g": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        },
+        "r": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "lexicon": 1
+}

--- a/lexicons/vendor/community/README.md
+++ b/lexicons/vendor/community/README.md
@@ -1,0 +1,21 @@
+# Vendored lexicon.community schemas
+
+Copied from the community lexicon repository, which is the authority:
+
+<https://tangled.org/lexicon.community/lexicons> (`did:plc:g5niz7yav7io2erxaoyef5dn`)
+
+## What is here, and why
+
+- `calendar/event.json` — `community.lexicon.calendar.event`. A talk or
+  presentation about an eprint is an event, and the event record links out
+  through `uris[]`. That is how "presented at…" becomes something Chive can
+  show without anyone typing it in twice.
+
+Only the schemas a Chive reader actually parses are copied. Add one when a
+reader needs it.
+
+## Chive does not serve these
+
+Same rule as `lexicons/vendor/leaflet/`: read-only reference copies, kept out
+of the code generator by the `*/vendor/*` exclusion in
+`scripts/generate-lexicons.sh`. Chive publishes `pub.chive.*` and nothing else.

--- a/lexicons/vendor/community/calendar/event.json
+++ b/lexicons/vendor/community/calendar/event.json
@@ -1,0 +1,145 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.calendar.event",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A calendar event.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["createdAt", "name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the event."
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the event."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when the event was created."
+          },
+          "startsAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when the event starts."
+          },
+          "endsAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when the event ends."
+          },
+          "mode": {
+            "type": "ref",
+            "ref": "community.lexicon.calendar.event#mode",
+            "description": "The attendance mode of the event."
+          },
+          "status": {
+            "type": "ref",
+            "ref": "community.lexicon.calendar.event#status",
+            "description": "The status of the event."
+          },
+          "locations": {
+            "type": "array",
+            "description": "The locations where the event takes place.",
+            "items": {
+              "type": "union",
+              "refs": [
+                "community.lexicon.calendar.event#uri",
+                "community.lexicon.location.address",
+                "community.lexicon.location.fsq",
+                "community.lexicon.location.geo",
+                "community.lexicon.location.hthree"
+              ]
+            }
+          },
+          "uris": {
+            "type": "array",
+            "description": "URIs associated with the event.",
+            "items": {
+              "type": "ref",
+              "ref": "community.lexicon.calendar.event#uri"
+            }
+          },
+          "rsvpExpected": {
+            "type": "boolean",
+            "description": "Whether a response is requested from attendees."
+          }
+        }
+      }
+    },
+    "mode": {
+      "type": "string",
+      "description": "The mode of the event.",
+      "default": "community.lexicon.calendar.event#inperson",
+      "knownValues": [
+        "community.lexicon.calendar.event#hybrid",
+        "community.lexicon.calendar.event#inperson",
+        "community.lexicon.calendar.event#virtual"
+      ]
+    },
+    "virtual": {
+      "type": "token",
+      "description": "A virtual event that takes place online."
+    },
+    "inperson": {
+      "type": "token",
+      "description": "An in-person event that takes place offline."
+    },
+    "hybrid": {
+      "type": "token",
+      "description": "A hybrid event that takes place both online and offline."
+    },
+    "status": {
+      "type": "string",
+      "description": "The status of the event.",
+      "default": "community.lexicon.calendar.event#scheduled",
+      "knownValues": [
+        "community.lexicon.calendar.event#cancelled",
+        "community.lexicon.calendar.event#planned",
+        "community.lexicon.calendar.event#postponed",
+        "community.lexicon.calendar.event#rescheduled",
+        "community.lexicon.calendar.event#scheduled"
+      ]
+    },
+    "planned": {
+      "type": "token",
+      "description": "The event has been created, but not finalized."
+    },
+    "scheduled": {
+      "type": "token",
+      "description": "The event has been created and scheduled."
+    },
+    "rescheduled": {
+      "type": "token",
+      "description": "The event has been rescheduled."
+    },
+    "cancelled": {
+      "type": "token",
+      "description": "The event has been cancelled."
+    },
+    "postponed": {
+      "type": "token",
+      "description": "The event has been postponed and a new start date has not been set."
+    },
+    "uri": {
+      "type": "object",
+      "description": "A URI associated with the event.",
+      "required": ["uri"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "type": "string",
+          "description": "The display name of the URI."
+        }
+      }
+    }
+  }
+}

--- a/lexicons/vendor/leaflet/README.md
+++ b/lexicons/vendor/leaflet/README.md
@@ -1,0 +1,51 @@
+# Vendored Leaflet lexicons
+
+Leaflet's published schemas, copied here so `leaflet-backlinks.ts` is written
+against what Leaflet actually publishes rather than against a guess.
+
+Fetched from Leaflet's own lexicon repository, which is the authority:
+
+```
+did:plc:btxrwcaeyodrap5mnjw2fvmz
+com.atproto.lexicon.schema
+```
+
+They are also browsable at
+<https://lexicon.garden/lexicon/did:plc:btxrwcaeyodrap5mnjw2fvmz>.
+
+The `$type: com.atproto.lexicon.schema` wrapper is stripped; the rest is
+verbatim, including `revision`.
+
+## Why these seven
+
+Only the ones on the path from a Leaflet record to a Chive eprint:
+
+- `comment` — `subject` is an at-uri, the most direct reference there is.
+- `document` — `pages` is a union of page types.
+- `pages/linearDocument` — `blocks[].block` is a union of block types.
+- `blocks/website` — `src` is a URL, where a link to chive.pub appears.
+- `blocks/text` — carries richtext `facets`.
+- `richtext/facet` — `#link.uri` is where an inline link lives.
+- `blocks/standardSitePost` — `uri` is an at-uri to a `site.standard`
+  document. Chive emits those for eprints, so a Leaflet document embedding one
+  is referring to an eprint at one remove.
+
+Not vendored: the remaining thirty-odd block, page and graph lexicons, which
+carry no path to an eprint. Add one here when a reader needs it.
+
+## Why `lexicons/vendor/`, and not `lexicons/pub/leaflet/`
+
+Chive publishes `pub.chive.*` and nothing else. These are read-only reference
+copies, used by a plugin that parses records out of other people's
+repositories.
+
+They sit under `vendor/` because `scripts/generate-lexicons.sh` runs codegen
+over everything in `lexicons/`, and generating a client for another app's
+schemas is both pointless and broken here: only the seven on the eprint path
+are copied, and the generated types would import the thirty-odd that are not.
+The script excludes `*/vendor/*` for that reason, alongside the exclusions it
+already had for `auth/` and `permission-sets/`.
+
+`lexicons/site/standard/` is vendored _inside_ the codegen path by contrast,
+because Chive writes those records and wants the generated types. The rule is
+whether Chive emits the schema, not who owns it.

--- a/lexicons/vendor/leaflet/blocks/standardSitePost.json
+++ b/lexicons/vendor/leaflet/blocks/standardSitePost.json
@@ -1,0 +1,26 @@
+{
+  "id": "pub.leaflet.blocks.standardSitePost",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["uri"],
+      "properties": {
+        "cid": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "size": {
+          "type": "string",
+          "knownValues": ["large", "medium", "small"]
+        },
+        "showPublicationTheme": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "lexicon": 1
+}

--- a/lexicons/vendor/leaflet/blocks/text.json
+++ b/lexicons/vendor/leaflet/blocks/text.json
@@ -1,0 +1,26 @@
+{
+  "id": "pub.leaflet.blocks.text",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["plaintext"],
+      "properties": {
+        "facets": {
+          "type": "array",
+          "items": {
+            "ref": "pub.leaflet.richtext.facet",
+            "type": "ref"
+          }
+        },
+        "textSize": {
+          "enum": ["default", "small", "large"],
+          "type": "string"
+        },
+        "plaintext": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "lexicon": 1
+}

--- a/lexicons/vendor/leaflet/blocks/website.json
+++ b/lexicons/vendor/leaflet/blocks/website.json
@@ -1,0 +1,27 @@
+{
+  "id": "pub.leaflet.blocks.website",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["src"],
+      "properties": {
+        "src": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "previewImage": {
+          "type": "blob",
+          "accept": ["image/*"],
+          "maxSize": 1000000
+        }
+      }
+    }
+  },
+  "lexicon": 1
+}

--- a/lexicons/vendor/leaflet/comment.json
+++ b/lexicons/vendor/leaflet/comment.json
@@ -1,0 +1,72 @@
+{
+  "id": "pub.leaflet.comment",
+  "defs": {
+    "main": {
+      "key": "tid",
+      "type": "record",
+      "record": {
+        "type": "object",
+        "required": ["subject", "plaintext", "createdAt"],
+        "properties": {
+          "reply": {
+            "ref": "#replyRef",
+            "type": "ref"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "ref": "pub.leaflet.richtext.facet",
+              "type": "ref"
+            }
+          },
+          "onPage": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string",
+            "format": "at-uri"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "plaintext": {
+            "type": "string"
+          },
+          "attachment": {
+            "refs": ["#linearDocumentQuote"],
+            "type": "union"
+          }
+        }
+      },
+      "description": "Record containing a comment"
+    },
+    "replyRef": {
+      "type": "object",
+      "required": ["parent"],
+      "properties": {
+        "parent": {
+          "type": "string",
+          "format": "at-uri"
+        }
+      }
+    },
+    "linearDocumentQuote": {
+      "type": "object",
+      "required": ["document", "quote"],
+      "properties": {
+        "quote": {
+          "ref": "pub.leaflet.pages.linearDocument#quote",
+          "type": "ref"
+        },
+        "document": {
+          "type": "string",
+          "format": "at-uri"
+        }
+      }
+    }
+  },
+  "lexicon": 1,
+  "revision": 1,
+  "description": "A lexicon for comments on documents"
+}

--- a/lexicons/vendor/leaflet/document.json
+++ b/lexicons/vendor/leaflet/document.json
@@ -1,0 +1,72 @@
+{
+  "id": "pub.leaflet.document",
+  "defs": {
+    "main": {
+      "key": "tid",
+      "type": "record",
+      "record": {
+        "type": "object",
+        "required": ["pages", "author", "title"],
+        "properties": {
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 50
+            }
+          },
+          "pages": {
+            "type": "array",
+            "items": {
+              "refs": ["pub.leaflet.pages.linearDocument", "pub.leaflet.pages.canvas"],
+              "type": "union"
+            }
+          },
+          "theme": {
+            "ref": "pub.leaflet.publication#theme",
+            "type": "ref"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 5000,
+            "maxGraphemes": 500
+          },
+          "author": {
+            "type": "string",
+            "format": "at-identifier"
+          },
+          "postRef": {
+            "ref": "com.atproto.repo.strongRef",
+            "type": "ref"
+          },
+          "coverImage": {
+            "type": "blob",
+            "accept": ["image/png", "image/jpeg", "image/webp"],
+            "maxSize": 1000000
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 30000,
+            "maxGraphemes": 3000
+          },
+          "preferences": {
+            "ref": "pub.leaflet.publication#preferences",
+            "type": "ref"
+          },
+          "publication": {
+            "type": "string",
+            "format": "at-uri"
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      },
+      "description": "Record containing a document"
+    }
+  },
+  "lexicon": 1,
+  "revision": 1,
+  "description": "A lexicon for long form rich media documents"
+}

--- a/lexicons/vendor/leaflet/pages/linearDocument.json
+++ b/lexicons/vendor/leaflet/pages/linearDocument.json
@@ -1,0 +1,105 @@
+{
+  "id": "pub.leaflet.pages.linearDocument",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["blocks"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "blocks": {
+          "type": "array",
+          "items": {
+            "ref": "#block",
+            "type": "ref"
+          }
+        }
+      }
+    },
+    "block": {
+      "type": "object",
+      "required": ["block"],
+      "properties": {
+        "block": {
+          "refs": [
+            "pub.leaflet.blocks.iframe",
+            "pub.leaflet.blocks.html",
+            "pub.leaflet.blocks.text",
+            "pub.leaflet.blocks.blockquote",
+            "pub.leaflet.blocks.header",
+            "pub.leaflet.blocks.image",
+            "pub.leaflet.blocks.imageGallery",
+            "pub.leaflet.blocks.unorderedList",
+            "pub.leaflet.blocks.orderedList",
+            "pub.leaflet.blocks.website",
+            "pub.leaflet.blocks.math",
+            "pub.leaflet.blocks.code",
+            "pub.leaflet.blocks.horizontalRule",
+            "pub.leaflet.blocks.bskyPost",
+            "pub.leaflet.blocks.standardSitePost",
+            "pub.leaflet.blocks.standardSitePublication",
+            "pub.leaflet.blocks.page",
+            "pub.leaflet.blocks.poll",
+            "pub.leaflet.blocks.button",
+            "pub.leaflet.blocks.postsList",
+            "pub.leaflet.blocks.signup",
+            "pub.leaflet.blocks.membersOnlyDelimiter"
+          ],
+          "type": "union"
+        },
+        "alignment": {
+          "type": "string",
+          "knownValues": [
+            "#textAlignLeft",
+            "#textAlignCenter",
+            "#textAlignRight",
+            "#textAlignJustify"
+          ]
+        }
+      }
+    },
+    "quote": {
+      "type": "object",
+      "required": ["start", "end"],
+      "properties": {
+        "end": {
+          "ref": "#position",
+          "type": "ref"
+        },
+        "start": {
+          "ref": "#position",
+          "type": "ref"
+        }
+      }
+    },
+    "position": {
+      "type": "object",
+      "required": ["block", "offset"],
+      "properties": {
+        "block": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "offset": {
+          "type": "integer"
+        }
+      }
+    },
+    "textAlignLeft": {
+      "type": "token"
+    },
+    "textAlignRight": {
+      "type": "token"
+    },
+    "textAlignCenter": {
+      "type": "token"
+    },
+    "textAlignJustify": {
+      "type": "token"
+    }
+  },
+  "lexicon": 1
+}

--- a/lexicons/vendor/leaflet/richtext/facet.json
+++ b/lexicons/vendor/leaflet/richtext/facet.json
@@ -1,0 +1,158 @@
+{
+  "id": "pub.leaflet.richtext.facet",
+  "defs": {
+    "id": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "description": "Facet feature for an identifier. Used for linking to a segment"
+    },
+    "bold": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "description": "Facet feature for bold text"
+    },
+    "code": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "description": "Facet feature for inline code."
+    },
+    "link": {
+      "type": "object",
+      "required": ["uri"],
+      "properties": {
+        "uri": {
+          "type": "string"
+        }
+      },
+      "description": "Facet feature for a URL. The text URL may have been simplified or truncated, but the facet reference should be a complete URL."
+    },
+    "main": {
+      "type": "object",
+      "required": ["index", "features"],
+      "properties": {
+        "index": {
+          "ref": "#byteSlice",
+          "type": "ref"
+        },
+        "features": {
+          "type": "array",
+          "items": {
+            "refs": [
+              "#link",
+              "#didMention",
+              "#atMention",
+              "#code",
+              "#highlight",
+              "#underline",
+              "#strikethrough",
+              "#id",
+              "#bold",
+              "#italic",
+              "#footnote"
+            ],
+            "type": "union"
+          }
+        }
+      },
+      "description": "Annotation of a sub-string within rich text."
+    },
+    "italic": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "description": "Facet feature for italic text"
+    },
+    "footnote": {
+      "type": "object",
+      "required": ["footnoteId", "contentPlaintext"],
+      "properties": {
+        "footnoteId": {
+          "type": "string"
+        },
+        "contentFacets": {
+          "type": "array",
+          "items": {
+            "ref": "#main",
+            "type": "ref"
+          }
+        },
+        "contentPlaintext": {
+          "type": "string"
+        }
+      },
+      "description": "Facet feature for a footnote reference"
+    },
+    "atMention": {
+      "type": "object",
+      "required": ["atURI"],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri"
+        },
+        "atURI": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "description": "Facet feature for mentioning an AT URI."
+    },
+    "byteSlice": {
+      "type": "object",
+      "required": ["byteStart", "byteEnd"],
+      "properties": {
+        "byteEnd": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "byteStart": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "description": "Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets."
+    },
+    "highlight": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "color": {
+          "refs": ["pub.leaflet.theme.color#rgba", "pub.leaflet.theme.color#rgb"],
+          "type": "union"
+        }
+      },
+      "description": "Facet feature for highlighted text."
+    },
+    "underline": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "description": "Facet feature for underline markup"
+    },
+    "didMention": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        }
+      },
+      "description": "Facet feature for mentioning a did."
+    },
+    "strikethrough": {
+      "type": "object",
+      "required": [],
+      "properties": {},
+      "description": "Facet feature for strikethrough markup"
+    }
+  },
+  "lexicon": 1
+}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "docs:openapi": "tsx scripts/generate-openapi-spec.ts",
     "lexicons:generate": "./scripts/generate-lexicons.sh",
     "test:stack:start": "./scripts/start-test-stack.sh",
-    "test:stack:stop": "docker-compose -f docker/docker-compose.yml down",
+    "test:stack:stop": "docker compose -f docker/docker-compose.yml down",
     "seed:test": "./scripts/seed-test-data.sh",
     "cleanup:test": "./scripts/cleanup-test.sh",
     "db:init": "./scripts/db/init-all.sh",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "db:migrate:up": "tsx scripts/db/migrate.ts up",
     "db:migrate:down": "tsx scripts/db/migrate.ts down",
     "db:migrate:create": "tsx scripts/db/migrate.ts create",
-    "db:seed:knowledge-graph": "tsx scripts/db/seed-knowledge-graph.ts"
+    "db:seed:knowledge-graph": "tsx scripts/db/seed-knowledge-graph.ts",
+    "mcp": "tsx src/mcp/index.ts"
   },
   "devDependencies": {
     "@atproto/lex-cli": "^0.9.8",
@@ -122,6 +123,7 @@
     "@ipld/car": "^5.4.2",
     "@ipld/dag-cbor": "^9.2.5",
     "@jamesgopsill/crossref-client": "^1.1.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.67.2",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.208.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@jamesgopsill/crossref-client':
         specifier: ^1.1.0
         version: 1.1.0
+      '@modelcontextprotocol/sdk':
+        specifier: 1.30.0
+        version: 1.30.0(zod@4.1.13)
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
@@ -600,7 +603,7 @@ importers:
         version: 8.1.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       recharts:
         specifier: ^3.7.0
-        version: 3.7.0(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-is@18.3.1)(react@19.2.1)(redux@4.2.1)
+        version: 3.7.0(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-is@18.3.1)(react@19.2.1)
       rehype-highlight:
         specifier: ^7.0.2
         version: 7.0.2
@@ -2771,6 +2774,12 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hono/node-server@1.19.7':
     resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
     engines: {node: '>=18.14.1'}
@@ -3227,6 +3236,16 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -6159,6 +6178,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -6427,6 +6447,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -6452,6 +6473,10 @@ packages:
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
   acorn-import-attributes@1.9.5:
@@ -6835,6 +6860,10 @@ packages:
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
 
   bonjour-service@1.3.0:
     resolution: {integrity: sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==}
@@ -7318,9 +7347,17 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -7330,6 +7367,10 @@ packages:
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -7360,6 +7401,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -7407,6 +7452,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -7418,6 +7464,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@4.0.0:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
@@ -8309,6 +8356,7 @@ packages:
   eslint@9.39.1:
     resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -8402,6 +8450,10 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -8420,9 +8472,19 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -8545,6 +8607,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-cache-dir@3.3.2:
     resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
     engines: {node: '>=8'}
@@ -8647,6 +8713,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -9001,6 +9071,10 @@ packages:
     resolution: {integrity: sha512-icXIITfw/07Q88nLSkB9aiUrd8rYzSweK681Kjo/TSggaGbOX4RRyxxm71v+3PC8C/j+4rlxGeoTRxQDkaJkUw==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
+    engines: {node: '>=16.9.0'}
+
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
 
@@ -9141,6 +9215,10 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   icss-utils@5.1.0:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
@@ -9247,6 +9325,10 @@ packages:
   ioredis@5.8.2:
     resolution: {integrity: sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==}
     engines: {node: '>=12.22.0'}
+
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -9429,6 +9511,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -9655,6 +9740,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -10044,6 +10132,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -10056,6 +10148,10 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-refs@2.0.0:
     resolution: {integrity: sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==}
@@ -10466,6 +10562,10 @@ packages:
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
+
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -10932,6 +11032,9 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -11060,6 +11163,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -11583,6 +11690,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -11630,6 +11738,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -11742,6 +11851,10 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
+    engines: {node: '>=0.6'}
+
   querystring-es3@0.2.1:
     resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
     engines: {node: '>=0.4.x'}
@@ -11779,6 +11892,10 @@ packages:
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -12315,6 +12432,10 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
@@ -12489,6 +12610,10 @@ packages:
     resolution: {integrity: sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
@@ -12502,6 +12627,10 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -12583,6 +12712,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -12593,6 +12726,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -13311,6 +13448,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -13601,10 +13742,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -14163,6 +14306,11 @@ packages:
 
   zlibjs@0.3.1:
     resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -17416,6 +17564,10 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
+  '@hono/node-server@1.19.17(hono@4.13.5)':
+    dependencies:
+      hono: 4.13.5
+
   '@hono/node-server@1.19.7(hono@4.10.7)':
     dependencies:
       hono: 4.10.7
@@ -17855,6 +18007,28 @@ snapshots:
       langium: 3.3.1
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.1.13)':
+    dependencies:
+      '@hono/node-server': 1.19.17(hono@4.13.5)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.5
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.2(zod@4.1.13)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -19641,7 +19815,7 @@ snapshots:
       react: 18.3.1
       react-redux: 7.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@reduxjs/toolkit@1.9.7(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@4.2.1))(react@19.2.1)':
+  '@reduxjs/toolkit@1.9.7(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)':
     dependencies:
       immer: 9.0.21
       redux: 4.2.1
@@ -19649,7 +19823,7 @@ snapshots:
       reselect: 4.1.8
     optionalDependencies:
       react: 19.2.1
-      react-redux: 9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@4.2.1)
+      react-redux: 9.2.0(@types/react@19.2.7)(react@19.2.1)
 
   '@remirror/core-constants@3.0.0': {}
 
@@ -21812,6 +21986,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+
   acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -22238,6 +22417,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.16.0
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -22794,13 +22987,19 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
 
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.7: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
 
@@ -22827,6 +23026,11 @@ snapshots:
   core-js@3.47.0: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -23888,8 +24092,8 @@ snapshots:
       '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@1.21.7))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.1(jiti@1.21.7))
@@ -23919,7 +24123,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -23930,7 +24134,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -23949,14 +24153,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -23971,7 +24175,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -23982,7 +24186,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7)))(eslint@9.39.1(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24250,6 +24454,10 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -24272,6 +24480,14 @@ snapshots:
   expand-template@2.0.3: {}
 
   expect-type@1.2.2: {}
+
+  express-rate-limit@8.7.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.7.0
+    transitivePeerDependencies:
+      - supports-color
 
   express@4.22.1:
     dependencies:
@@ -24305,6 +24521,39 @@ snapshots:
       statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -24432,6 +24681,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-cache-dir@3.3.2:
     dependencies:
       commondir: 1.0.1
@@ -24530,6 +24790,8 @@ snapshots:
   fraction.js@5.3.4: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -25065,6 +25327,8 @@ snapshots:
 
   hono@4.10.7: {}
 
+  hono@4.13.5: {}
+
   hpack.js@2.1.6:
     dependencies:
       inherits: 2.0.4
@@ -25246,6 +25510,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   icss-utils@5.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -25336,6 +25604,8 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  ip-address@10.7.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -25492,6 +25762,8 @@ snapshots:
       isobject: 3.0.1
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -25730,6 +26002,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -26316,6 +26590,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.1: {}
+
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
@@ -26334,6 +26610,8 @@ snapshots:
       map-or-similar: 1.5.0
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-refs@2.0.0(@types/react@19.2.7):
     optionalDependencies:
@@ -27049,6 +27327,10 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
+
   neo-async@2.6.2: {}
 
   neo4j-driver-bolt-connection@6.0.1:
@@ -27590,6 +27872,8 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  path-to-regexp@8.4.2: {}
+
   path-type@4.0.0: {}
 
   path@0.12.7:
@@ -27737,6 +28021,8 @@ snapshots:
       thread-stream: 2.7.0
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -28543,6 +28829,11 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.16.0:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   querystring-es3@0.2.1: {}
 
   queue-microtask@1.2.3: {}
@@ -28575,6 +28866,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
       unpipe: 1.0.0
 
   rc@1.2.8:
@@ -28765,14 +29063,13 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
-  react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@4.2.1):
+  react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1):
     dependencies:
       '@types/use-sync-external-store': 0.0.6
       react: 19.2.1
       use-sync-external-store: 1.6.0(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.2.7
-      redux: 4.2.1
 
   react-refresh@0.14.2: {}
 
@@ -28923,9 +29220,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  recharts@3.7.0(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-is@18.3.1)(react@19.2.1)(redux@4.2.1):
+  recharts@3.7.0(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-is@18.3.1)(react@19.2.1):
     dependencies:
-      '@reduxjs/toolkit': 1.9.7(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@4.2.1))(react@19.2.1)
+      '@reduxjs/toolkit': 1.9.7(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
       es-toolkit: 1.45.0
@@ -28934,7 +29231,7 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       react-is: 18.3.1
-      react-redux: 9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@4.2.1)
+      react-redux: 9.2.0(@types/react@19.2.7)(react@19.2.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
       use-sync-external-store: 1.6.0(react@19.2.1)
@@ -29396,6 +29693,16 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
@@ -29577,6 +29884,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
@@ -29609,6 +29932,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -29756,6 +30088,11 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
   side-channel-map@1.0.1:
     dependencies:
       call-bound: 1.0.4
@@ -29776,6 +30113,14 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
       side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -30534,6 +30879,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -31581,6 +31932,10 @@ snapshots:
   yoga-layout@3.2.1: {}
 
   zlibjs@0.3.1: {}
+
+  zod-to-json-schema@3.25.2(zod@4.1.13):
+    dependencies:
+      zod: 4.1.13
 
   zod@3.25.76: {}
 

--- a/scripts/cleanup-test.sh
+++ b/scripts/cleanup-test.sh
@@ -4,7 +4,7 @@ set -e
 echo "Cleaning up test data..."
 
 # Stop and remove test stack
-docker-compose -f docker/docker-compose.yml down -v
+docker compose -f docker/docker-compose.yml down -v
 
 # Remove test databases
 rm -rf tmp/test-data

--- a/scripts/generate-lexicons.sh
+++ b/scripts/generate-lexicons.sh
@@ -24,6 +24,10 @@ if [ ! -d "$ATPROTO_LEXICONS_DIR" ]; then
   # Copy only the com/atproto/repo lexicons (needed for record CRUD operations)
   mkdir -p "$LEXICONS_DIR/com/atproto/repo"
   cp "$TEMP_DIR/atproto-main/lexicons/com/atproto/repo/"*.json "$LEXICONS_DIR/com/atproto/repo/"
+  # `com.atproto.label.defs` too: site.standard.document and .publication both
+  # reference `#selfLabels`, so codegen fails without it.
+  mkdir -p "$LEXICONS_DIR/com/atproto/label"
+  cp "$TEMP_DIR/atproto-main/lexicons/com/atproto/label/defs.json" "$LEXICONS_DIR/com/atproto/label/"
 
   rm -rf "$TEMP_DIR"
   echo "✅ Downloaded ATProto base lexicons"
@@ -37,7 +41,7 @@ echo "Generating server types..."
 rm -rf "$SERVER_OUTPUT_DIR"
 mkdir -p "$SERVER_OUTPUT_DIR"
 
-pnpm exec lex gen-server --yes "$SERVER_OUTPUT_DIR" $(find "$LEXICONS_DIR" -name "*.json" -not -path "*/auth/*" -not -path "*/permission-sets/*" | xargs)
+pnpm exec lex gen-server --yes "$SERVER_OUTPUT_DIR" $(find "$LEXICONS_DIR" -name "*.json" -not -path "*/auth/*" -not -path "*/permission-sets/*" -not -path "*/vendor/*" | xargs)
 
 # Post-process server files for NodeNext module resolution
 echo "Fixing server import paths for NodeNext module resolution..."
@@ -70,7 +74,7 @@ echo "Generating web client types..."
 rm -rf "$WEB_OUTPUT_DIR"
 mkdir -p "$WEB_OUTPUT_DIR"
 
-pnpm exec lex gen-api --yes "$WEB_OUTPUT_DIR" $(find "$LEXICONS_DIR" -name "*.json" -not -path "*/auth/*" -not -path "*/permission-sets/*" | xargs)
+pnpm exec lex gen-api --yes "$WEB_OUTPUT_DIR" $(find "$LEXICONS_DIR" -name "*.json" -not -path "*/auth/*" -not -path "*/permission-sets/*" -not -path "*/vendor/*" | xargs)
 
 # Remove .js extensions from web client imports.
 # Next.js/webpack resolves .ts imports without extensions, but the

--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -183,11 +183,14 @@ const TEST_BACKLINKS = [
     indexedAt: '2024-03-10T09:15:00.000Z',
   },
   {
-    sourceUri: 'at://did:plc:leaflet001/xyz.leaflet.list/list001',
-    sourceType: 'leaflet.list',
+    // `xyz.leaflet.list` does not exist; Leaflet publishes documents and
+    // comments. Seeding the fictional NSID kept the invented shape alive in
+    // the one place that could still fail a build over it.
+    sourceUri: 'at://did:plc:leaflet001/pub.leaflet.document/doc001',
+    sourceType: 'leaflet.document',
     sourceDid: 'did:plc:leaflet001',
     targetUri: 'at://did:plc:scharlow789ghi/pub.chive.eprint.submission/4lu9n1bcdef03',
-    context: 'Scope and Continuations Papers',
+    context: 'Scope and continuations: a reading',
     indexedAt: '2024-04-05T16:45:00.000Z',
   },
 ];

--- a/src/api/handlers/rest/well-known.ts
+++ b/src/api/handlers/rest/well-known.ts
@@ -38,11 +38,25 @@ import type { ChiveEnv } from '../../types/context.js';
  * @public
  */
 export function standardPublicationHandler(c: Context<ChiveEnv>): Response {
-  // Get service DID from environment
-  const serviceDid = process.env.CHIVE_SERVICE_DID ?? 'did:web:chive.pub';
+  // This used to answer `at://<serviceDid>/site.standard.publication/self`
+  // unconditionally. Two things were wrong with that, and they compound:
+  //
+  //   - No such record exists. The collection is absent from the service
+  //     repository entirely, so a reader following the URI gets nothing.
+  //   - `self` is not a legal record key here. `site.standard.publication`
+  //     declares `key: tid`, so the rkey is a timestamp identifier and cannot
+  //     be a fixed literal.
+  //
+  // Advertising a URI that cannot resolve is worse than advertising none: it
+  // reads as a broken publication rather than an unconfigured one. So the URI
+  // is now configuration, and absent configuration this answers 404.
+  const publicationUri = process.env.CHIVE_PUBLICATION_URI;
 
-  // Return the AT-URI pointing to Chive's publication record
-  const publicationUri = `at://${serviceDid}/site.standard.publication/self`;
+  if (!publicationUri) {
+    return c.text('No publication record is configured for this deployment.', 404, {
+      'Content-Type': 'text/plain; charset=utf-8',
+    });
+  }
 
   return c.text(publicationUri, 200, {
     'Content-Type': 'text/plain; charset=utf-8',

--- a/src/api/handlers/xrpc/admin/triggerBackfill.ts
+++ b/src/api/handlers/xrpc/admin/triggerBackfill.ts
@@ -34,6 +34,10 @@ const VALID_TYPES = [
 export const triggerBackfill: XRPCMethod<void, TriggerBackfillInput, unknown> = {
   type: 'procedure',
   auth: true,
+  // The handler contract returns a Promise and every path here throws. Making
+  // it synchronous would turn a rejected promise into a synchronous throw,
+  // which the XRPC adapter and its callers do not expect.
+  // eslint-disable-next-line @typescript-eslint/require-await
   handler: async ({ input, c }): Promise<XRPCResponse<unknown>> => {
     const user = c.get('user');
     if (!user?.isAdmin) {
@@ -53,19 +57,36 @@ export const triggerBackfill: XRPCMethod<void, TriggerBackfillInput, unknown> = 
       throw new ServiceUnavailableError('Backfill manager is not configured');
     }
 
-    const { type, ...metadata } = input;
-    const { operation } = await backfillManager.startOperation(
-      type as (typeof VALID_TYPES)[number],
-      { ...metadata, startedBy: user.did }
-    );
+    // This used to call `startOperation` and return, running nothing. Each of
+    // the six types has a dedicated endpoint that does the work — this one
+    // recorded an operation that stayed pending forever, so an admin saw a
+    // backfill start and never finish.
+    //
+    // Rather than duplicate five handlers' worth of service wiring here, it
+    // says where the work lives. Nothing calls this endpoint today; if
+    // something does, it now gets an actionable answer instead of a ghost
+    // operation.
+    const { type } = input;
+    const dedicated: Record<(typeof VALID_TYPES)[number], string> = {
+      pdsScan: 'pub.chive.admin.triggerPDSScan',
+      freshnessScan: 'pub.chive.admin.triggerFreshnessScan',
+      citationExtraction: 'pub.chive.admin.triggerCitationExtraction',
+      fullReindex: 'pub.chive.admin.triggerFullReindex',
+      governanceSync: 'pub.chive.admin.triggerGovernanceSync',
+      didSync: 'pub.chive.admin.triggerDIDSync',
+    };
 
-    const logger = c.get('logger');
-    logger.info('Backfill triggered via admin dashboard', {
+    const endpoint = dedicated[type as (typeof VALID_TYPES)[number]];
+
+    c.get('logger').info('Generic backfill trigger redirected to its dedicated endpoint', {
       type,
-      operationId: operation.id,
+      endpoint,
       startedBy: user.did,
     });
 
-    return { encoding: 'application/json', body: { operation } };
+    throw new ValidationError(
+      `Use ${endpoint} to run a ${type} backfill. This endpoint records an operation without running one.`,
+      'type'
+    );
   },
 };

--- a/src/api/handlers/xrpc/admin/triggerDIDSync.ts
+++ b/src/api/handlers/xrpc/admin/triggerDIDSync.ts
@@ -46,7 +46,12 @@ export const triggerDIDSync: XRPCMethod<void, TriggerDIDSyncInput, unknown> = {
       throw new ServiceUnavailableError('PDS scanner is not configured');
     }
 
-    const { operation } = await backfillManager.startOperation('didSync', { did: input.did });
+    // `signal` was dropped here; see triggerGovernanceSync for the same fix.
+    // A DID scan walks every collection in a repository, so cancelling it is
+    // something an admin genuinely wants to be able to do.
+    const { operation, signal } = await backfillManager.startOperation('didSync', {
+      did: input.did,
+    });
 
     logger.info('DID sync triggered', { operationId: operation.id, did: input.did });
 
@@ -79,6 +84,14 @@ export const triggerDIDSync: XRPCMethod<void, TriggerDIDSyncInput, unknown> = {
         }
 
         const recordsIndexed = await pdsScanner.scanDID(pdsUrl, input.did as DID);
+
+        if (signal.aborted) {
+          logger.info('DID sync was cancelled; not marking it complete', {
+            operationId: operation.id,
+            did: input.did,
+          });
+          return;
+        }
 
         await backfillManager.completeOperation(operation.id, recordsIndexed);
       } catch (error) {

--- a/src/api/handlers/xrpc/admin/triggerGovernanceSync.ts
+++ b/src/api/handlers/xrpc/admin/triggerGovernanceSync.ts
@@ -34,7 +34,12 @@ export const triggerGovernanceSync: XRPCMethod<void, void, unknown> = {
       throw new ServiceUnavailableError('Backfill manager is not configured');
     }
 
-    const { operation } = await backfillManager.startOperation('governanceSync');
+    // `signal` was dropped here. `startOperation` hands back an AbortSignal so
+    // a long-running background job can be cancelled — an admin who cancels an
+    // operation expects it to stop, and without reading the signal the work
+    // continued to completion and then reported success against a cancelled
+    // operation.
+    const { operation, signal } = await backfillManager.startOperation('governanceSync');
 
     logger.info('Governance sync triggered', { operationId: operation.id });
 
@@ -51,6 +56,13 @@ export const triggerGovernanceSync: XRPCMethod<void, void, unknown> = {
 
         // Run a single sync cycle (do not start the periodic timer)
         await syncJob.run();
+
+        if (signal.aborted) {
+          logger.info('Governance sync was cancelled; not marking it complete', {
+            operationId: operation.id,
+          });
+          return;
+        }
 
         await backfillManager.completeOperation(operation.id);
       } catch (error) {

--- a/src/api/handlers/xrpc/backlink/create.ts
+++ b/src/api/handlers/xrpc/backlink/create.ts
@@ -13,6 +13,7 @@ import type {
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/backlink/create.js';
 import { AuthenticationError, ValidationError } from '../../../../types/errors.js';
+import type { BacklinkSourceType } from '../../../../types/interfaces/plugin.interface.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 /**
@@ -41,14 +42,11 @@ export const create: XRPCMethod<void, InputSchema, OutputSchema> = {
       targetUri: input.targetUri,
     });
 
-    // Cast lexicon type to service type (lexicon uses (string & {}) for extensibility)
-    type ServiceSourceType =
-      | 'cosmik.collection'
-      | 'leaflet.list'
-      | 'whitewind.blog'
-      | 'bluesky.post'
-      | 'bluesky.embed'
-      | 'other';
+    // The lexicon types this as `(string & {})` for extensibility, so it is
+    // narrowed to the canonical union here. This used to redeclare its own
+    // copy of the list, which had drifted: it was missing the two cosmik
+    // types and all three margin ones, and still named `leaflet.list`.
+    type ServiceSourceType = BacklinkSourceType;
 
     const result = await backlink.createBacklink({
       sourceUri: input.sourceUri,

--- a/src/api/handlers/xrpc/backlink/list.ts
+++ b/src/api/handlers/xrpc/backlink/list.ts
@@ -18,6 +18,7 @@ import type {
   QueryParams,
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/backlink/list.js';
+import type { BacklinkSourceType } from '../../../../types/interfaces/plugin.interface.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 /**
@@ -39,14 +40,11 @@ export const list: XRPCMethod<QueryParams, void, OutputSchema> = {
       cursor: params.cursor,
     });
 
-    // Cast lexicon type to service type (lexicon uses (string & {}) for extensibility)
-    type ServiceSourceType =
-      | 'cosmik.collection'
-      | 'leaflet.list'
-      | 'whitewind.blog'
-      | 'bluesky.post'
-      | 'bluesky.embed'
-      | 'other';
+    // The lexicon types this as `(string & {})` for extensibility, so it is
+    // narrowed to the canonical union here. This used to redeclare its own
+    // copy of the list, which had drifted: it was missing the two cosmik
+    // types and all three margin ones, and still named `leaflet.list`.
+    type ServiceSourceType = BacklinkSourceType;
 
     const result = await backlink.getBacklinks(params.targetUri, {
       sourceType: params.sourceType as ServiceSourceType | undefined,

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -31,11 +31,13 @@ import { FieldLabelResolutionJob } from './jobs/field-label-resolution-job.js';
 import { FieldPromotionJob } from './jobs/field-promotion-job.js';
 import { PinoLogger } from './observability/logger.js';
 import { initTelemetry } from './observability/telemetry.js';
+import { CalendarEventsPlugin } from './plugins/builtin/calendar-events.js';
 import { CosmikBacklinksPlugin } from './plugins/builtin/cosmik-backlinks.js';
 import { CosmikConnectionsPlugin } from './plugins/builtin/cosmik-connections.js';
 import { CosmikFollowsPlugin } from './plugins/builtin/cosmik-follows.js';
 import { CosmikLinkRemovalsPlugin } from './plugins/builtin/cosmik-link-removals.js';
 import { MarginNotesPlugin, MarginRepliesPlugin } from './plugins/builtin/margin-annotations.js';
+import { StandardSiteBacklinksPlugin } from './plugins/builtin/standard-site-backlinks.js';
 import { registerPluginDependencies } from './plugins/core/plugin-di-helpers.js';
 import {
   getEventBus,
@@ -62,6 +64,10 @@ import {
   type FirehoseHealthServer,
   startFirehoseHealthServer,
 } from './services/indexing/firehose-health-server.js';
+import {
+  OBSERVED_COLLECTIONS,
+  OBSERVED_COLLECTIONS_HIGH_VOLUME,
+} from './services/indexing/indexed-collections.js';
 import { IndexingService } from './services/indexing/indexing-service.js';
 import { KnowledgeGraphService } from './services/knowledge-graph/graph-service.js';
 import { PDSRegistry } from './services/pds-discovery/pds-registry.js';
@@ -544,6 +550,16 @@ async function main(): Promise<void> {
       logger.error('Failed to load Cosmik plugins', err instanceof Error ? err : undefined);
     }
 
+    // standard.site — the cross-ecosystem document record. Also the mapping a
+    // recommend or an embedded document block resolves through.
+    try {
+      await pluginManager.loadBuiltinPlugin(new StandardSiteBacklinksPlugin(), pluginContext);
+      await pluginManager.loadBuiltinPlugin(new CalendarEventsPlugin(), pluginContext);
+      logger.info('standard.site and calendar plugins loaded');
+    } catch (err) {
+      logger.error('Failed to load standard.site plugin', err instanceof Error ? err : undefined);
+    }
+
     // Margin (W3C Web Annotation) ecosystem plugins
     try {
       await pluginManager.loadBuiltinPlugin(new MarginNotesPlugin(), pluginContext);
@@ -583,8 +599,23 @@ async function main(): Promise<void> {
     });
 
     // Create indexing service
+    // Foreign collections the backlink plugins subscribe to. Without these the
+    // filter drops every non-`pub.chive.*` record before the processor runs, so
+    // the plugins are constructed, subscribed, and never called.
+    const observeHighVolume = process.env.FIREHOSE_OBSERVE_HIGH_VOLUME === 'true';
+    const observedCollections = [
+      ...OBSERVED_COLLECTIONS,
+      ...(observeHighVolume ? OBSERVED_COLLECTIONS_HIGH_VOLUME : []),
+    ];
+
+    logger.info('Observing foreign collections for backlinks', {
+      count: observedCollections.length,
+      highVolume: observeHighVolume,
+    });
+
     const indexingService = new IndexingService({
       relays: [config.relayUrl],
+      observedCollections,
       db: pgPool,
       redis,
       redisConnection: parseRedisUrl(config.redisUrl),

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+/**
+ * Executable entry point for the Chive MCP server.
+ *
+ * @packageDocumentation
+ */
+
+import { main } from './server.js';
+
+main().catch((error: unknown) => {
+  // stderr, not stdout: stdout carries the MCP protocol, and writing anything
+  // else there corrupts the stream the client is parsing.
+  process.stderr.write(`chive-mcp failed to start: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,195 @@
+/**
+ * MCP server over Chive's public read API.
+ *
+ * @remarks
+ * Chive indexes eprints, their citations and their reviews, and answers
+ * questions about them over unauthenticated XRPC. An agent that can call those
+ * endpoints can use Chive as a literature backend — find work on a topic,
+ * resolve a DOI to a record, follow a citation graph, read what people said
+ * about a paper.
+ *
+ * This is a thin adapter, deliberately. It speaks to the same public HTTP API
+ * any other client uses rather than reaching into the database, which means:
+ *
+ *   - it needs no credentials, and can be pointed at any Chive deployment;
+ *   - it cannot read anything a browser could not;
+ *   - it stays correct when a handler changes, because it is a caller like any
+ *     other rather than a second implementation.
+ *
+ * Every tool here is read-only. Nothing writes to a repository, and there is no
+ * authenticated surface: an agent acting on someone's behalf should hold their
+ * own session rather than borrow one from a server.
+ *
+ * Run it over stdio:
+ *
+ * ```bash
+ * pnpm mcp
+ * CHIVE_API_URL=https://api.staging.chive.pub pnpm mcp
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+/**
+ * Default deployment this server reads from.
+ *
+ * @public
+ */
+export const DEFAULT_API_URL = 'https://api.chive.pub';
+
+/**
+ * How long to wait on any one call before giving up.
+ *
+ * @remarks
+ * An agent waiting on a tool call is blocked, so a slow answer is worse than a
+ * refused one.
+ */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Calls one XRPC method and returns its JSON body.
+ *
+ * @param apiUrl - Base URL of the Chive API
+ * @param nsid - XRPC method to call
+ * @param params - Query parameters; undefined values are omitted
+ * @returns The parsed response body
+ *
+ * @throws Error when the call fails, times out, or the endpoint answers with an
+ * error status. The message is what the agent sees, so it names the method.
+ *
+ * @public
+ */
+export async function callXrpc(
+  apiUrl: string,
+  nsid: string,
+  params: Record<string, string | number | undefined>
+): Promise<unknown> {
+  const url = new URL(`${apiUrl.replace(/\/$/, '')}/xrpc/${nsid}`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as { message?: string };
+      throw new Error(`${nsid} failed (${response.status}): ${body.message ?? 'no detail given'}`);
+    }
+
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Wraps a value as MCP tool output.
+ *
+ * @param value - Whatever the endpoint returned
+ * @returns Tool content the SDK can serialise
+ */
+function asContent(value: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+/**
+ * Builds the Chive MCP server.
+ *
+ * @param apiUrl - Base URL of the deployment to read from
+ * @returns A configured server, not yet connected to a transport
+ *
+ * @public
+ */
+export function createChiveMcpServer(apiUrl: string = DEFAULT_API_URL): McpServer {
+  const server = new McpServer({ name: 'chive', version: '0.1.0' });
+
+  server.tool(
+    'search_eprints',
+    'Search Chive for eprints matching a query. Returns titles, abstracts, authors and AT-URIs.',
+    {
+      query: z.string().describe('Free-text search over titles, abstracts and keywords'),
+      limit: z.number().int().min(1).max(50).optional().describe('Results to return, default 10'),
+    },
+    async ({ query, limit }) =>
+      asContent(
+        await callXrpc(apiUrl, 'pub.chive.eprint.searchSubmissions', {
+          q: query,
+          limit: limit ?? 10,
+        })
+      )
+  );
+
+  server.tool(
+    'get_eprint',
+    'Fetch one eprint by its AT-URI, with full metadata.',
+    {
+      uri: z.string().describe('AT-URI of the eprint, as returned by search_eprints'),
+    },
+    async ({ uri }) => asContent(await callXrpc(apiUrl, 'pub.chive.eprint.getSubmission', { uri }))
+  );
+
+  server.tool(
+    'resolve_identifier',
+    'Resolve an external identifier — a DOI, arXiv ID, ORCID, ROR, ISBN, PMID or Wikidata ID — to the Chive record that declares it. Answers {found: false} when Chive does not index that identifier, which is not the same as the work not existing.',
+    {
+      system: z
+        .enum(['doi', 'arxiv', 'orcid', 'ror', 'isbn', 'pmid', 'wikidata'])
+        .describe('Identifier system'),
+      identifier: z.string().describe('The identifier itself, with no resolver prefix'),
+    },
+    async ({ system, identifier }) =>
+      asContent(await callXrpc(apiUrl, 'pub.chive.resolve.byExternalId', { system, identifier }))
+  );
+
+  server.tool(
+    'list_citations',
+    'List the works an eprint cites, with their relation type where one is recorded.',
+    {
+      eprintUri: z.string().describe('AT-URI of the citing eprint'),
+      limit: z.number().int().min(1).max(100).optional().describe('Results to return, default 50'),
+    },
+    async ({ eprintUri, limit }) =>
+      asContent(
+        await callXrpc(apiUrl, 'pub.chive.eprint.listCitations', { eprintUri, limit: limit ?? 50 })
+      )
+  );
+
+  server.tool(
+    'list_reviews',
+    'List the reviews and comments left on an eprint.',
+    {
+      eprintUri: z.string().describe('AT-URI of the eprint'),
+      limit: z.number().int().min(1).max(100).optional().describe('Results to return, default 25'),
+    },
+    async ({ eprintUri, limit }) =>
+      asContent(
+        await callXrpc(apiUrl, 'pub.chive.review.listForEprint', { eprintUri, limit: limit ?? 25 })
+      )
+  );
+
+  return server;
+}
+
+/**
+ * Entry point: serve over stdio until the client disconnects.
+ *
+ * @public
+ */
+export async function main(): Promise<void> {
+  const apiUrl = process.env.CHIVE_API_URL ?? DEFAULT_API_URL;
+  const server = createChiveMcpServer(apiUrl);
+  await server.connect(new StdioServerTransport());
+}

--- a/src/plugins/builtin/calendar-events.ts
+++ b/src/plugins/builtin/calendar-events.ts
@@ -1,0 +1,200 @@
+/**
+ * Calendar event backlinks plugin.
+ *
+ * @remarks
+ * A talk, a conference presentation or a reading group is an event, and the
+ * community calendar lexicon (`community.lexicon.calendar.event`, used by
+ * Smoke Signal among others) records one as an ATProto record with a list of
+ * associated URIs.
+ *
+ * When one of those URIs is a Chive eprint, the event is a fact about that
+ * paper: it was presented somewhere, on a date, by someone. Recording it as a
+ * backlink is how "presented at…" becomes something Chive can show without an
+ * author entering it a second time by hand.
+ *
+ * The schema is vendored at `lexicons/vendor/community/calendar/event.json`,
+ * from the community lexicon repository.
+ *
+ * @packageDocumentation
+ */
+
+import type { BacklinkSourceType } from '../../types/interfaces/plugin.interface.js';
+import type { IPluginManifest } from '../../types/interfaces/plugin.interface.js';
+import { BacklinkTrackingPlugin } from '../core/backlink-plugin.js';
+
+/**
+ * A URI associated with an event.
+ *
+ * @internal
+ */
+interface CalendarEventUri {
+  uri?: string;
+  name?: string;
+}
+
+/**
+ * `community.lexicon.calendar.event`, in the parts this plugin reads.
+ *
+ * @internal
+ */
+interface CalendarEvent {
+  $type?: string;
+  name?: string;
+  description?: string;
+  startsAt?: string;
+  status?: string;
+  uris?: CalendarEventUri[];
+}
+
+/**
+ * Event statuses that mean the event is not happening.
+ *
+ * @remarks
+ * The lexicon's status values. A cancelled talk is not evidence that a paper
+ * was presented, so those events are skipped rather than recorded and then
+ * explained away in the UI.
+ */
+const NOT_HAPPENING = new Set(['cancelled', 'postponed']);
+
+/**
+ * Tracks references to Chive eprints from community calendar events.
+ *
+ * @public
+ */
+export class CalendarEventsPlugin extends BacklinkTrackingPlugin {
+  /**
+   * Plugin ID.
+   */
+  readonly id = 'pub.chive.plugin.calendar-events';
+
+  /**
+   * ATProto collection to track.
+   */
+  readonly trackedCollection = 'community.lexicon.calendar.event';
+
+  /**
+   * Backlink source type.
+   */
+  readonly sourceType: BacklinkSourceType = 'calendar.event';
+
+  /**
+   * Plugin manifest.
+   */
+  readonly manifest: IPluginManifest = {
+    id: 'pub.chive.plugin.calendar-events',
+    name: 'Calendar Event Backlinks',
+    version: '0.1.0',
+    description: 'Tracks talks and presentations that reference a Chive eprint',
+    author: 'Aaron Steven White',
+    license: 'MIT',
+    permissions: {
+      hooks: ['firehose.community.lexicon.calendar.event'],
+      storage: {
+        maxSize: 10 * 1024 * 1024, // 10MB
+      },
+    },
+    entrypoint: 'calendar-events.js',
+  };
+
+  /**
+   * Extracts the eprints an event refers to.
+   *
+   * @param record - A `community.lexicon.calendar.event`
+   * @returns Eprint AT-URIs the event links to, deduplicated
+   *
+   * @remarks
+   * `uris` is typed as `format: uri`, which admits `at://` alongside `https://`
+   * — so an event may name an eprint by its record URI directly.
+   */
+  extractEprintRefs(record: unknown): string[] {
+    if (record === null || typeof record !== 'object') {
+      return [];
+    }
+
+    const event = record as CalendarEvent;
+    const refs = new Set<string>();
+
+    for (const entry of event.uris ?? []) {
+      if (this.isEprintUri(entry?.uri)) {
+        refs.add(entry.uri);
+      }
+    }
+
+    return [...refs];
+  }
+
+  /**
+   * Extracts context from an event.
+   *
+   * @param record - A `community.lexicon.calendar.event`
+   * @returns The event name, with its date when there is one
+   *
+   * @remarks
+   * The name and date are what make the backlink readable — "presented at the
+   * ATScience workshop, 12 October 2026" rather than a bare link.
+   */
+  protected override extractContext(record: unknown): string | undefined {
+    if (record === null || typeof record !== 'object') {
+      return undefined;
+    }
+    const event = record as CalendarEvent;
+
+    if (!event.name) {
+      return undefined;
+    }
+
+    const date = eventDate(event.startsAt);
+    return date ? `${event.name} (${date})` : event.name;
+  }
+
+  /**
+   * Determines whether an event should be recorded.
+   *
+   * @param record - A `community.lexicon.calendar.event`
+   * @returns True unless the event was cancelled or postponed
+   */
+  protected override shouldProcess(record: unknown): boolean {
+    if (record === null || typeof record !== 'object') {
+      return false;
+    }
+    const status = (record as CalendarEvent).status;
+    if (typeof status !== 'string') {
+      return true;
+    }
+    // The lexicon expresses status as a ref such as `#cancelled`; match on the
+    // final segment so both forms are handled.
+    return !NOT_HAPPENING.has(status.replace(/^.*#/, ''));
+  }
+}
+
+/**
+ * Formats an event's start date for display.
+ *
+ * @param startsAt - ISO timestamp from the event record
+ * @returns A date such as `12 October 2026`, or undefined
+ *
+ * @remarks
+ * A malformed timestamp from another repository yields undefined rather than
+ * `Invalid Date` in a backlink's context string.
+ *
+ * @public
+ */
+export function eventDate(startsAt: string | undefined): string | undefined {
+  if (!startsAt) {
+    return undefined;
+  }
+
+  const parsed = new Date(startsAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+
+  return parsed.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+export default CalendarEventsPlugin;

--- a/src/plugins/builtin/leaflet-backlinks.ts
+++ b/src/plugins/builtin/leaflet-backlinks.ts
@@ -1,94 +1,133 @@
 /**
- * Leaflet backlinks tracking plugin.
+ * Leaflet backlinks plugin.
  *
  * @remarks
- * Tracks references to Chive eprints from Leaflet reading lists.
- * Leaflet (https://leaflet.app) is an ATProto-based reading list manager
- * that allows users to organize and share reading materials.
+ * Leaflet (https://leaflet.pub) is an ATProto app for long-form rich documents.
+ * When a Leaflet document or comment refers to a Chive eprint, this plugin
+ * records a backlink so the reference surfaces on the eprint page.
  *
- * When a Leaflet reading list includes a Chive eprint, this plugin
- * creates a backlink for aggregation and discovery.
+ * This was previously written against `xyz.leaflet.list`, an NSID Leaflet does
+ * not publish, with an invented record shape — so it matched nothing however it
+ * was wired up. The schemas it now parses are vendored under
+ * `lexicons/pub/leaflet/`, taken from Leaflet's own lexicon repository
+ * (`did:plc:btxrwcaeyodrap5mnjw2fvmz`).
  *
- * Reading list schema: xyz.leaflet.list
+ * A Leaflet document reaches an eprint by four routes, and this plugin follows
+ * all of them:
  *
- * WARNING: `xyz.leaflet.list` does not exist. Leaflet publishes
- * `pub.leaflet.document` and `pub.leaflet.comment`; this NSID, and the
- * `LeafletList` interface below with its `items` / `visibility` / `tags`
- * fields, were invented rather than taken from a published lexicon. The plugin
- * therefore matches no record that any repository actually holds, and indexes
- * nothing however it is wired up.
+ * 1. `pub.leaflet.comment.subject` — an at-uri, the direct case.
+ * 2. `blocks.website.src` — an ordinary URL, so a link to a chive.pub eprint
+ *    page counts.
+ * 3. `blocks.text.facets[].features[]` — an inline richtext link, which is how
+ *    a citation inside a paragraph appears.
+ * 4. `blocks.standardSitePost.uri` — an at-uri to a `site.standard` document.
+ *    Chive emits one of those for every eprint submitted with cross-platform
+ *    discovery enabled, so a Leaflet document embedding a Chive standard.site
+ *    post is referring to an eprint at one remove.
  *
- * It is left pointing at the fictional NSID deliberately. Repointing it at
- * `pub.leaflet.document` while the parser still expects this invented shape
- * would turn "indexes nothing" into "indexes wrong backlinks", which is the
- * worse failure — a real record would be read against a schema it does not
- * have. Fixing this properly means reading Leaflet's published lexicon and
- * rewriting the record handling against it, which is integration work rather
- * than remediation.
- *
- * Note also that nothing loads this plugin today, and the event filter drops
- * every non-`pub.chive.*` record before the plugin bus in any case (INT-1), so
- * no wiring change alone would bring it to life.
- *
- * ATProto Compliance:
- * - All backlinks indexed from firehose (rebuildable via replay)
- * - Tracks deletions to honor record removal
- * - Never writes to user PDSes
+ * Route 4 is resolved by shape rather than by fetching: a `site.standard`
+ * at-uri is recorded as a backlink to the document, and mapping it back to the
+ * eprint it wraps needs `content.uri` from the record itself. That second hop
+ * is deliberately not done here — see the note on {@link extractEprintRefs}.
  *
  * @packageDocumentation
- * @public
- * @since 0.1.0
  */
 
-import type {
-  BacklinkSourceType,
-  IPluginManifest,
-} from '../../types/interfaces/plugin.interface.js';
+import type { BacklinkSourceType } from '../../types/interfaces/plugin.interface.js';
+import type { IPluginManifest } from '../../types/interfaces/plugin.interface.js';
 import { BacklinkTrackingPlugin } from '../core/backlink-plugin.js';
 
 /**
- * Leaflet reading list record structure.
- *
- * @internal
- */
-interface LeafletList {
-  $type: 'xyz.leaflet.list';
-  name: string;
-  description?: string;
-  visibility: 'public' | 'private' | 'followers';
-  items: LeafletListItem[];
-  createdAt: string;
-  updatedAt?: string;
-  tags?: string[];
-}
-
-/**
- * Leaflet list item structure.
- *
- * @internal
- */
-interface LeafletListItem {
-  uri: string;
-  addedAt: string;
-  status?: 'unread' | 'reading' | 'read';
-  notes?: string;
-  rating?: number;
-}
-
-/**
- * Leaflet backlinks tracking plugin.
+ * A richtext facet feature.
  *
  * @remarks
- * Tracks eprint references in Leaflet reading lists via firehose
- * and creates backlinks for discovery and aggregation.
+ * `pub.leaflet.richtext.facet#link` carries `uri`. The other features (bold,
+ * code, mentions) carry no link and are ignored.
  *
- * Only processes public reading lists to respect privacy.
+ * @internal
+ */
+interface LeafletFacetFeature {
+  $type?: string;
+  uri?: string;
+}
+
+/**
+ * A richtext facet.
  *
- * @example
- * ```typescript
- * const plugin = new LeafletBacklinksPlugin();
- * await manager.loadBuiltinPlugin(plugin);
- * ```
+ * @internal
+ */
+interface LeafletFacet {
+  features?: LeafletFacetFeature[];
+}
+
+/**
+ * One block inside a linear document page.
+ *
+ * @remarks
+ * `pub.leaflet.pages.linearDocument#block` wraps the block union in a `block`
+ * property. Only the members that can carry a reference are typed here.
+ *
+ * @internal
+ */
+interface LeafletBlockWrapper {
+  block?: {
+    $type?: string;
+    /** `blocks.website` */
+    src?: string;
+    /** `blocks.text` and `blocks.header` */
+    facets?: LeafletFacet[];
+    /** `blocks.standardSitePost` and `blocks.standardSitePublication` */
+    uri?: string;
+  };
+}
+
+/**
+ * A page within a document.
+ *
+ * @internal
+ */
+interface LeafletPage {
+  blocks?: LeafletBlockWrapper[];
+}
+
+/**
+ * `pub.leaflet.document`.
+ *
+ * @internal
+ */
+interface LeafletDocument {
+  $type?: 'pub.leaflet.document';
+  title?: string;
+  description?: string;
+  author?: string;
+  publication?: string;
+  pages?: LeafletPage[];
+}
+
+/**
+ * `pub.leaflet.comment`.
+ *
+ * @internal
+ */
+interface LeafletComment {
+  $type?: 'pub.leaflet.comment';
+  subject?: string;
+  plaintext?: string;
+  facets?: LeafletFacet[];
+  attachment?: {
+    document?: string;
+  };
+}
+
+/**
+ * Collections this plugin reads.
+ *
+ * @public
+ */
+export const LEAFLET_COLLECTIONS = ['pub.leaflet.document', 'pub.leaflet.comment'] as const;
+
+/**
+ * Tracks references to Chive eprints from Leaflet documents and comments.
  *
  * @public
  */
@@ -100,13 +139,18 @@ export class LeafletBacklinksPlugin extends BacklinkTrackingPlugin {
 
   /**
    * ATProto collection to track.
+   *
+   * @remarks
+   * The base class subscribes to one collection. Comments are subscribed to
+   * additionally in {@link onInitialize}, since both carry references and
+   * splitting them into two plugins would duplicate the extraction.
    */
-  readonly trackedCollection = 'xyz.leaflet.list';
+  readonly trackedCollection = 'pub.leaflet.document';
 
   /**
    * Backlink source type.
    */
-  readonly sourceType: BacklinkSourceType = 'leaflet.list';
+  readonly sourceType: BacklinkSourceType = 'leaflet.document';
 
   /**
    * Plugin manifest.
@@ -114,12 +158,12 @@ export class LeafletBacklinksPlugin extends BacklinkTrackingPlugin {
   readonly manifest: IPluginManifest = {
     id: 'pub.chive.plugin.leaflet-backlinks',
     name: 'Leaflet Backlinks',
-    version: '0.4.0',
-    description: 'Tracks references to Chive eprints from Leaflet reading lists',
+    version: '0.5.0',
+    description: 'Tracks references to Chive eprints from Leaflet documents and comments',
     author: 'Aaron Steven White',
     license: 'MIT',
     permissions: {
-      hooks: ['firehose.xyz.leaflet.list'],
+      hooks: ['firehose.pub.leaflet.document', 'firehose.pub.leaflet.comment'],
       storage: {
         maxSize: 10 * 1024 * 1024, // 10MB
       },
@@ -128,48 +172,141 @@ export class LeafletBacklinksPlugin extends BacklinkTrackingPlugin {
   };
 
   /**
-   * Extracts eprint AT-URIs from a Leaflet reading list.
+   * Subscribe to comments as well as documents.
    *
-   * @param record - Leaflet list record
-   * @returns Array of eprint AT-URIs
+   * @remarks
+   * `BacklinkTrackingPlugin` subscribes to `trackedCollection`; this adds the
+   * second collection through the same handler, because a comment and a
+   * document reach an eprint through the same extraction.
    */
-  extractEprintRefs(record: unknown): string[] {
-    const list = record as LeafletList;
-
-    if (!list.items || !Array.isArray(list.items)) {
-      return [];
-    }
-
-    return list.items.filter((item) => this.isEprintUri(item.uri)).map((item) => item.uri);
+  protected override onInitialize(): Promise<void> {
+    this.context.eventBus.on('firehose.pub.leaflet.comment', (...args: readonly unknown[]) => {
+      void this.handleFirehoseRecord(args[0] as Parameters<typeof this.handleFirehoseRecord>[0]);
+    });
+    return Promise.resolve();
   }
 
   /**
-   * Extracts context from a Leaflet reading list.
+   * Extracts eprint AT-URIs from a Leaflet document or comment.
    *
-   * @param record - Leaflet list record
-   * @returns List name and description
+   * @param record - `pub.leaflet.document` or `pub.leaflet.comment`
+   * @returns Eprint AT-URIs the record refers to, deduplicated
+   *
+   * @remarks
+   * A `site.standard` at-uri found in a `standardSitePost` block is *not*
+   * returned. Chive emits a `site.standard.document` whose `content.uri` is the
+   * eprint, so resolving one to an eprint means reading that record — a network
+   * fetch per block, from a repository that may be unavailable. Recording a
+   * backlink to the wrapper instead would attach it to the wrong subject.
+   * Until Chive indexes the standard.site documents it emits (it does not
+   * today), that route is better left unfollowed than followed wrongly.
+   */
+  extractEprintRefs(record: unknown): string[] {
+    if (record === null || typeof record !== 'object') {
+      return [];
+    }
+
+    const refs = new Set<string>();
+    const value = record as LeafletDocument & LeafletComment;
+
+    // A comment names its subject directly.
+    if (this.isEprintUri(value.subject)) {
+      refs.add(value.subject);
+    }
+
+    // A comment may quote a document, and carries its own facets.
+    if (this.isEprintUri(value.attachment?.document)) {
+      refs.add(value.attachment.document);
+    }
+    for (const uri of this.facetLinks(value.facets)) {
+      refs.add(uri);
+    }
+
+    // A document carries its references inside its pages' blocks.
+    for (const page of value.pages ?? []) {
+      for (const wrapper of page.blocks ?? []) {
+        const block = wrapper.block;
+        if (!block) continue;
+
+        // `blocks.website` — a plain URL.
+        if (this.isEprintUri(block.src)) {
+          refs.add(block.src);
+        }
+
+        // `blocks.standardSitePost` — an at-uri. Counted only when it points at
+        // an eprint directly; see the remark above.
+        if (this.isEprintUri(block.uri)) {
+          refs.add(block.uri);
+        }
+
+        for (const uri of this.facetLinks(block.facets)) {
+          refs.add(uri);
+        }
+      }
+    }
+
+    return [...refs];
+  }
+
+  /**
+   * Collects eprint URIs from a richtext facet array.
+   *
+   * @param facets - Facets from a text block or comment
+   * @returns Eprint AT-URIs found in link features
+   *
+   * @internal
+   */
+  private facetLinks(facets: LeafletFacet[] | undefined): string[] {
+    const found: string[] = [];
+    for (const facet of facets ?? []) {
+      for (const feature of facet.features ?? []) {
+        if (this.isEprintUri(feature.uri)) {
+          found.push(feature.uri);
+        }
+      }
+    }
+    return found;
+  }
+
+  /**
+   * Extracts context from a Leaflet record.
+   *
+   * @param record - Document or comment
+   * @returns A title, or the opening of a comment
    */
   protected override extractContext(record: unknown): string | undefined {
-    const list = record as LeafletList;
+    if (record === null || typeof record !== 'object') {
+      return undefined;
+    }
+    const value = record as LeafletDocument & LeafletComment;
 
-    if (list.name) {
-      return list.description ? `${list.name}: ${list.description}` : list.name;
+    if (value.title) {
+      return value.description ? `${value.title}: ${value.description}` : value.title;
+    }
+
+    // Comments have no title; their opening line is the useful context.
+    if (value.plaintext) {
+      return value.plaintext.length > 200 ? `${value.plaintext.slice(0, 197)}...` : value.plaintext;
     }
 
     return undefined;
   }
 
   /**
-   * Determines if a reading list should be processed.
+   * Determines whether a record should be processed.
    *
-   * @param record - Leaflet list record
-   * @returns True if the list is public
+   * @param record - Document or comment
+   * @returns True when the record is one this plugin can read
+   *
+   * @remarks
+   * The previous version filtered on `visibility === 'public'`, a field the
+   * real lexicons do not have — so with the invented shape gone, every record
+   * would have been skipped. Leaflet expresses membership limits inside a
+   * document with a `membersOnlyDelimiter` block rather than a record-level
+   * flag, and a record on the public firehose is public by construction.
    */
   protected override shouldProcess(record: unknown): boolean {
-    const list = record as LeafletList;
-
-    // Only process public reading lists
-    return list.visibility === 'public';
+    return record !== null && typeof record === 'object';
   }
 }
 

--- a/src/plugins/builtin/standard-site-backlinks.ts
+++ b/src/plugins/builtin/standard-site-backlinks.ts
@@ -1,0 +1,180 @@
+/**
+ * standard.site backlinks plugin.
+ *
+ * @remarks
+ * `site.standard.document` is the ATProto publishing ecosystem's shared record
+ * for "a document on the web". Chive emits one for every eprint submitted with
+ * cross-platform discovery enabled, and so does every other standard.site
+ * publisher — which means a document written anywhere may point at a Chive
+ * eprint.
+ *
+ * This plugin records that reference as a backlink. A document identifies the
+ * work it describes by `site` + `path`, so a Chive eprint's document carries a
+ * `path` of `/eprints/<encoded at-uri>`; documents written before that was
+ * fixed carry the eprint in `content.uri` instead, and both are read here.
+ *
+ * Why it matters beyond the backlink itself: several references into Chive
+ * arrive addressed to a *document* rather than to an eprint —
+ * `site.standard.graph.recommend` names a document, and a Leaflet
+ * `standardSitePost` block embeds one. Resolving those to the eprint they
+ * describe needs a document-to-eprint mapping, and this is where that mapping
+ * comes from. Without it, following such a reference means fetching the
+ * document record over the network, from a repository that may be unavailable.
+ *
+ * @packageDocumentation
+ */
+
+import type { BacklinkSourceType } from '../../types/interfaces/plugin.interface.js';
+import type { IPluginManifest } from '../../types/interfaces/plugin.interface.js';
+import { BacklinkTrackingPlugin } from '../core/backlink-plugin.js';
+
+/**
+ * The path prefix under which Chive serves eprint pages.
+ *
+ * @remarks
+ * Mirrors the frontend route and `eprintPath` in the web record creator. A
+ * document whose `path` begins with this names an eprint in its remainder.
+ */
+const EPRINT_PATH_PREFIX = '/eprints/';
+
+/**
+ * `site.standard.document`, in the parts this plugin reads.
+ *
+ * @internal
+ */
+interface StandardDocument {
+  $type?: string;
+  title?: string;
+  description?: string;
+  /** Path under `site`, where a Chive document names its eprint */
+  path?: string;
+  /** Pre-revision shape: the eprint URI lived here */
+  content?: { uri?: string };
+}
+
+/**
+ * Tracks references to Chive eprints from standard.site documents.
+ *
+ * @public
+ */
+export class StandardSiteBacklinksPlugin extends BacklinkTrackingPlugin {
+  /**
+   * Plugin ID.
+   */
+  readonly id = 'pub.chive.plugin.standard-site-backlinks';
+
+  /**
+   * ATProto collection to track.
+   */
+  readonly trackedCollection = 'site.standard.document';
+
+  /**
+   * Backlink source type.
+   */
+  readonly sourceType: BacklinkSourceType = 'standard.document';
+
+  /**
+   * Plugin manifest.
+   */
+  readonly manifest: IPluginManifest = {
+    id: 'pub.chive.plugin.standard-site-backlinks',
+    name: 'standard.site Backlinks',
+    version: '0.1.0',
+    description: 'Tracks references to Chive eprints from standard.site documents',
+    author: 'Aaron Steven White',
+    license: 'MIT',
+    permissions: {
+      hooks: ['firehose.site.standard.document'],
+      storage: {
+        maxSize: 10 * 1024 * 1024, // 10MB
+      },
+    },
+    entrypoint: 'standard-site-backlinks.js',
+  };
+
+  /**
+   * Extracts the eprint a standard.site document describes.
+   *
+   * @param record - A `site.standard.document`
+   * @returns The eprint AT-URI, or an empty array
+   *
+   * @remarks
+   * A document describes at most one work, so this returns zero or one URI.
+   * Both shapes are read: `path`, which is where the link lives now, and the
+   * legacy `content.uri`, which is what documents written before the schema was
+   * corrected still carry. Dropping the legacy branch would make every
+   * already-published Chive document invisible.
+   */
+  extractEprintRefs(record: unknown): string[] {
+    if (record === null || typeof record !== 'object') {
+      return [];
+    }
+
+    const document = record as StandardDocument;
+
+    const fromPath = eprintUriFromPath(document.path);
+    if (this.isEprintUri(fromPath)) {
+      return [fromPath];
+    }
+
+    if (this.isEprintUri(document.content?.uri)) {
+      return [document.content.uri];
+    }
+
+    return [];
+  }
+
+  /**
+   * Extracts context from a standard.site document.
+   *
+   * @param record - A `site.standard.document`
+   * @returns The document's title, with its description when there is one
+   */
+  protected override extractContext(record: unknown): string | undefined {
+    if (record === null || typeof record !== 'object') {
+      return undefined;
+    }
+    const document = record as StandardDocument;
+
+    if (!document.title) {
+      return undefined;
+    }
+
+    return document.description
+      ? `${document.title}: ${document.description.slice(0, 200)}`
+      : document.title;
+  }
+}
+
+/**
+ * Recovers an eprint AT-URI from a document path.
+ *
+ * @param path - The document's `path`, such as `/eprints/at%3A%2F%2F...`
+ * @returns The decoded AT-URI, or undefined when the path names no eprint
+ *
+ * @remarks
+ * A malformed percent-encoding throws from `decodeURIComponent`, and a path
+ * arriving from another repository is not something to trust — so the failure
+ * is caught and treated as "this document is not about an eprint" rather than
+ * allowed to abort processing the record.
+ *
+ * @public
+ */
+export function eprintUriFromPath(path: string | undefined): string | undefined {
+  if (!path?.startsWith(EPRINT_PATH_PREFIX)) {
+    return undefined;
+  }
+
+  const encoded = path.slice(EPRINT_PATH_PREFIX.length);
+  if (!encoded) {
+    return undefined;
+  }
+
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return undefined;
+  }
+}
+
+export default StandardSiteBacklinksPlugin;

--- a/src/services/indexing/event-filter.ts
+++ b/src/services/indexing/event-filter.ts
@@ -58,6 +58,22 @@ export interface EventFilterOptions {
   readonly collections?: readonly NSID[];
 
   /**
+   * Foreign collections to admit for the plugin bus.
+   *
+   * @remarks
+   * Collections outside `pub.chive.*` that Chive observes but does not index.
+   * They are forwarded to the backlink plugins by the event processor; nothing
+   * writes them to a Chive index. Omitted means no foreign collection is
+   * admitted, which is what starved every backlink plugin.
+   *
+   * @example
+   * ```typescript
+   * { observedCollections: ['at.margin.note', 'com.whtwnd.blog.entry'] }
+   * ```
+   */
+  readonly observedCollections?: readonly string[];
+
+  /**
    * Enable strict validation of collection NSIDs.
    *
    * @remarks
@@ -83,6 +99,7 @@ export interface EventFilterOptions {
  */
 export class EventFilter {
   private readonly collections?: ReadonlySet<NSID>;
+  private readonly observedCollections: ReadonlySet<string>;
   private readonly strictValidation: boolean;
 
   /**
@@ -92,6 +109,7 @@ export class EventFilter {
    */
   constructor(options: EventFilterOptions = {}) {
     this.collections = options.collections ? new Set(options.collections) : undefined;
+    this.observedCollections = new Set(options.observedCollections ?? []);
     this.strictValidation = options.strictValidation ?? true;
   }
 
@@ -127,7 +145,15 @@ export class EventFilter {
       return false;
     }
 
-    // Reject non-Chive collections early
+    // Foreign collections Chive observes for backlinks. They are admitted so
+    // the event processor can forward them to the plugin bus, and are checked
+    // before the `collections` allow-list below because that list names the
+    // Chive collections to index and says nothing about these.
+    if (this.observedCollections.has(collection)) {
+      return this.strictValidation ? this.isValidNSID(collection) : true;
+    }
+
+    // Reject everything else outside the Chive namespace.
     if (!collection.startsWith('pub.chive.')) {
       return false;
     }
@@ -202,14 +228,49 @@ export class EventFilter {
       return false;
     }
 
-    // Validate each segment
-    for (const segment of segments) {
+    // An NSID is a domain authority followed by a name. They have different
+    // rules, and treating them alike is what made this filter drop seven of
+    // Chive's own collections: the authority segments are domain labels and
+    // are lowercase, but the final name segment allows any letter, which is
+    // where camelCase lives — `userTag`, `nodeProposal`, `createRecord`.
+    const name = segments[segments.length - 1];
+    const authority = segments.slice(0, -1);
+
+    if (name === undefined) {
+      return false;
+    }
+
+    for (const segment of authority) {
       if (!this.isValidNSIDSegment(segment)) {
         return false;
       }
     }
 
-    return true;
+    return this.isValidNSIDName(name);
+  }
+
+  /**
+   * Validates the final (name) segment of an NSID.
+   *
+   * @param segment - Name segment
+   * @returns `true` if valid
+   *
+   * @remarks
+   * The grammar is `name = alpha *( alpha / number )`: a letter, then letters
+   * or digits, up to 63 characters. Unlike the authority segments it carries no
+   * hyphens and cannot begin with a digit, and its conventional form is
+   * camelCase — which is the part this filter used to reject.
+   *
+   * Checked against the regex `@atproto/syntax` uses, so `userTag`,
+   * `collectionLinkRemoval` and `submission3` are accepted while
+   * `submission-type` and `user_tag` are not.
+   *
+   * @see {@link https://atproto.com/specs/nsid | NSID specification}
+   *
+   * @internal
+   */
+  private isValidNSIDName(segment: string): boolean {
+    return /^[A-Za-z][A-Za-z0-9]{0,62}$/.test(segment);
   }
 
   /**

--- a/src/services/indexing/indexed-collections.ts
+++ b/src/services/indexing/indexed-collections.ts
@@ -76,3 +76,81 @@ export const INDEXED_COLLECTIONS: readonly string[] = [
 export function isIndexedCollection(collection: string): boolean {
   return INDEXED_COLLECTIONS.includes(collection);
 }
+
+/**
+ * Foreign collections Chive observes but does not index.
+ *
+ * @remarks
+ * These are other applications' lexicons. Chive never stores them as its own
+ * records: `createEventProcessor` forwards them to the plugin event bus as
+ * `firehose.<collection>`, and the backlink plugins turn the ones that
+ * reference an eprint into backlink rows. A backlink is derived data,
+ * rebuildable by replaying the firehose, so this stays inside the AppView
+ * rules — Chive is still authoritative for nothing but `pub.chive.*`.
+ *
+ * The plugins subscribing to these were dormant for a different reason than
+ * anyone assumed. They were constructed and listening, and the processor was
+ * already forwarding foreign records; `EventFilter` rejected every collection
+ * outside `pub.chive.*` before the processor ever saw one. Five registered
+ * plugins were therefore subscribed to events that could not fire.
+ *
+ * `app.bsky.feed.post` is deliberately absent. It is the entire Bluesky
+ * timeline — millions of records a day against Chive's thousands — and
+ * admitting it changes the indexer from something that reads a niche namespace
+ * into something that reads the whole network. That may well be worth doing for
+ * the timeline-card backlinks it would enable, but it is a capacity decision
+ * with a cost attached, not a filter entry. `OBSERVED_COLLECTIONS_HIGH_VOLUME`
+ * holds it, and `FIREHOSE_OBSERVE_HIGH_VOLUME=true` opts in.
+ *
+ * @public
+ */
+export const OBSERVED_COLLECTIONS: readonly string[] = [
+  // Cosmik — collection cards, connections, follows, and link removals.
+  'network.cosmik.card',
+  'network.cosmik.collectionLinkRemoval',
+  'network.cosmik.connection',
+  'network.cosmik.follow',
+  // Margin — annotations and replies on eprints.
+  'at.margin.note',
+  'at.margin.reply',
+  // WhiteWind — blog entries that may cite an eprint.
+  'com.whtwnd.blog.entry',
+  // Leaflet — long-form documents and the comments on them. Both carry
+  // references to eprints; see `leaflet-backlinks.ts` for the four routes.
+  'pub.leaflet.document',
+  'pub.leaflet.comment',
+  // standard.site — the ecosystem's shared "document on the web" record. Any
+  // publisher may write one describing a Chive eprint, and it is also the
+  // mapping that lets a reference addressed to a document resolve to the work.
+  'site.standard.document',
+  // Community calendar — a talk or presentation that names an eprint among its
+  // URIs is evidence the work was presented, and where.
+  'community.lexicon.calendar.event',
+] as const;
+
+/**
+ * Foreign collections whose volume makes observing them a capacity decision.
+ *
+ * @remarks
+ * Enabled by `FIREHOSE_OBSERVE_HIGH_VOLUME=true`. Off by default: a deployment
+ * should choose to read the whole Bluesky timeline rather than discover it did.
+ *
+ * @public
+ */
+export const OBSERVED_COLLECTIONS_HIGH_VOLUME: readonly string[] = ['app.bsky.feed.post'] as const;
+
+/**
+ * Reports whether a collection is one Chive observes for backlinks.
+ *
+ * @param collection - Collection NSID
+ * @param includeHighVolume - Whether the high-volume set is enabled
+ * @returns True when the collection should reach the plugin bus
+ *
+ * @public
+ */
+export function isObservedCollection(collection: string, includeHighVolume = false): boolean {
+  if (OBSERVED_COLLECTIONS.includes(collection)) {
+    return true;
+  }
+  return includeHighVolume && OBSERVED_COLLECTIONS_HIGH_VOLUME.includes(collection);
+}

--- a/src/services/indexing/indexing-service.ts
+++ b/src/services/indexing/indexing-service.ts
@@ -120,6 +120,16 @@ export interface IndexingServiceOptions {
   readonly collections?: readonly NSID[];
 
   /**
+   * Foreign collections to observe for the plugin bus.
+   *
+   * @remarks
+   * Passed to {@link EventFilter}. These are other applications' lexicons that
+   * Chive forwards to backlink plugins without indexing. See
+   * `OBSERVED_COLLECTIONS`.
+   */
+  readonly observedCollections?: readonly string[];
+
+  /**
    * Event processor function.
    *
    * @remarks
@@ -411,6 +421,7 @@ interface RelayConsumerState {
 export class IndexingService {
   private readonly relays: readonly string[];
   private readonly collections?: readonly NSID[];
+  private readonly observedCollections?: readonly string[];
   private readonly processor: EventProcessor;
   private readonly logger: ILogger;
 
@@ -444,6 +455,7 @@ export class IndexingService {
     this.relays = options.relays;
 
     this.collections = options.collections;
+    this.observedCollections = options.observedCollections;
     this.processor = options.processor;
     this.logger = options.logger;
 
@@ -519,6 +531,7 @@ export class IndexingService {
     // Initialize filter
     this.filter = new EventFilter({
       collections: this.collections,
+      ...(this.observedCollections ? { observedCollections: this.observedCollections } : {}),
       strictValidation: true,
     });
 
@@ -642,7 +655,11 @@ export class IndexingService {
     const events = state.consumer.subscribe({
       relay,
       cursor,
-      filter: this.collections ? { collections: this.collections } : undefined,
+      // The relay-side filter must cover the observed collections too, or they
+      // are dropped upstream and never reach the local EventFilter.
+      filter: this.collections
+        ? { collections: [...this.collections, ...(this.observedCollections ?? [])] as NSID[] }
+        : undefined,
     });
 
     state.connected = true;

--- a/src/storage/postgresql/migrations/1742200000000_leaflet-source-types.ts
+++ b/src/storage/postgresql/migrations/1742200000000_leaflet-source-types.ts
@@ -1,0 +1,91 @@
+/**
+ * Correct the backlink source types to the records that actually exist.
+ *
+ * @remarks
+ * `leaflet.list` corresponded to `xyz.leaflet.list`, an NSID that does not
+ * exist. Leaflet publishes `pub.leaflet.document` and `pub.leaflet.comment`,
+ * and the plugin now reads both.
+ *
+ * `standard.document` is added at the same time: a `site.standard.document`
+ * describing an eprint is a backlink, and it is also the mapping through which
+ * a standard.site recommend or an embedded document block resolves to the work
+ * it ultimately refers to.
+ *
+ * Production rows are unlikely to carry the old value, since the plugin that
+ * would have written it was never loaded and matched no record even when it
+ * was. Seeded test data does carry it, though, so the rewrite below is not
+ * hypothetical.
+ *
+ * Order matters: the constraint is dropped *before* the rows are rewritten.
+ * Updating first fails, because the old constraint still forbids the value
+ * being written.
+ *
+ * @packageDocumentation
+ */
+
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+const SOURCE_TYPES = [
+  'cosmik.collection',
+  'cosmik.connection',
+  'cosmik.follow',
+  'leaflet.document',
+  'leaflet.comment',
+  'standard.document',
+  'calendar.event',
+  'whitewind.blog',
+  'bluesky.post',
+  'bluesky.embed',
+  'chive.comment',
+  'chive.endorsement',
+  'margin.annotation',
+  'margin.highlight',
+  'margin.bookmark',
+  'other',
+];
+
+const PREVIOUS_SOURCE_TYPES = [
+  'cosmik.collection',
+  'cosmik.connection',
+  'cosmik.follow',
+  'leaflet.list',
+  'whitewind.blog',
+  'bluesky.post',
+  'bluesky.embed',
+  'chive.comment',
+  'chive.endorsement',
+  'margin.annotation',
+  'margin.highlight',
+  'margin.bookmark',
+  'other',
+];
+
+function quoted(values: readonly string[]): string {
+  return values.map((v) => `'${v}'`).join(', ');
+}
+
+export function up(pgm: MigrationBuilder): void {
+  // Drop first: the old constraint rejects the value the update writes.
+  pgm.sql(`ALTER TABLE backlinks DROP CONSTRAINT IF EXISTS backlinks_source_type_check`);
+
+  pgm.sql(
+    `UPDATE backlinks SET source_type = 'leaflet.document' WHERE source_type = 'leaflet.list'`
+  );
+  pgm.sql(`
+    ALTER TABLE backlinks
+    ADD CONSTRAINT backlinks_source_type_check
+    CHECK (source_type IN (${quoted(SOURCE_TYPES)}))
+  `);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.sql(`ALTER TABLE backlinks DROP CONSTRAINT IF EXISTS backlinks_source_type_check`);
+
+  pgm.sql(`UPDATE backlinks SET source_type = 'leaflet.list' WHERE source_type LIKE 'leaflet.%'`);
+
+  pgm.sql(`
+    ALTER TABLE backlinks
+    ADD CONSTRAINT backlinks_source_type_check
+    CHECK (source_type IN (${quoted(PREVIOUS_SOURCE_TYPES)}))
+  `);
+}

--- a/src/types/interfaces/plugin.interface.ts
+++ b/src/types/interfaces/plugin.interface.ts
@@ -1474,13 +1474,24 @@ export type BacklinkSourceType =
   | 'cosmik.collection'
   | 'cosmik.connection'
   | 'cosmik.follow'
-  | 'leaflet.list'
+  // Leaflet publishes `pub.leaflet.document` and `pub.leaflet.comment`; there
+  // is no list record type, and `leaflet.list` named an NSID that does not
+  // exist. No backlink was ever written with it, so nothing carries the old
+  // value.
+  | 'leaflet.document'
+  | 'leaflet.comment'
   | 'whitewind.blog'
   | 'bluesky.post'
   | 'bluesky.embed'
   | 'margin.annotation'
   | 'margin.highlight'
   | 'margin.bookmark'
+  // A `site.standard.document` describing an eprint. Also the mapping other
+  // references resolve through: a standard.site recommend and a Leaflet
+  // standardSitePost block both name a document rather than the work.
+  | 'standard.document'
+  // A talk or presentation that names an eprint among its URIs.
+  | 'calendar.event'
   | 'other';
 
 /**

--- a/src/types/models/eprint.ts
+++ b/src/types/models/eprint.ts
@@ -373,6 +373,10 @@ export type CodePlatform =
   | 'codeberg'
   | 'sourcehut'
   | 'software_heritage'
+  // Tangled hosts repositories as ATProto records (`sh.tangled.repo`), so one
+  // is addressable by AT-URI as well as by web URL. See `recordUri` on
+  // `#codeRepository`.
+  | 'tangled'
   | 'other';
 
 /**

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -157,11 +157,13 @@ test.describe('Authentication', () => {
     const signInPage = new SignInPage(page);
     await signInPage.goto();
 
-    // Form should have a visible label
-    const label = page.getByText('Handle or DID');
-    await expect(label).toBeVisible();
-
-    // Input should be visible and focusable
+    // Assert the association, not merely that the words appear somewhere:
+    // `getByLabel` only matches when the label is actually bound to the
+    // control, which is the property a screen reader depends on. The old
+    // `getByText('Handle or DID')` matched the label and the description
+    // both, and would have passed even while the input had no accessible
+    // name at all — which is exactly the state the page was in.
+    await expect(page.getByLabel('Handle or DID')).toBeVisible();
     await expect(signInPage.handleInput).toBeVisible();
 
     // Button should be focusable

--- a/tests/e2e/eprint/author-display.spec.ts
+++ b/tests/e2e/eprint/author-display.spec.ts
@@ -120,13 +120,14 @@ test.describe('Author Display - Badges and Indicators', () => {
       .or(page.locator('[data-testid="corresponding-badge"]'))
       .or(page.getByRole('img', { name: /corresponding/i }));
 
-    // May or may not be present depending on data
-    const isVisible = await correspondingBadge.isVisible({ timeout: 3000 }).catch(() => false);
-    // Just verify page loaded, badge is optional
-    expect(true).toBe(true);
+    // scripts/seed-test-data.ts sets isCorrespondingAuthor on the sole author
+    // of every seeded eprint, so this indicator is not optional and the test
+    // can assert it. It used to compute the visibility and discard the answer,
+    // so it passed whether or not the badge rendered.
+    await expect(correspondingBadge.first()).toBeVisible();
   });
 
-  test('displays highlighted author indicator (co-first)', async ({ page }) => {
+  test('shows no highlighted-author indicator when no author is highlighted', async ({ page }) => {
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
     // Look for highlighted author indicator
@@ -135,10 +136,11 @@ test.describe('Author Display - Badges and Indicators', () => {
       .or(page.locator('[data-testid="highlighted-badge"]'))
       .or(page.getByText(/\u2020/)); // Dagger symbol
 
-    // May or may not be present depending on data
-    const isVisible = await highlightedBadge.isVisible({ timeout: 3000 }).catch(() => false);
-    // Just verify page loaded, badge is optional
-    expect(true).toBe(true);
+    // The seed sets isHighlighted false on every author, so absence is what
+    // this page can assert — and it is worth asserting: a bug rendering the
+    // dagger unconditionally would mark every author co-first, which the
+    // previous form of this test could not have noticed.
+    await expect(highlightedBadge.first()).toBeHidden();
   });
 
   test('displays ORCID link when available', async ({ page }) => {
@@ -179,13 +181,13 @@ test.describe('Author Display - Contribution Types', () => {
 
       // Look for contribution types
       const contributions = page.getByText(/conceptualization|methodology|investigation|writing/i);
-      const isVisible = await contributions.isVisible({ timeout: 3000 }).catch(() => false);
-      // Just verify expansion works, contributions are optional
-      expect(true).toBe(true);
+      // The seeded authors carry an empty contributions array, so no CRediT
+      // role should appear. That catches an expansion rendering placeholders.
+      await expect(contributions.first()).toBeHidden();
     }
   });
 
-  test('displays contribution degree when available', async ({ page }) => {
+  test('shows no contribution degree when the author has no contributions', async ({ page }) => {
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
     // Look for contribution degrees (lead/equal/supporting)
@@ -193,13 +195,9 @@ test.describe('Author Display - Contribution Types', () => {
       has: page.locator('[data-testid="contribution-degree"]').or(page.locator('.contribution')),
     });
 
-    // May or may not be visible depending on data structure
-    const isVisible = await degrees
-      .first()
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-    // Just verify page loads, degrees are optional
-    expect(true).toBe(true);
+    // Same reasoning: with no contributions seeded, a degree chip appearing
+    // would be the page inventing data.
+    await expect(degrees.first()).toBeHidden();
   });
 });
 
@@ -212,10 +210,9 @@ test.describe('Author Display - External Authors', () => {
     // External authors (if any) should not have clickable links
     // This is tested implicitly - if no profile link, clicking does nothing
     const authorName = page.getByText(SEEDED_AUTHORS.white.displayName);
+    // The assertion above is the whole test: the seeded author renders by
+    // name. The trailing expect(true) added nothing.
     await expect(authorName).toBeVisible({ timeout: 10000 });
-
-    // Just verify page displays correctly
-    expect(true).toBe(true);
   });
 
   test('external authors can show ORCID even without DID', async ({ page }) => {
@@ -227,9 +224,9 @@ test.describe('Author Display - External Authors', () => {
       .getByRole('link', { name: /orcid/i })
       .or(page.locator('a[href*="orcid.org"]'));
 
-    // Optional - may or may not have external authors with ORCID
-    const isVisible = await orcidLink.isVisible({ timeout: 3000 }).catch(() => false);
-    expect(true).toBe(true);
+    // The seed gives this author an ORCID, so the link is not optional here.
+    await expect(orcidLink.first()).toBeVisible();
+    await expect(orcidLink.first()).toHaveAttribute('href', /orcid\.org/);
   });
 });
 

--- a/tests/e2e/fixtures/page-objects.ts
+++ b/tests/e2e/fixtures/page-objects.ts
@@ -247,8 +247,14 @@ export class SignInPage {
 
   constructor(page: Page) {
     this.page = page;
-    // The login form uses a handle/DID input (accessible name comes from placeholder)
-    this.handleInput = page.getByRole('textbox', { name: /bsky\.social/i });
+    // The field is labelled "Handle or DID", and that label is what gives the
+    // textbox its accessible name. The previous selector matched the
+    // placeholder instead, which said `bsky.social` and now says
+    // `yourhandle.example.com` — so it stopped matching, and every test that
+    // touched the sign-in form failed on a locator rather than on behaviour.
+    // A label is also the right thing to bind to: it is the accessible name a
+    // screen reader announces, where a placeholder is not.
+    this.handleInput = page.getByRole('textbox', { name: /handle or did/i });
     this.continueButton = page.getByRole('button', { name: /continue with at protocol/i });
     // Server-side errors shown in Alert (exclude Next.js route announcer)
     this.errorMessage = page.locator('[role="alert"]:not(#__next-route-announcer__)');

--- a/tests/e2e/governance/contribution-type-approval.spec.ts
+++ b/tests/e2e/governance/contribution-type-approval.spec.ts
@@ -158,9 +158,9 @@ trailer << /Size 4 /Root 1 0 R >>
       .getByText(/recently approved|just approved/i)
       .or(page.locator('[data-testid="recently-approved"]'));
 
-    // This may or may not be visible depending on test data
-    const isVisible = await recentlyApproved.isVisible({ timeout: 3000 }).catch(() => false);
-    expect(true).toBe(true); // Just verify page loads
+    // Whether anything was recently approved depends on test data, so that is
+    // not assertable. That the page rendered is.
+    await expect(page.getByRole('heading').first()).toBeVisible();
   });
 });
 

--- a/tests/e2e/governance/contribution-type-proposal.spec.ts
+++ b/tests/e2e/governance/contribution-type-proposal.spec.ts
@@ -322,9 +322,11 @@ test.describe('Contribution Type Proposals - Detail View', () => {
         .getByText(/external.*mapping|credit|cro|ontolog/i)
         .or(page.locator('[data-testid="external-mappings"]'));
 
-      // Mappings are optional
-      const isVisible = await mappingsSection.isVisible({ timeout: 3000 }).catch(() => false);
-      expect(true).toBe(true); // Just verify page loaded
+      // Mappings are genuinely optional, so their presence is not assertable.
+      // What is assertable is that following the link reached a proposal page
+      // rather than an error, which is what "verify page loaded" meant.
+      await expect(page).toHaveURL(/\/governance\/proposals\//);
+      await expect(page.getByRole('heading').first()).toBeVisible();
     }
   });
 });
@@ -356,18 +358,29 @@ test.describe('Contribution Type Proposals - Existing Types', () => {
       /supervision/i,
     ];
 
-    // At least one CRediT role should be visible if types are loaded
-    let foundRole = false;
+    // The loop used to compute `foundRole` and the assertion discarded it, so
+    // the test passed whether or not any CRediT role rendered.
+    let matched: RegExp | undefined;
     for (const role of creditRoles) {
-      const roleElement = page.getByText(role);
-      if (await roleElement.isVisible({ timeout: 1000 }).catch(() => false)) {
-        foundRole = true;
+      if (
+        await page
+          .getByText(role)
+          .first()
+          .isVisible({ timeout: 1000 })
+          .catch(() => false)
+      ) {
+        matched = role;
         break;
       }
     }
 
-    // If governance page shows types, at least one should be found
-    // (this may be 0 if types are on a different page)
-    expect(true).toBe(true);
+    // The governance page itself must render.
+    await expect(page.getByRole('heading').first()).toBeVisible();
+
+    // CRediT roles may legitimately live on a different page, so requiring one
+    // here would be wrong. Say so in the report rather than passing silently:
+    // a skip is visible, an unconditional pass is not.
+    test.skip(matched === undefined, 'No CRediT role is rendered on /governance');
+    await expect(page.getByText(matched!).first()).toBeVisible();
   });
 });

--- a/tests/e2e/governance/contribution-type-voting.spec.ts
+++ b/tests/e2e/governance/contribution-type-voting.spec.ts
@@ -154,9 +154,14 @@ test.describe('Contribution Type Voting - Cast Vote', () => {
           .getByText(/your vote|voted|already voted/i)
           .or(page.locator('[data-testid="user-vote"]'));
 
-        // May show auth prompt instead if not authenticated
-        const isVisible = await confirmation.isVisible({ timeout: 5000 }).catch(() => false);
-        expect(true).toBe(true); // Just verify interaction works
+        // After clicking, the page must land in one of the two states this
+        // test's own comment names: a vote confirmation, or a prompt to sign
+        // in. Anything else — a blank panel, an unhandled error — is a real
+        // failure the previous unconditional pass could not surface.
+        const authPrompt = page
+          .getByText(/sign in|log in|authentication required/i)
+          .or(page.getByRole('dialog'));
+        await expect(confirmation.first().or(authPrompt.first())).toBeVisible({ timeout: 5000 });
       }
     }
   });
@@ -227,9 +232,11 @@ test.describe('Contribution Type Voting - Duplicate Prevention', () => {
         .getByText(/you voted|your vote|voted/i)
         .or(page.locator('[data-testid="user-vote-indicator"]'));
 
-      // May or may not be visible depending on vote state
-      const isVisible = await votedIndicator.isVisible({ timeout: 3000 }).catch(() => false);
-      expect(true).toBe(true);
+      // Reaching the proposal page is the assertable outcome of following the
+      // link; the indicator depends on vote state, which this test does not
+      // control.
+      await expect(page).toHaveURL(/\/governance\/proposals\//);
+      await expect(page.getByRole('heading').first()).toBeVisible();
     }
   });
 
@@ -246,12 +253,20 @@ test.describe('Contribution Type Voting - Duplicate Prevention', () => {
       const approveButton = page.getByRole('button', { name: /approve/i });
       const rejectButton = page.getByRole('button', { name: /reject/i });
 
-      // Check if buttons exist and their state
-      const approveVisible = await approveButton.isVisible({ timeout: 3000 }).catch(() => false);
-      const rejectVisible = await rejectButton.isVisible({ timeout: 3000 }).catch(() => false);
+      // The two buttons are a pair: a proposal page offering one without the
+      // other is broken regardless of vote state. That is assertable where
+      // "are they disabled" is not, since this test does not control whether
+      // the user has already voted.
+      const approveVisible = await approveButton
+        .first()
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+      const rejectVisible = await rejectButton
+        .first()
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
 
-      // Buttons either don't exist, are disabled, or show "voted" state
-      expect(true).toBe(true);
+      expect(approveVisible).toBe(rejectVisible);
     }
   });
 
@@ -297,9 +312,12 @@ test.describe('Contribution Type Voting - Authentication', () => {
           .or(page.getByRole('dialog'))
           .or(page.locator('[data-testid="auth-required"]'));
 
-        // May show auth prompt or vote confirmation depending on auth state
-        const isVisible = await authPrompt.isVisible({ timeout: 5000 }).catch(() => false);
-        expect(true).toBe(true);
+        // Same two-state rule as above. Whichever branch the app takes, it
+        // must show one of them rather than swallowing the click.
+        const confirmation = page
+          .getByText(/your vote|voted|already voted/i)
+          .or(page.locator('[data-testid="user-vote"]'));
+        await expect(authPrompt.first().or(confirmation.first())).toBeVisible({ timeout: 5000 });
       }
     }
   });

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -28,8 +28,8 @@ test.describe('Home page', () => {
     await expect(landingPage.tagline).toContainText(/decentralized eprints/i);
   });
 
-  // Skip: Browse button not present during alpha - will be restored post-alpha
-  test.skip('displays browse eprints button', async ({ page }) => {
+  test('displays browse eprints button', async ({ page }) => {
+    test.skip(true, 'Browse button is not on the alpha landing page; restore post-alpha');
     const landingPage = new AlphaLandingPage(page);
     await landingPage.goto();
 
@@ -37,8 +37,8 @@ test.describe('Home page', () => {
     await expect(browseButton).toBeVisible();
   });
 
-  // Skip: Browse button not present during alpha - will be restored post-alpha
-  test.skip('browse button navigates to eprints page', async ({ page }) => {
+  test('browse button navigates to eprints page', async ({ page }) => {
+    test.skip(true, 'Browse button is not on the alpha landing page; restore post-alpha');
     const landingPage = new AlphaLandingPage(page);
     await landingPage.goto();
 
@@ -48,8 +48,8 @@ test.describe('Home page', () => {
     await expect(page).toHaveURL(/\/eprints/);
   });
 
-  // Skip: Submit CTA not present during alpha - will be restored post-alpha
-  test.skip('displays submit eprint CTA', async ({ page }) => {
+  test('displays submit eprint CTA', async ({ page }) => {
+    test.skip(true, 'Submit CTA is not on the alpha landing page; restore post-alpha');
     const landingPage = new AlphaLandingPage(page);
     await landingPage.goto();
 
@@ -61,8 +61,8 @@ test.describe('Home page', () => {
     await expect(submitButton).toBeVisible();
   });
 
-  // Skip: Features section not present during alpha - will be restored post-alpha
-  test.skip('displays features section with Why Chive heading', async ({ page }) => {
+  test('displays features section with Why Chive heading', async ({ page }) => {
+    test.skip(true, 'Features section is not on the alpha landing page; restore post-alpha');
     const landingPage = new AlphaLandingPage(page);
     await landingPage.goto();
 
@@ -70,8 +70,8 @@ test.describe('Home page', () => {
     await expect(featuresHeading).toBeVisible();
   });
 
-  // Skip: Feature cards not present during alpha - will be restored post-alpha
-  test.skip('displays feature cards', async ({ page }) => {
+  test('displays feature cards', async ({ page }) => {
+    test.skip(true, 'Feature cards are not on the alpha landing page; restore post-alpha');
     const landingPage = new AlphaLandingPage(page);
     await landingPage.goto();
 
@@ -127,8 +127,21 @@ test.describe('Home page', () => {
     const landingPage = new AlphaLandingPage(page);
     await landingPage.goto();
 
-    const signInButton = page.getByRole('button', { name: /sign in with bluesky/i });
+    // The button says ATProto, not Bluesky: Chive signs in any ATProto
+    // identity, and naming one PDS operator in the button was wrong about the
+    // product as well as about the markup.
+    const signInButton = page.getByRole('button', { name: /sign in with atproto/i });
     await expect(signInButton).toBeVisible();
+  });
+
+  test('offers a handle field to sign in with', async ({ page }) => {
+    const landingPage = new AlphaLandingPage(page);
+    await landingPage.goto();
+
+    // Sign-in begins by resolving a handle. Nothing covered that this field
+    // renders, and it is the first thing a user touches.
+    const handleInput = page.getByRole('textbox');
+    await expect(handleInput.first()).toBeVisible();
   });
 
   test('displays external links', async ({ page }) => {
@@ -143,8 +156,9 @@ test.describe('Home page', () => {
     const githubLink = page.getByRole('link', { name: /github/i });
     await expect(githubLink).toBeVisible();
 
-    // Check for Bluesky link
-    const blueskyLink = page.getByRole('link', { name: /bluesky/i });
-    await expect(blueskyLink).toBeVisible();
+    // The third link is ATProto. There is no Bluesky link on this page, and
+    // asserting one had been failing rather than protecting anything.
+    const atprotoLink = page.getByRole('link', { name: /^atproto$/i });
+    await expect(atprotoLink).toBeVisible();
   });
 });

--- a/tests/e2e/submission/paper-centric-submission.spec.ts
+++ b/tests/e2e/submission/paper-centric-submission.spec.ts
@@ -31,10 +31,12 @@ test.describe('Paper-Centric Submission - Display', () => {
       .locator('[data-testid="paper-identity"]')
       .or(page.getByText(/paper account|paper identity/i));
 
-    // May or may not be visible depending on whether seeded data has paperDid
-    const isVisible = await paperIdentity.isVisible({ timeout: 3000 }).catch(() => false);
-    // Paper-centric is optional, so just verify page loads
-    expect(true).toBe(true);
+    // scripts/seed-test-data.ts sets no paperDid on any eprint, so every
+    // seeded submission is traditional and the badge must be absent. That is
+    // worth asserting: showing a paper-identity badge on a submission that has
+    // no paper account would misattribute the work, and the previous form of
+    // this test passed either way.
+    await expect(paperIdentity.first()).toBeHidden();
   });
 
   test('shows "Submitted by" separately from paper identity', async ({ page }) => {
@@ -60,9 +62,9 @@ test.describe('Paper-Centric Submission - Display', () => {
       .locator('a[href*="/papers/"]')
       .or(page.getByRole('link', { name: /view paper profile/i }));
 
-    // Only present for paper-centric submissions
-    const isVisible = await paperProfileLink.isVisible({ timeout: 3000 }).catch(() => false);
-    expect(true).toBe(true);
+    // Same reasoning: no seeded eprint is paper-centric, so a link to a paper
+    // profile would point at something that does not exist.
+    await expect(paperProfileLink.first()).toBeHidden();
   });
 });
 
@@ -92,9 +94,10 @@ test.describe('Paper-Centric Submission - Blob Fetching', () => {
       .getByText(/supplementary|additional files/i)
       .or(page.locator('[data-testid="supplementary-files"]'));
 
-    // Supplementary files are optional
-    const isVisible = await supplementary.isVisible({ timeout: 3000 }).catch(() => false);
-    expect(true).toBe(true);
+    // No supplementary materials are seeded, so the panel should not render.
+    // SupplementaryPanel returns null when it has nothing to show, and this
+    // catches a regression that renders an empty one.
+    await expect(supplementary.first()).toBeHidden();
   });
 });
 
@@ -125,10 +128,9 @@ test.describe('Paper-Centric vs Traditional - Detection', () => {
       .locator('[data-testid="paper-identity-badge"]')
       .or(page.getByText(/paper account/i));
 
-    const isPaperCentric = await paperIdentityBadge.isVisible({ timeout: 3000 }).catch(() => false);
-
-    // Either way is valid - just verify the page handles both
-    expect(true).toBe(true);
+    // The seeded eprints are all traditional, so this resolves to the
+    // traditional branch rather than "either way is valid".
+    await expect(paperIdentityBadge.first()).toBeHidden();
   });
 
   test('shows submitter for both paper-centric and traditional', async ({ page }) => {

--- a/tests/pre-deployment/job-verification.test.ts
+++ b/tests/pre-deployment/job-verification.test.ts
@@ -29,30 +29,29 @@ describe('Pre-Deployment Job Verification', () => {
   // ===========================================================================
 
   describe('Job Module Imports', () => {
-    it('governance-sync-job module exports correctly', () => {
-      expect(GovernanceSyncJob).toBeDefined();
-      // Check for expected exports (adjust based on actual exports)
-      expect(typeof GovernanceSyncJob).toBe('object');
+    // `typeof <namespace import>` is 'object' for every module that loads at
+    // all, so the previous form of these could not fail — including when a job
+    // class was renamed or removed. Each case now names the export the caller
+    // in src/index.ts or src/indexer.ts actually constructs, and checks it is
+    // a constructor, which is the property that makes the module usable.
+    const jobExports: [string, string, Record<string, unknown>][] = [
+      ['governance-sync-job', 'GovernanceSyncJob', GovernanceSyncJob],
+      ['graph-algorithm-job', 'GraphAlgorithmJob', GraphAlgorithmJob],
+      ['freshness-scan-job', 'FreshnessScanJob', FreshnessScanJob],
+      ['pds-scan-scheduler-job', 'PDSScanSchedulerJob', PdsScanSchedulerJob],
+      ['tag-sync-job', 'TagSyncJob', TagSyncJob],
+    ];
+
+    it.each(jobExports)('%s exports the %s class', (_module, exportName, namespace) => {
+      expect(namespace[exportName], `${exportName} is not exported`).toBeDefined();
+      expect(typeof namespace[exportName]).toBe('function');
+      expect((namespace[exportName] as { prototype?: unknown }).prototype).toBeDefined();
     });
 
-    it('graph-algorithm-job module exports correctly', () => {
-      expect(GraphAlgorithmJob).toBeDefined();
-      expect(typeof GraphAlgorithmJob).toBe('object');
-    });
-
-    it('freshness-scan-job module exports correctly', () => {
-      expect(FreshnessScanJob).toBeDefined();
-      expect(typeof FreshnessScanJob).toBe('object');
-    });
-
-    it('pds-scan-scheduler-job module exports correctly', () => {
-      expect(PdsScanSchedulerJob).toBeDefined();
-      expect(typeof PdsScanSchedulerJob).toBe('object');
-    });
-
-    it('tag-sync-job module exports correctly', () => {
-      expect(TagSyncJob).toBeDefined();
-      expect(typeof TagSyncJob).toBe('object');
+    it('graph-algorithm-job exports the scheduler src/index.ts calls', () => {
+      // The job is only reachable through this factory; without it the
+      // community and trending caches have no producer.
+      expect(typeof GraphAlgorithmJob.createGraphAlgorithmJobScheduler).toBe('function');
     });
   });
 
@@ -61,14 +60,19 @@ describe('Pre-Deployment Job Verification', () => {
   // ===========================================================================
 
   describe('Worker Module Imports', () => {
-    it('index-retry-worker module exports correctly', () => {
-      expect(IndexRetryWorker).toBeDefined();
-      expect(typeof IndexRetryWorker).toBe('object');
+    const workerExports: [string, string, Record<string, unknown>][] = [
+      ['index-retry-worker', 'IndexRetryWorker', IndexRetryWorker],
+      ['freshness-worker', 'FreshnessWorker', FreshnessWorker],
+    ];
+
+    it.each(workerExports)('%s exports the %s class', (_module, exportName, namespace) => {
+      expect(namespace[exportName], `${exportName} is not exported`).toBeDefined();
+      expect(typeof namespace[exportName]).toBe('function');
+      expect((namespace[exportName] as { prototype?: unknown }).prototype).toBeDefined();
     });
 
-    it('freshness-worker module exports correctly', () => {
-      expect(FreshnessWorker).toBeDefined();
-      expect(typeof FreshnessWorker).toBe('object');
+    it('freshness-worker exports its queue factory', () => {
+      expect(typeof FreshnessWorker.createFreshnessQueue).toBe('function');
     });
   });
 

--- a/tests/unit/api/handlers/admin-trigger-signals.test.ts
+++ b/tests/unit/api/handlers/admin-trigger-signals.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for admin trigger endpoints.
+ *
+ * @remarks
+ * `BackfillManager.startOperation` returns `{operation, signal}`. Handlers that
+ * run work in the background must read the signal: an admin who cancels an
+ * operation expects it to stop, and a handler that ignores it runs to
+ * completion and then reports success against an operation the admin cancelled.
+ *
+ * These read the source rather than executing the handlers, because what is
+ * being asserted is that the signal is consulted at all — a property of the
+ * code, and one that a mocked run can satisfy without meaning anything.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const ADMIN_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  '..',
+  'src',
+  'api',
+  'handlers',
+  'xrpc',
+  'admin'
+);
+
+function source(name: string): string {
+  return readFileSync(join(ADMIN_DIR, `${name}.ts`), 'utf8');
+}
+
+/** Handlers that start an operation and then do work in the background. */
+const BACKGROUND_HANDLERS = [
+  'triggerCitationExtraction',
+  'triggerFreshnessScan',
+  'triggerGovernanceSync',
+  'triggerDIDSync',
+];
+
+describe('admin trigger handlers honour cancellation', () => {
+  it.each(BACKGROUND_HANDLERS)('%s takes the abort signal', (name) => {
+    expect(source(name)).toMatch(/const \{ operation, signal \}/);
+  });
+
+  it.each(BACKGROUND_HANDLERS)('%s actually reads the signal', (name) => {
+    // Destructuring it and never checking it is the same bug wearing a
+    // different shape.
+    expect(source(name)).toMatch(/signal\.aborted/);
+  });
+
+  it('every handler that destructures an operation also takes the signal', () => {
+    // Catches a new handler added in the old shape.
+    const offenders = readdirSync(ADMIN_DIR)
+      .filter((f) => f.endsWith('.ts'))
+      .filter((f) => readFileSync(join(ADMIN_DIR, f), 'utf8').includes('const { operation }'));
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('triggerBackfill', () => {
+  const contents = source('triggerBackfill');
+
+  it('does not start an operation it has no way to run', () => {
+    // It used to call startOperation and return, leaving an operation pending
+    // forever: an admin saw a backfill start and never finish.
+    expect(contents).not.toMatch(/backfillManager\.startOperation/);
+  });
+
+  it('names the endpoint that does the work instead', () => {
+    expect(contents).toMatch(/pub\.chive\.admin\.triggerFullReindex/);
+    expect(contents).toMatch(/pub\.chive\.admin\.triggerPDSScan/);
+  });
+});

--- a/tests/unit/api/handlers/rest/well-known.test.ts
+++ b/tests/unit/api/handlers/rest/well-known.test.ts
@@ -33,50 +33,68 @@ describe('well-known endpoints', () => {
   });
 
   describe('GET /.well-known/site.standard.publication', () => {
-    it('returns AT-URI pointing to publication record', async () => {
-      process.env.CHIVE_SERVICE_DID = 'did:web:test.chive.pub';
+    // These used to assert the endpoint always answered
+    // `at://<serviceDid>/site.standard.publication/self`. That URI could not
+    // resolve for two independent reasons: no publication record exists in the
+    // service repository, and `self` is not a legal rkey for a lexicon whose
+    // key is `tid`. A reader following it saw a broken publication rather than
+    // an unconfigured one, so the endpoint now reports honestly.
+
+    it('returns the configured publication URI', async () => {
+      process.env.CHIVE_PUBLICATION_URI =
+        'at://did:web:test.chive.pub/site.standard.publication/3l';
 
       const res = await app.request('/.well-known/site.standard.publication');
 
       expect(res.status).toBe(200);
-      const text = await res.text();
-      expect(text).toBe('at://did:web:test.chive.pub/site.standard.publication/self');
+      expect(await res.text()).toBe('at://did:web:test.chive.pub/site.standard.publication/3l');
     });
 
-    it('uses default DID when env not set', async () => {
-      delete process.env.CHIVE_SERVICE_DID;
+    it('answers 404 when no publication record is configured', async () => {
+      delete process.env.CHIVE_PUBLICATION_URI;
 
       const res = await app.request('/.well-known/site.standard.publication');
 
-      expect(res.status).toBe(200);
-      const text = await res.text();
-      expect(text).toBe('at://did:web:chive.pub/site.standard.publication/self');
+      expect(res.status).toBe(404);
+    });
+
+    it('does not invent a URI from the service DID', async () => {
+      // The old behaviour: a service DID alone was enough to advertise a
+      // record. It is not — the record has to exist.
+      process.env.CHIVE_SERVICE_DID = 'did:web:test.chive.pub';
+      delete process.env.CHIVE_PUBLICATION_URI;
+
+      const res = await app.request('/.well-known/site.standard.publication');
+
+      expect(res.status).toBe(404);
+      expect(await res.text()).not.toContain('at://');
     });
 
     it('returns plain text content type', async () => {
+      process.env.CHIVE_PUBLICATION_URI =
+        'at://did:web:test.chive.pub/site.standard.publication/3l';
+
       const res = await app.request('/.well-known/site.standard.publication');
 
-      expect(res.status).toBe(200);
-      expect(res.headers.get('Content-Type')).toContain('text/plain');
+      expect(res.headers.get('content-type')).toContain('text/plain');
     });
 
-    it('sets cache control header', async () => {
+    it('sets cache control header when it has something to advertise', async () => {
+      process.env.CHIVE_PUBLICATION_URI =
+        'at://did:web:test.chive.pub/site.standard.publication/3l';
+
       const res = await app.request('/.well-known/site.standard.publication');
 
-      expect(res.status).toBe(200);
-      const cacheControl = res.headers.get('Cache-Control');
-      expect(cacheControl).toContain('public');
-      expect(cacheControl).toContain('max-age=86400');
+      expect(res.headers.get('cache-control')).toContain('max-age');
     });
 
-    it('handles did:plc format', async () => {
-      process.env.CHIVE_SERVICE_DID = 'did:plc:abc123xyz';
+    it('does not cache the unconfigured answer', async () => {
+      // Caching a 404 for a day would outlast the deployment that fixes it.
+      delete process.env.CHIVE_PUBLICATION_URI;
 
       const res = await app.request('/.well-known/site.standard.publication');
 
-      expect(res.status).toBe(200);
-      const text = await res.text();
-      expect(text).toBe('at://did:plc:abc123xyz/site.standard.publication/self');
+      expect(res.headers.get('cache-control')).toBeNull();
     });
   });
 });

--- a/tests/unit/api/handlers/xrpc/admin.test.ts
+++ b/tests/unit/api/handlers/xrpc/admin.test.ts
@@ -1692,39 +1692,48 @@ describe('XRPC Admin Handlers', () => {
       ).rejects.toThrow(ServiceUnavailableError);
     });
 
-    it('starts operation with type and metadata', async () => {
-      const result = await triggerBackfill.handler({
-        params: undefined,
-        input: { type: 'fullReindex' },
-        auth: null,
-        c: mockContext as never,
-      });
-      expect(mockBackfillManager.startOperation).toHaveBeenCalledWith('fullReindex', {
-        startedBy: ADMIN_DID,
-      });
-      expect(result.body).toHaveProperty('operation');
+    // These two used to assert the handler called `startOperation` and returned
+    // the operation. It did — and then nothing ran it, so the operation stayed
+    // pending forever and an admin saw a backfill that never finished. The
+    // handler now names the endpoint that does the work instead, which is a
+    // behaviour change worth pinning rather than a regression to route around.
+
+    it('does not start an operation it cannot run', async () => {
+      await expect(
+        triggerBackfill.handler({
+          params: undefined,
+          input: { type: 'fullReindex' },
+          auth: null,
+          c: mockContext as never,
+        })
+      ).rejects.toThrow(/triggerFullReindex/);
+
+      expect(mockBackfillManager.startOperation).not.toHaveBeenCalled();
     });
 
-    it('accepts all valid backfill types', async () => {
-      const validTypes = [
-        'pdsScan',
-        'freshnessScan',
-        'citationExtraction',
-        'fullReindex',
-        'governanceSync',
-        'didSync',
-      ];
-      for (const type of validTypes) {
+    it('names the dedicated endpoint for every valid type', async () => {
+      const expected: Record<string, string> = {
+        pdsScan: 'triggerPDSScan',
+        freshnessScan: 'triggerFreshnessScan',
+        citationExtraction: 'triggerCitationExtraction',
+        fullReindex: 'triggerFullReindex',
+        governanceSync: 'triggerGovernanceSync',
+        didSync: 'triggerDIDSync',
+      };
+
+      for (const [type, endpoint] of Object.entries(expected)) {
         vi.clearAllMocks();
         mockBackfillManager = createMockBackfillManager();
         mockContext = buildContext(adminUser);
-        await triggerBackfill.handler({
-          params: undefined,
-          input: { type },
-          auth: null,
-          c: mockContext as never,
-        });
-        expect(mockBackfillManager.startOperation).toHaveBeenCalledWith(type, expect.any(Object));
+
+        await expect(
+          triggerBackfill.handler({
+            params: undefined,
+            input: { type },
+            auth: null,
+            c: mockContext as never,
+          })
+        ).rejects.toThrow(new RegExp(endpoint));
       }
     });
   });

--- a/tests/unit/config/governance-did-validity.test.ts
+++ b/tests/unit/config/governance-did-validity.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests that no configuration carries an invalid governance DID.
+ *
+ * @remarks
+ * `did:plc:chive-governance` reads like an identifier and is not one: a PLC DID
+ * is `did:plc:` followed by 24 base32 characters. It resolved to nothing, so
+ * the governance sync imported an empty graph.
+ *
+ * 0.10.0 corrected the environment files and made an ill-formed value fail at
+ * startup. It missed `k8s/helm/chive/values.yaml`, which a Helm deployment
+ * would still have carried — the startup check would then have refused to boot,
+ * turning a silent empty graph into a crash loop. This sweeps every config
+ * rather than the ones someone thought of.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+/** A PLC DID is `did:plc:` plus 24 base32 characters. */
+const PLC_DID = /^did:plc:[a-z2-7]{24}$/;
+
+function configFiles(): string[] {
+  // Tracked files only; node_modules and build output are not configuration.
+  const listed = execFileSync('git', ['ls-files'], { cwd: REPO_ROOT, encoding: 'utf8' });
+  return listed
+    .split('\n')
+    .filter(Boolean)
+    .filter((f) => /\.(ya?ml|env|example|json)$/.test(f) || f.includes('.env'))
+    .filter((f) => !f.startsWith('web/tests/') && !f.startsWith('tests/'));
+}
+
+describe('governance PDS DID', () => {
+  it('is a well-formed PLC identifier where it is set', () => {
+    expect(PLC_DID.test('did:plc:5wzpn4a4nbqtz3q45hyud6hd')).toBe(true);
+    expect(PLC_DID.test('did:plc:chive-governance')).toBe(false);
+  });
+
+  it('is not set to the invalid literal in any configuration', () => {
+    // Comment lines are skipped on purpose: a config explaining why the value
+    // used to be wrong is doing the reader a favour, and should not be the
+    // thing that fails this test. Only a live setting counts.
+    const offenders = configFiles().filter((file) => {
+      const contents = readFileSync(join(REPO_ROOT, file), 'utf8');
+      return contents
+        .split('\n')
+        .filter((line) => !/^\s*[#/]/.test(line))
+        .some((line) => line.includes('did:plc:chive-governance'));
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/config/tangled-code-platform.test.ts
+++ b/tests/unit/config/tangled-code-platform.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for Tangled as a linked code artifact.
+ *
+ * @remarks
+ * Tangled hosts git repositories as ATProto records (`sh.tangled.repo`), so a
+ * repository there is addressable by AT-URI and not only by web URL. Chive's
+ * platform vocabulary previously named only web-hosted forges, which meant a
+ * Tangled repository could be recorded as a URL and nothing more — losing the
+ * fact that it is a record on the same network as the eprint citing it.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+const submission = JSON.parse(
+  readFileSync(join(REPO_ROOT, 'lexicons/pub/chive/eprint/submission.json'), 'utf8')
+) as {
+  defs: {
+    codeRepository: {
+      properties: Record<string, { format?: string; knownValues?: string[] }>;
+    };
+  };
+};
+
+const codeRepository = submission.defs.codeRepository;
+
+describe('Tangled as a code platform', () => {
+  it('is one of the known platform slugs', () => {
+    expect(codeRepository.properties.platformSlug?.knownValues).toContain('tangled');
+  });
+
+  it('does not displace the forges already known', () => {
+    const slugs = codeRepository.properties.platformSlug?.knownValues ?? [];
+    for (const existing of ['github', 'gitlab', 'codeberg', 'sourcehut', 'software_heritage']) {
+      expect(slugs).toContain(existing);
+    }
+  });
+
+  it('a code repository can be addressed by AT-URI', () => {
+    // The point of the change: `url` addresses a repository at one web host,
+    // `recordUri` addresses the record on the network, which survives that host
+    // moving or disappearing.
+    expect(codeRepository.properties.recordUri).toBeDefined();
+    expect(codeRepository.properties.recordUri?.format).toBe('at-uri');
+  });
+
+  it('keeps the web URL, since most forges are not on ATProto', () => {
+    expect(codeRepository.properties.url).toBeDefined();
+  });
+});
+
+describe('the frontend knows how to label Tangled', () => {
+  it('has a platform entry, so a Tangled repo does not render unlabelled', () => {
+    const panel = readFileSync(
+      join(REPO_ROOT, 'web/components/eprints/repositories-panel.tsx'),
+      'utf8'
+    );
+    expect(panel).toMatch(/tangled:\s*\{/);
+    expect(panel).toMatch(/label: 'Tangled'/);
+  });
+});

--- a/tests/unit/mcp/server.test.ts
+++ b/tests/unit/mcp/server.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the Chive MCP server.
+ *
+ * @remarks
+ * The server is a thin adapter over the public XRPC API: it holds no
+ * credentials, reaches no database, and exposes only read operations. These
+ * tests pin that shape — an agent-facing surface that could write, or that
+ * needed a session, would be a different and much more dangerous thing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { callXrpc, createChiveMcpServer, DEFAULT_API_URL } from '../../../src/mcp/server.js';
+
+const originalFetch = global.fetch;
+
+describe('callXrpc', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('calls the named method on the configured deployment', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({ found: false }) });
+    global.fetch = fetchMock as never;
+
+    await callXrpc('https://api.example.test', 'pub.chive.resolve.byExternalId', {
+      system: 'doi',
+      identifier: '10.1000/abc',
+    });
+
+    const url = (fetchMock.mock.calls[0] as [URL])[0];
+    expect(url.origin + url.pathname).toBe(
+      'https://api.example.test/xrpc/pub.chive.resolve.byExternalId'
+    );
+    expect(url.searchParams.get('system')).toBe('doi');
+    expect(url.searchParams.get('identifier')).toBe('10.1000/abc');
+  });
+
+  it('does not double the slash when the base URL has a trailing one', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    global.fetch = fetchMock as never;
+
+    await callXrpc('https://api.example.test/', 'pub.chive.eprint.getSubmission', {
+      uri: 'at://x',
+    });
+
+    const url = (fetchMock.mock.calls[0] as [URL])[0];
+    expect(url.pathname).toBe('/xrpc/pub.chive.eprint.getSubmission');
+  });
+
+  it('omits parameters that were not supplied', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    global.fetch = fetchMock as never;
+
+    await callXrpc('https://api.example.test', 'pub.chive.eprint.searchSubmissions', {
+      q: 'semantics',
+      limit: undefined,
+    });
+
+    const url = (fetchMock.mock.calls[0] as [URL])[0];
+    expect(url.searchParams.has('limit')).toBe(false);
+  });
+
+  it('reports the failing method in the error, since that is what the agent sees', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ message: 'Invalid identifier' }),
+    }) as never;
+
+    await expect(
+      callXrpc('https://api.example.test', 'pub.chive.resolve.byExternalId', {})
+    ).rejects.toThrow(/pub\.chive\.resolve\.byExternalId failed \(400\): Invalid identifier/);
+  });
+
+  it('still reports usefully when the error body is not JSON', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: () => Promise.reject(new Error('not json')),
+    }) as never;
+
+    await expect(
+      callXrpc('https://api.example.test', 'pub.chive.eprint.getSubmission', {})
+    ).rejects.toThrow(/502/);
+  });
+
+  it('clears its timeout when a call settles', async () => {
+    // Otherwise every tool call leaves a live 15-second timer behind.
+    const clearSpy = vi.spyOn(global, 'clearTimeout');
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as never;
+
+    await callXrpc('https://api.example.test', 'pub.chive.eprint.getSubmission', {});
+
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});
+
+describe('createChiveMcpServer', () => {
+  it('builds against the production deployment by default', () => {
+    expect(DEFAULT_API_URL).toBe('https://api.chive.pub');
+  });
+
+  it('constructs without credentials of any kind', () => {
+    // The point of the design: it reads what a browser could read, so there is
+    // no session for an agent to borrow.
+    expect(() => createChiveMcpServer('https://api.example.test')).not.toThrow();
+  });
+});

--- a/tests/unit/plugins/builtin/backlink-collection-nsids.test.ts
+++ b/tests/unit/plugins/builtin/backlink-collection-nsids.test.ts
@@ -42,13 +42,26 @@ describe('WhiteWind backlink plugin', () => {
 describe('Leaflet backlink plugin', () => {
   const contents = source('leaflet-backlinks');
 
-  // Kept pointing at the fictional NSID on purpose; see the file header.
-  it('still tracks the fictional collection', () => {
-    expect(contents).toMatch(/trackedCollection = 'xyz\.leaflet\.list'/);
+  // This used to assert the plugin still pointed at `xyz.leaflet.list`, an
+  // NSID Leaflet does not publish, because pointing it at a real collection
+  // while its parser expected an invented shape would have produced wrong
+  // backlinks rather than none. The schemas are now vendored under
+  // `lexicons/pub/leaflet/`, taken from Leaflet's own lexicon repository, and
+  // the parser is written against them — so the reason for staying wrong is
+  // gone, and these assert the collections Leaflet actually publishes.
+  it('tracks pub.leaflet.document', () => {
+    expect(contents).toMatch(/trackedCollection = 'pub\.leaflet\.document'/);
   });
 
-  it('says plainly that the collection does not exist', () => {
-    expect(contents).toMatch(/does not exist/);
-    expect(contents).toMatch(/pub\.leaflet\.document/);
+  it('also subscribes to pub.leaflet.comment', () => {
+    // A comment names its subject directly, which is the most reliable
+    // reference of the four routes.
+    expect(contents).toMatch(/firehose\.pub\.leaflet\.comment/);
+  });
+
+  it('no longer mentions the fictional collection except as history', () => {
+    // One reference survives, in the header explaining what was wrong.
+    const occurrences = contents.match(/xyz\.leaflet\.list/g) ?? [];
+    expect(occurrences).toHaveLength(1);
   });
 });

--- a/tests/unit/plugins/builtin/calendar-events.test.ts
+++ b/tests/unit/plugins/builtin/calendar-events.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the calendar event backlinks plugin.
+ *
+ * @remarks
+ * A `community.lexicon.calendar.event` names associated URIs, and one of them
+ * may be an eprint — a talk about that paper. The schema is vendored at
+ * `lexicons/vendor/community/calendar/event.json`; these fixtures follow it.
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+
+import {
+  CalendarEventsPlugin,
+  eventDate,
+} from '../../../../src/plugins/builtin/calendar-events.js';
+
+const EPRINT = 'at://did:plc:author/pub.chive.eprint.submission/abc123';
+
+const plugin = new CalendarEventsPlugin();
+
+const internals = plugin as unknown as {
+  extractContext(record: unknown): string | undefined;
+  shouldProcess(record: unknown): boolean;
+};
+
+describe('CalendarEventsPlugin', () => {
+  it('tracks the community calendar collection', () => {
+    expect(plugin.trackedCollection).toBe('community.lexicon.calendar.event');
+  });
+
+  describe('extractEprintRefs', () => {
+    it('finds an eprint among the event URIs', () => {
+      const event = {
+        name: 'ATScience workshop',
+        uris: [{ uri: 'https://example.org/schedule' }, { uri: EPRINT, name: 'The paper' }],
+      };
+      expect(plugin.extractEprintRefs(event)).toEqual([EPRINT]);
+    });
+
+    it('reports an eprint once when it is listed twice', () => {
+      const event = { name: 'A talk', uris: [{ uri: EPRINT }, { uri: EPRINT }] };
+      expect(plugin.extractEprintRefs(event)).toEqual([EPRINT]);
+    });
+
+    it('ignores URIs that are not eprints', () => {
+      const event = {
+        name: 'A talk',
+        uris: [{ uri: 'https://example.org' }, { uri: 'at://did:plc:x/app.bsky.feed.post/1' }],
+      };
+      expect(plugin.extractEprintRefs(event)).toEqual([]);
+    });
+
+    it('survives an event with no URIs', () => {
+      expect(plugin.extractEprintRefs({ name: 'A talk' })).toEqual([]);
+    });
+
+    it('survives a malformed URI entry', () => {
+      expect(plugin.extractEprintRefs({ name: 'A talk', uris: [{}, { uri: null }] })).toEqual([]);
+    });
+
+    it('survives values that are not records', () => {
+      for (const value of [null, undefined, 'a string', 5]) {
+        expect(plugin.extractEprintRefs(value)).toEqual([]);
+      }
+    });
+  });
+
+  describe('shouldProcess', () => {
+    it('records a scheduled event', () => {
+      expect(internals.shouldProcess({ name: 'A talk', status: 'scheduled' })).toBe(true);
+    });
+
+    it('records an event with no status', () => {
+      expect(internals.shouldProcess({ name: 'A talk' })).toBe(true);
+    });
+
+    it('skips a cancelled event', () => {
+      // A cancelled talk is not evidence the paper was presented.
+      expect(internals.shouldProcess({ name: 'A talk', status: 'cancelled' })).toBe(false);
+    });
+
+    it('skips a postponed event', () => {
+      expect(internals.shouldProcess({ name: 'A talk', status: 'postponed' })).toBe(false);
+    });
+
+    it('handles the ref form of a status value', () => {
+      // The lexicon expresses status as `#cancelled`.
+      expect(
+        internals.shouldProcess({
+          name: 'A talk',
+          status: 'community.lexicon.calendar.event#cancelled',
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('extractContext', () => {
+    it('names the event and its date', () => {
+      expect(
+        internals.extractContext({ name: 'ATScience workshop', startsAt: '2026-10-12T09:00:00Z' })
+      ).toBe('ATScience workshop (12 October 2026)');
+    });
+
+    it('names the event alone when it has no date', () => {
+      expect(internals.extractContext({ name: 'A reading group' })).toBe('A reading group');
+    });
+
+    it('returns nothing for an event with no name', () => {
+      expect(internals.extractContext({ startsAt: '2026-10-12T09:00:00Z' })).toBeUndefined();
+    });
+  });
+});
+
+describe('eventDate', () => {
+  it('formats a timestamp as a readable date', () => {
+    expect(eventDate('2026-10-12T09:00:00Z')).toBe('12 October 2026');
+  });
+
+  it('uses UTC, so an evening event does not shift a day', () => {
+    expect(eventDate('2026-10-12T23:30:00Z')).toBe('12 October 2026');
+  });
+
+  it('returns nothing for a malformed timestamp', () => {
+    // The record comes from another repository; "Invalid Date" must not reach
+    // a backlink's context string.
+    expect(eventDate('not-a-date')).toBeUndefined();
+  });
+
+  it('returns nothing when there is no timestamp', () => {
+    expect(eventDate(undefined)).toBeUndefined();
+  });
+});

--- a/tests/unit/plugins/builtin/leaflet-backlinks.test.ts
+++ b/tests/unit/plugins/builtin/leaflet-backlinks.test.ts
@@ -8,7 +8,6 @@ import 'reflect-metadata';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { LeafletBacklinksPlugin } from '../../../../src/plugins/builtin/leaflet-backlinks.js';
-import type { FirehoseRecord } from '../../../../src/plugins/core/backlink-plugin.js';
 import type { ILogger } from '../../../../src/types/interfaces/logger.interface.js';
 import type {
   ICacheProvider,
@@ -63,8 +62,8 @@ const createMockEventBus = (): IPluginEventBus => ({
 const createMockBacklinkService = (): IBacklinkService => ({
   createBacklink: vi.fn().mockResolvedValue({
     id: 1,
-    sourceUri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-    sourceType: 'leaflet.list',
+    sourceUri: 'at://did:plc:user/pub.leaflet.document/abc123',
+    sourceType: 'leaflet.document',
     targetUri: 'at://did:plc:author/pub.chive.eprint.submission/xyz789',
     indexedAt: new Date(),
     deleted: false,
@@ -95,651 +94,291 @@ const createMockContext = (overrides?: Partial<IPluginContext>): IPluginContext 
 
 // ============================================================================
 // Sample Data
+//
+// Shaped to the vendored lexicons under `lexicons/pub/leaflet/`, which come
+// from Leaflet's own repository. The previous fixtures were built on
+// `xyz.leaflet.list`, an NSID Leaflet does not publish.
 // ============================================================================
 
-/**
- * Sample Leaflet reading list with eprints.
- */
-const SAMPLE_LEAFLET_LIST = {
-  $type: 'xyz.leaflet.list',
-  name: 'Reading Queue: Semantics Papers',
-  description: 'Papers on semantics and pragmatics I want to read',
-  visibility: 'public' as const,
-  items: [
-    {
-      uri: 'at://did:plc:author1/pub.chive.eprint.submission/abc123',
-      addedAt: '2024-01-15T10:00:00Z',
-      status: 'unread' as const,
-      notes: 'Interesting approach to quantifier scope',
-      rating: 5,
-    },
-    {
-      uri: 'at://did:plc:author2/pub.chive.eprint.submission/def456',
-      addedAt: '2024-01-16T11:30:00Z',
-      status: 'reading' as const,
-    },
-    {
-      uri: 'at://did:plc:author3/pub.chive.eprint.submission/ghi789',
-      addedAt: '2024-01-17T14:00:00Z',
-      status: 'read' as const,
-      rating: 4,
-    },
-  ],
-  createdAt: '2024-01-15T10:00:00Z',
-  updatedAt: '2024-01-17T14:00:00Z',
-  tags: ['semantics', 'pragmatics'],
-};
+const EPRINT_A = 'at://did:plc:author1/pub.chive.eprint.submission/abc123';
+const EPRINT_B = 'at://did:plc:author2/pub.chive.eprint.submission/def456';
 
-/**
- * Sample Leaflet list with mixed URIs (eprints and non-eprints).
- */
-const SAMPLE_MIXED_LIST = {
-  $type: 'xyz.leaflet.list',
-  name: 'Mixed Reading List',
-  visibility: 'public' as const,
-  items: [
+/** A document whose text block links an eprint through a richtext facet. */
+const DOCUMENT_WITH_FACET_LINK = {
+  $type: 'pub.leaflet.document',
+  title: 'Notes on quantifier scope',
+  description: 'Reading notes',
+  author: 'reader.example.com',
+  pages: [
     {
-      uri: 'at://did:plc:author1/pub.chive.eprint.submission/abc123',
-      addedAt: '2024-01-15T10:00:00Z',
-    },
-    {
-      uri: 'at://did:plc:user/app.bsky.feed.post/xyz789',
-      addedAt: '2024-01-15T11:00:00Z',
-    },
-    {
-      uri: 'at://did:plc:author2/pub.chive.eprint.submission/def456',
-      addedAt: '2024-01-15T12:00:00Z',
-    },
-    {
-      uri: 'https://example.com/paper',
-      addedAt: '2024-01-15T13:00:00Z',
+      $type: 'pub.leaflet.pages.linearDocument',
+      blocks: [
+        {
+          block: {
+            $type: 'pub.leaflet.blocks.text',
+            plaintext: 'The clearest treatment is in this paper.',
+            facets: [
+              {
+                index: { byteStart: 30, byteEnd: 39 },
+                features: [{ $type: 'pub.leaflet.richtext.facet#link', uri: EPRINT_A }],
+              },
+            ],
+          },
+        },
+      ],
     },
   ],
-  createdAt: '2024-01-15T10:00:00Z',
 };
 
-/**
- * Sample private Leaflet list.
- */
-const SAMPLE_PRIVATE_LIST = {
-  $type: 'xyz.leaflet.list',
-  name: 'Private Reading List',
-  visibility: 'private' as const,
-  items: [
+/** A document embedding an eprint as a website block. */
+const DOCUMENT_WITH_WEBSITE_BLOCK = {
+  $type: 'pub.leaflet.document',
+  title: 'Linked reading',
+  pages: [
     {
-      uri: 'at://did:plc:author1/pub.chive.eprint.submission/abc123',
-      addedAt: '2024-01-15T10:00:00Z',
+      blocks: [{ block: { $type: 'pub.leaflet.blocks.website', src: EPRINT_B, title: 'A paper' } }],
     },
   ],
-  createdAt: '2024-01-15T10:00:00Z',
+};
+
+/** A comment whose subject is an eprint. */
+const COMMENT_ON_EPRINT = {
+  $type: 'pub.leaflet.comment',
+  subject: EPRINT_A,
+  plaintext: 'This replicates the 2019 result almost exactly.',
+  createdAt: '2026-08-31T10:00:00Z',
 };
 
 /**
- * Sample followers-only Leaflet list.
+ * The protected surface these tests exercise.
+ *
+ * @remarks
+ * `extractContext` and `shouldProcess` are protected. Accessing them through a
+ * narrow named type keeps the tests readable and stops `dot-notation` from
+ * rewriting bracket access into a member access that does not compile.
  */
-const SAMPLE_FOLLOWERS_LIST = {
-  $type: 'xyz.leaflet.list',
-  name: 'Followers Only List',
-  visibility: 'followers' as const,
-  items: [
-    {
-      uri: 'at://did:plc:author1/pub.chive.eprint.submission/abc123',
-      addedAt: '2024-01-15T10:00:00Z',
-    },
-  ],
-  createdAt: '2024-01-15T10:00:00Z',
-};
-
-/**
- * Sample Leaflet list with empty items array.
- */
-const SAMPLE_EMPTY_LIST = {
-  $type: 'xyz.leaflet.list',
-  name: 'Empty List',
-  visibility: 'public' as const,
-  items: [],
-  createdAt: '2024-01-15T10:00:00Z',
-};
-
-/**
- * Sample Leaflet list without items field.
- */
-const SAMPLE_NO_ITEMS_LIST = {
-  $type: 'xyz.leaflet.list',
-  name: 'No Items List',
-  visibility: 'public' as const,
-  createdAt: '2024-01-15T10:00:00Z',
-};
-
-// ============================================================================
-// Testable Subclass
-// ============================================================================
-
-/**
- * Testable subclass that exposes protected methods and properties for testing.
- */
-class TestableLeafletBacklinksPlugin extends LeafletBacklinksPlugin {
-  /**
-   * Exposes the protected extractContext method for testing.
-   */
-  public testExtractContext(record: unknown): string | undefined {
-    return this.extractContext(record);
-  }
-
-  /**
-   * Exposes the protected shouldProcess method for testing.
-   */
-  public testShouldProcess(record: unknown): boolean {
-    return this.shouldProcess(record);
-  }
-
-  /**
-   * Exposes the protected backlinkService for testing.
-   */
-  public getBacklinkService(): IBacklinkService | undefined {
-    return this.backlinkService;
-  }
+interface PluginInternals {
+  extractContext(record: unknown): string | undefined;
+  shouldProcess(record: unknown): boolean;
 }
+
+const internals = (p: LeafletBacklinksPlugin): PluginInternals => p as unknown as PluginInternals;
 
 // ============================================================================
 // Tests
 // ============================================================================
 
 describe('LeafletBacklinksPlugin', () => {
-  let plugin: TestableLeafletBacklinksPlugin;
-  let context: IPluginContext;
-  let backlinkService: IBacklinkService;
+  let plugin: LeafletBacklinksPlugin;
 
   beforeEach(() => {
-    backlinkService = createMockBacklinkService();
-    context = createMockContext({
-      config: {
-        backlinkService,
-      },
-    });
-    plugin = new TestableLeafletBacklinksPlugin();
+    plugin = new LeafletBacklinksPlugin();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('manifest and properties', () => {
-    it('should have correct plugin ID', () => {
-      expect(plugin.id).toBe('pub.chive.plugin.leaflet-backlinks');
+  describe('identity', () => {
+    it('tracks the collection Leaflet actually publishes', () => {
+      // The whole reason this plugin indexed nothing: `xyz.leaflet.list` does
+      // not exist, so it matched no record in any repository.
+      expect(plugin.trackedCollection).toBe('pub.leaflet.document');
     });
 
-    it('should have correct tracked collection', () => {
-      expect(plugin.trackedCollection).toBe('xyz.leaflet.list');
+    it('declares hooks for both Leaflet collections', () => {
+      expect(plugin.manifest.permissions?.hooks).toEqual([
+        'firehose.pub.leaflet.document',
+        'firehose.pub.leaflet.comment',
+      ]);
     });
 
-    it('should have correct source type', () => {
-      expect(plugin.sourceType).toBe('leaflet.list');
-    });
-
-    it('should have correct manifest ID', () => {
-      expect(plugin.manifest.id).toBe('pub.chive.plugin.leaflet-backlinks');
-    });
-
-    it('should have correct manifest name', () => {
-      expect(plugin.manifest.name).toBe('Leaflet Backlinks');
-    });
-
-    it('should have correct manifest version', () => {
-      expect(plugin.manifest.version).toBe('0.4.0');
-    });
-
-    it('should have correct manifest description', () => {
-      expect(plugin.manifest.description).toBe(
-        'Tracks references to Chive eprints from Leaflet reading lists'
-      );
-    });
-
-    it('should have correct manifest author', () => {
-      expect(plugin.manifest.author).toBe('Aaron Steven White');
-    });
-
-    it('should have correct manifest license', () => {
-      expect(plugin.manifest.license).toBe('MIT');
-    });
-
-    it('should declare correct firehose hook permission', () => {
-      expect(plugin.manifest.permissions.hooks).toContain('firehose.xyz.leaflet.list');
-    });
-
-    it('should declare storage permission with correct max size', () => {
-      expect(plugin.manifest.permissions.storage?.maxSize).toBe(10 * 1024 * 1024); // 10MB
-    });
-
-    it('should have correct entrypoint', () => {
-      expect(plugin.manifest.entrypoint).toBe('leaflet-backlinks.js');
+    it('reports a source type that names a real record type', () => {
+      expect(plugin.sourceType).toBe('leaflet.document');
     });
   });
 
-  describe('initialize', () => {
-    it('should initialize successfully', async () => {
+  describe('subscription', () => {
+    it('subscribes to comments as well as documents', async () => {
+      const context = createMockContext();
       await plugin.initialize(context);
 
-      expect(context.logger.info).toHaveBeenCalledWith(
-        'Backlink tracking initialized',
-        expect.objectContaining({
-          collection: 'xyz.leaflet.list',
-          sourceType: 'leaflet.list',
-        })
+      const subscribed = (context.eventBus.on as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c) => c[0] as string
       );
-    });
-
-    it('should subscribe to firehose events for xyz.leaflet.list', async () => {
-      await plugin.initialize(context);
-
-      expect(context.eventBus.on).toHaveBeenCalledWith(
-        'firehose.xyz.leaflet.list',
-        expect.any(Function)
-      );
-    });
-
-    it('should retrieve backlink service from context', async () => {
-      await plugin.initialize(context);
-
-      expect(plugin.getBacklinkService()).toBe(backlinkService);
+      expect(subscribed).toContain('firehose.pub.leaflet.document');
+      expect(subscribed).toContain('firehose.pub.leaflet.comment');
     });
   });
 
   describe('extractEprintRefs', () => {
-    it('should extract eprint URIs from list items', () => {
-      const refs = plugin.extractEprintRefs(SAMPLE_LEAFLET_LIST);
-
-      expect(refs).toHaveLength(3);
-      expect(refs).toContain('at://did:plc:author1/pub.chive.eprint.submission/abc123');
-      expect(refs).toContain('at://did:plc:author2/pub.chive.eprint.submission/def456');
-      expect(refs).toContain('at://did:plc:author3/pub.chive.eprint.submission/ghi789');
+    it('finds an eprint linked from a richtext facet', () => {
+      // A citation inside a paragraph, which is the ordinary way a document
+      // refers to a paper.
+      expect(plugin.extractEprintRefs(DOCUMENT_WITH_FACET_LINK)).toEqual([EPRINT_A]);
     });
 
-    it('should filter out non-eprint URIs', () => {
-      const refs = plugin.extractEprintRefs(SAMPLE_MIXED_LIST);
-
-      expect(refs).toHaveLength(2);
-      expect(refs).toContain('at://did:plc:author1/pub.chive.eprint.submission/abc123');
-      expect(refs).toContain('at://did:plc:author2/pub.chive.eprint.submission/def456');
-      expect(refs).not.toContain('at://did:plc:user/app.bsky.feed.post/xyz789');
-      expect(refs).not.toContain('https://example.com/paper');
+    it('finds an eprint embedded as a website block', () => {
+      expect(plugin.extractEprintRefs(DOCUMENT_WITH_WEBSITE_BLOCK)).toEqual([EPRINT_B]);
     });
 
-    it('should return empty array for empty items', () => {
-      const refs = plugin.extractEprintRefs(SAMPLE_EMPTY_LIST);
-
-      expect(refs).toEqual([]);
+    it('finds the subject of a comment', () => {
+      expect(plugin.extractEprintRefs(COMMENT_ON_EPRINT)).toEqual([EPRINT_A]);
     });
 
-    it('should return empty array when items field is missing', () => {
-      const refs = plugin.extractEprintRefs(SAMPLE_NO_ITEMS_LIST);
-
-      expect(refs).toEqual([]);
-    });
-
-    it('should return empty array when items is not an array', () => {
-      const invalidList = {
-        $type: 'xyz.leaflet.list',
-        name: 'Invalid List',
-        visibility: 'public',
-        items: 'not-an-array',
-        createdAt: '2024-01-15T10:00:00Z',
+    it('finds a quoted document in a comment attachment', () => {
+      const comment = {
+        $type: 'pub.leaflet.comment',
+        subject: 'at://did:plc:other/pub.leaflet.document/xyz',
+        plaintext: 'Quoting this',
+        attachment: { document: EPRINT_B },
       };
-
-      const refs = plugin.extractEprintRefs(invalidList);
-
-      expect(refs).toEqual([]);
+      expect(plugin.extractEprintRefs(comment)).toEqual([EPRINT_B]);
     });
 
-    it('should handle items with undefined URIs', () => {
-      const listWithUndefinedUris = {
-        $type: 'xyz.leaflet.list',
-        name: 'List with Undefined URIs',
-        visibility: 'public' as const,
-        items: [
+    it('finds a standardSitePost block pointing straight at an eprint', () => {
+      const doc = {
+        $type: 'pub.leaflet.document',
+        pages: [
+          { blocks: [{ block: { $type: 'pub.leaflet.blocks.standardSitePost', uri: EPRINT_A } }] },
+        ],
+      };
+      expect(plugin.extractEprintRefs(doc)).toEqual([EPRINT_A]);
+    });
+
+    it('collects references across several pages and blocks', () => {
+      const doc = {
+        $type: 'pub.leaflet.document',
+        pages: [
+          { blocks: [{ block: { $type: 'pub.leaflet.blocks.website', src: EPRINT_A } }] },
+          { blocks: [{ block: { $type: 'pub.leaflet.blocks.website', src: EPRINT_B } }] },
+        ],
+      };
+      expect(plugin.extractEprintRefs(doc).sort()).toEqual([EPRINT_A, EPRINT_B].sort());
+    });
+
+    it('reports each eprint once however many times it is referenced', () => {
+      const doc = {
+        $type: 'pub.leaflet.document',
+        pages: [
           {
-            uri: 'at://did:plc:author1/pub.chive.eprint.submission/abc123',
-            addedAt: '2024-01-15T10:00:00Z',
-          },
-          {
-            uri: undefined as unknown as string,
-            addedAt: '2024-01-15T11:00:00Z',
-          },
-          {
-            uri: 'at://did:plc:author2/pub.chive.eprint.submission/def456',
-            addedAt: '2024-01-15T12:00:00Z',
+            blocks: [
+              { block: { $type: 'pub.leaflet.blocks.website', src: EPRINT_A } },
+              {
+                block: {
+                  $type: 'pub.leaflet.blocks.text',
+                  plaintext: 'again',
+                  facets: [{ features: [{ uri: EPRINT_A }] }],
+                },
+              },
+            ],
           },
         ],
-        createdAt: '2024-01-15T10:00:00Z',
       };
+      expect(plugin.extractEprintRefs(doc)).toEqual([EPRINT_A]);
+    });
 
-      const refs = plugin.extractEprintRefs(listWithUndefinedUris);
+    it('ignores links that are not eprints', () => {
+      const doc = {
+        $type: 'pub.leaflet.document',
+        pages: [
+          {
+            blocks: [
+              { block: { $type: 'pub.leaflet.blocks.website', src: 'https://example.com/blog' } },
+              {
+                block: {
+                  $type: 'pub.leaflet.blocks.standardSitePost',
+                  uri: 'at://did:plc:someone/site.standard.document/abc',
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(plugin.extractEprintRefs(doc)).toEqual([]);
+    });
 
-      expect(refs).toHaveLength(2);
-      expect(refs).toContain('at://did:plc:author1/pub.chive.eprint.submission/abc123');
-      expect(refs).toContain('at://did:plc:author2/pub.chive.eprint.submission/def456');
+    it('ignores facet features that carry no link', () => {
+      const doc = {
+        $type: 'pub.leaflet.document',
+        pages: [
+          {
+            blocks: [
+              {
+                block: {
+                  $type: 'pub.leaflet.blocks.text',
+                  plaintext: 'bold text',
+                  facets: [{ features: [{ $type: 'pub.leaflet.richtext.facet#bold' }] }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(plugin.extractEprintRefs(doc)).toEqual([]);
+    });
+
+    it('survives a document with no pages', () => {
+      expect(plugin.extractEprintRefs({ $type: 'pub.leaflet.document', title: 'Empty' })).toEqual(
+        []
+      );
+    });
+
+    it('survives a page with no blocks and a block with no content', () => {
+      const doc = { $type: 'pub.leaflet.document', pages: [{}, { blocks: [{}] }] };
+      expect(plugin.extractEprintRefs(doc)).toEqual([]);
+    });
+
+    it('survives values that are not records at all', () => {
+      for (const value of [null, undefined, 'a string', 42]) {
+        expect(plugin.extractEprintRefs(value)).toEqual([]);
+      }
     });
   });
 
   describe('extractContext', () => {
-    it('should extract list name when description is present', () => {
-      const extractedContext = plugin.testExtractContext(SAMPLE_LEAFLET_LIST);
-
-      expect(extractedContext).toBe(
-        'Reading Queue: Semantics Papers: Papers on semantics and pragmatics I want to read'
+    it('uses a document title and description', () => {
+      expect(internals(plugin).extractContext(DOCUMENT_WITH_FACET_LINK)).toBe(
+        'Notes on quantifier scope: Reading notes'
       );
     });
 
-    it('should extract only list name when description is absent', () => {
-      const listWithoutDescription = {
-        $type: 'xyz.leaflet.list',
-        name: 'My Reading List',
-        visibility: 'public' as const,
-        items: [],
-        createdAt: '2024-01-15T10:00:00Z',
-      };
-
-      const extractedContext = plugin.testExtractContext(listWithoutDescription);
-
-      expect(extractedContext).toBe('My Reading List');
+    it('uses the title alone when there is no description', () => {
+      expect(internals(plugin).extractContext(DOCUMENT_WITH_WEBSITE_BLOCK)).toBe('Linked reading');
     });
 
-    it('should return undefined when name is missing', () => {
-      const listWithoutName = {
-        $type: 'xyz.leaflet.list',
-        visibility: 'public' as const,
-        items: [],
-        createdAt: '2024-01-15T10:00:00Z',
-      };
-
-      const extractedContext = plugin.testExtractContext(listWithoutName);
-
-      expect(extractedContext).toBeUndefined();
+    it('falls back to a comment body, which has no title', () => {
+      expect(internals(plugin).extractContext(COMMENT_ON_EPRINT)).toBe(
+        'This replicates the 2019 result almost exactly.'
+      );
     });
 
-    it('should handle empty string name', () => {
-      const listWithEmptyName = {
-        $type: 'xyz.leaflet.list',
-        name: '',
-        description: 'Some description',
-        visibility: 'public' as const,
-        items: [],
-        createdAt: '2024-01-15T10:00:00Z',
-      };
+    it('truncates a long comment rather than storing the whole thing', () => {
+      const long = { $type: 'pub.leaflet.comment', plaintext: 'x'.repeat(500) };
+      const context = internals(plugin).extractContext(long);
+      expect(context).toHaveLength(200);
+      expect(context?.endsWith('...')).toBe(true);
+    });
 
-      const extractedContext = plugin.testExtractContext(listWithEmptyName);
-
-      expect(extractedContext).toBeUndefined();
+    it('returns nothing for a record with neither', () => {
+      expect(internals(plugin).extractContext({ $type: 'pub.leaflet.document' })).toBeUndefined();
     });
   });
 
   describe('shouldProcess', () => {
-    it('should return true for public lists', () => {
-      const result = plugin.testShouldProcess(SAMPLE_LEAFLET_LIST);
-
-      expect(result).toBe(true);
+    it('accepts a document', () => {
+      expect(internals(plugin).shouldProcess(DOCUMENT_WITH_FACET_LINK)).toBe(true);
     });
 
-    it('should return false for private lists', () => {
-      const result = plugin.testShouldProcess(SAMPLE_PRIVATE_LIST);
-
-      expect(result).toBe(false);
+    it('accepts a comment', () => {
+      // The previous version required `visibility === 'public'`, a field the
+      // real lexicons do not have — so every record would have been skipped.
+      expect(internals(plugin).shouldProcess(COMMENT_ON_EPRINT)).toBe(true);
     });
 
-    it('should return false for followers-only lists', () => {
-      const result = plugin.testShouldProcess(SAMPLE_FOLLOWERS_LIST);
-
-      expect(result).toBe(false);
-    });
-
-    it('should handle missing visibility field', () => {
-      const listWithoutVisibility = {
-        $type: 'xyz.leaflet.list',
-        name: 'List Without Visibility',
-        items: [],
-        createdAt: '2024-01-15T10:00:00Z',
-      };
-
-      const result = plugin.testShouldProcess(listWithoutVisibility);
-
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('firehose event handling', () => {
-    it('should process public list and create backlinks', async () => {
-      await plugin.initialize(context);
-
-      // Get the event handler that was registered
-      const onCall = vi
-        .mocked(context.eventBus.on)
-        .mock.calls.find((call) => call[0] === 'firehose.xyz.leaflet.list');
-      expect(onCall).toBeDefined();
-      expect(onCall).toBeDefined();
-      const handler = onCall?.[1];
-      if (!handler) throw new Error('Handler not found');
-
-      // Create a firehose record
-      const firehoseRecord: FirehoseRecord = {
-        uri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-        collection: 'xyz.leaflet.list',
-        did: 'did:plc:user',
-        rkey: 'abc123',
-        record: SAMPLE_LEAFLET_LIST,
-        deleted: false,
-        cid: 'bafyreicid',
-        timestamp: new Date(),
-      };
-
-      // Call the handler
-      handler(firehoseRecord);
-
-      // Wait for async processing
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(backlinkService.createBacklink).toHaveBeenCalledTimes(3);
-      expect(backlinkService.createBacklink).toHaveBeenCalledWith({
-        sourceUri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-        sourceType: 'leaflet.list',
-        targetUri: 'at://did:plc:author1/pub.chive.eprint.submission/abc123',
-        context:
-          'Reading Queue: Semantics Papers: Papers on semantics and pragmatics I want to read',
-      });
-    });
-
-    it('should not process private lists', async () => {
-      await plugin.initialize(context);
-
-      const onCall = vi
-        .mocked(context.eventBus.on)
-        .mock.calls.find((call) => call[0] === 'firehose.xyz.leaflet.list');
-      expect(onCall).toBeDefined();
-      const handler = onCall?.[1];
-      if (!handler) throw new Error('Handler not found');
-
-      const firehoseRecord: FirehoseRecord = {
-        uri: 'at://did:plc:user/xyz.leaflet.list/xyz789',
-        collection: 'xyz.leaflet.list',
-        did: 'did:plc:user',
-        rkey: 'xyz789',
-        record: SAMPLE_PRIVATE_LIST,
-        deleted: false,
-        cid: 'bafyreicid',
-        timestamp: new Date(),
-      };
-
-      handler(firehoseRecord);
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(backlinkService.createBacklink).not.toHaveBeenCalled();
-    });
-
-    it('should handle deletion events', async () => {
-      await plugin.initialize(context);
-
-      const onCall = vi
-        .mocked(context.eventBus.on)
-        .mock.calls.find((call) => call[0] === 'firehose.xyz.leaflet.list');
-      expect(onCall).toBeDefined();
-      const handler = onCall?.[1];
-      if (!handler) throw new Error('Handler not found');
-
-      const deletionRecord: FirehoseRecord = {
-        uri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-        collection: 'xyz.leaflet.list',
-        did: 'did:plc:user',
-        rkey: 'abc123',
-        record: null,
-        deleted: true,
-        timestamp: new Date(),
-      };
-
-      handler(deletionRecord);
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(backlinkService.deleteBacklink).toHaveBeenCalledWith(
-        'at://did:plc:user/xyz.leaflet.list/abc123'
-      );
-    });
-
-    it('should emit backlink.created event when backlink is created', async () => {
-      await plugin.initialize(context);
-
-      const onCall = vi
-        .mocked(context.eventBus.on)
-        .mock.calls.find((call) => call[0] === 'firehose.xyz.leaflet.list');
-      expect(onCall).toBeDefined();
-      const handler = onCall?.[1];
-      if (!handler) throw new Error('Handler not found');
-
-      const firehoseRecord: FirehoseRecord = {
-        uri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-        collection: 'xyz.leaflet.list',
-        did: 'did:plc:user',
-        rkey: 'abc123',
-        record: SAMPLE_LEAFLET_LIST,
-        deleted: false,
-        cid: 'bafyreicid',
-        timestamp: new Date(),
-      };
-
-      handler(firehoseRecord);
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(context.eventBus.emit).toHaveBeenCalledWith(
-        'backlink.created',
-        expect.objectContaining({
-          sourceUri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-          sourceType: 'leaflet.list',
-        })
-      );
-    });
-
-    it('should emit backlink.deleted event when deletion is processed', async () => {
-      await plugin.initialize(context);
-
-      const onCall = vi
-        .mocked(context.eventBus.on)
-        .mock.calls.find((call) => call[0] === 'firehose.xyz.leaflet.list');
-      expect(onCall).toBeDefined();
-      const handler = onCall?.[1];
-      if (!handler) throw new Error('Handler not found');
-
-      const deletionRecord: FirehoseRecord = {
-        uri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-        collection: 'xyz.leaflet.list',
-        did: 'did:plc:user',
-        rkey: 'abc123',
-        record: null,
-        deleted: true,
-        timestamp: new Date(),
-      };
-
-      handler(deletionRecord);
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(context.eventBus.emit).toHaveBeenCalledWith(
-        'backlink.deleted',
-        expect.objectContaining({
-          sourceUri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-          sourceType: 'leaflet.list',
-        })
-      );
-    });
-
-    it('should record metrics when backlinks are created', async () => {
-      await plugin.initialize(context);
-
-      const onCall = vi
-        .mocked(context.eventBus.on)
-        .mock.calls.find((call) => call[0] === 'firehose.xyz.leaflet.list');
-      expect(onCall).toBeDefined();
-      const handler = onCall?.[1];
-      if (!handler) throw new Error('Handler not found');
-
-      const firehoseRecord: FirehoseRecord = {
-        uri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-        collection: 'xyz.leaflet.list',
-        did: 'did:plc:user',
-        rkey: 'abc123',
-        record: SAMPLE_LEAFLET_LIST,
-        deleted: false,
-        cid: 'bafyreicid',
-        timestamp: new Date(),
-      };
-
-      handler(firehoseRecord);
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(context.metrics.incrementCounter).toHaveBeenCalledWith(
-        'backlinks_created',
-        {
-          source_type: 'leaflet.list',
-        },
-        undefined
-      );
-    });
-
-    it('should log warnings on processing errors', async () => {
-      await plugin.initialize(context);
-
-      // Make createBacklink throw an error
-      vi.mocked(backlinkService.createBacklink).mockRejectedValueOnce(new Error('Database error'));
-
-      const onCall = vi
-        .mocked(context.eventBus.on)
-        .mock.calls.find((call) => call[0] === 'firehose.xyz.leaflet.list');
-      expect(onCall).toBeDefined();
-      const handler = onCall?.[1];
-      if (!handler) throw new Error('Handler not found');
-
-      const firehoseRecord: FirehoseRecord = {
-        uri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-        collection: 'xyz.leaflet.list',
-        did: 'did:plc:user',
-        rkey: 'abc123',
-        record: SAMPLE_LEAFLET_LIST,
-        deleted: false,
-        cid: 'bafyreicid',
-        timestamp: new Date(),
-      };
-
-      handler(firehoseRecord);
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(context.logger.warn).toHaveBeenCalledWith(
-        'Failed to process firehose record',
-        expect.objectContaining({
-          error: 'Database error',
-          uri: 'at://did:plc:user/xyz.leaflet.list/abc123',
-        })
-      );
+    it('rejects a non-record', () => {
+      expect(internals(plugin).shouldProcess(null)).toBe(false);
+      expect(internals(plugin).shouldProcess('nope')).toBe(false);
     });
   });
 });

--- a/tests/unit/plugins/builtin/standard-site-backlinks.test.ts
+++ b/tests/unit/plugins/builtin/standard-site-backlinks.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the standard.site backlinks plugin.
+ *
+ * @remarks
+ * A `site.standard.document` names the work it describes by `site` + `path`.
+ * Recovering the eprint from a path is the mapping several other references
+ * resolve through — a `site.standard.graph.recommend` names a document, and a
+ * Leaflet `standardSitePost` block embeds one — so it has to handle both the
+ * current shape and the pre-revision one that documents already published
+ * still carry.
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+
+import {
+  StandardSiteBacklinksPlugin,
+  eprintUriFromPath,
+} from '../../../../src/plugins/builtin/standard-site-backlinks.js';
+
+const EPRINT = 'at://did:plc:author/pub.chive.eprint.submission/abc123';
+const PATH = `/eprints/${encodeURIComponent(EPRINT)}`;
+
+describe('eprintUriFromPath', () => {
+  it('recovers the eprint URI a Chive document encodes in its path', () => {
+    expect(eprintUriFromPath(PATH)).toBe(EPRINT);
+  });
+
+  it('ignores a path that is not an eprint page', () => {
+    expect(eprintUriFromPath('/blog/a-post')).toBeUndefined();
+  });
+
+  it('ignores the eprint prefix with nothing after it', () => {
+    expect(eprintUriFromPath('/eprints/')).toBeUndefined();
+  });
+
+  it('ignores an absent path', () => {
+    expect(eprintUriFromPath(undefined)).toBeUndefined();
+  });
+
+  it('treats a malformed encoding as "not about an eprint" rather than throwing', () => {
+    // The path comes from another repository. A decode failure must not abort
+    // processing the record.
+    expect(eprintUriFromPath('/eprints/%E0%A4%A')).toBeUndefined();
+  });
+});
+
+describe('StandardSiteBacklinksPlugin', () => {
+  const plugin = new StandardSiteBacklinksPlugin();
+
+  it('tracks the standard.site document collection', () => {
+    expect(plugin.trackedCollection).toBe('site.standard.document');
+  });
+
+  describe('extractEprintRefs', () => {
+    it('finds the eprint from a document path', () => {
+      expect(plugin.extractEprintRefs({ title: 'A paper', path: PATH })).toEqual([EPRINT]);
+    });
+
+    it('finds the eprint from a legacy content.uri', () => {
+      // Documents written before the schema was corrected carry the eprint
+      // here and have no path. Dropping this branch would make every
+      // already-published Chive document invisible.
+      expect(plugin.extractEprintRefs({ title: 'A paper', content: { uri: EPRINT } })).toEqual([
+        EPRINT,
+      ]);
+    });
+
+    it('prefers the path when a document carries both', () => {
+      const other = 'at://did:plc:other/pub.chive.eprint.submission/xyz';
+      expect(plugin.extractEprintRefs({ path: PATH, content: { uri: other } })).toEqual([EPRINT]);
+    });
+
+    it('returns nothing for a document about something else', () => {
+      expect(plugin.extractEprintRefs({ title: 'A blog post', path: '/posts/hello' })).toEqual([]);
+    });
+
+    it('returns nothing when a path names a non-eprint record', () => {
+      const notAnEprint = 'at://did:plc:a/pub.chive.review.comment/xyz';
+      expect(
+        plugin.extractEprintRefs({ path: `/eprints/${encodeURIComponent(notAnEprint)}` })
+      ).toEqual([]);
+    });
+
+    it('survives values that are not records', () => {
+      for (const value of [null, undefined, 'a string', 3]) {
+        expect(plugin.extractEprintRefs(value)).toEqual([]);
+      }
+    });
+  });
+
+  describe('extractContext', () => {
+    const context = (record: unknown): string | undefined =>
+      (plugin as unknown as { extractContext(r: unknown): string | undefined }).extractContext(
+        record
+      );
+
+    it('uses the title', () => {
+      expect(context({ title: 'A paper' })).toBe('A paper');
+    });
+
+    it('appends a description when there is one', () => {
+      expect(context({ title: 'A paper', description: 'On scope' })).toBe('A paper: On scope');
+    });
+
+    it('truncates a long description', () => {
+      const result = context({ title: 'A paper', description: 'x'.repeat(500) });
+      expect(result?.length).toBeLessThanOrEqual('A paper: '.length + 200);
+    });
+
+    it('returns nothing for a document with no title', () => {
+      expect(context({ path: PATH })).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/services/indexing/event-filter.test.ts
+++ b/tests/unit/services/indexing/event-filter.test.ts
@@ -256,15 +256,26 @@ describe('EventFilter', () => {
         ).toBe(false);
       });
 
-      it('accepts NSIDs with hyphens in segments after pub.chive', () => {
+      it('accepts hyphens in the authority but not in the name segment', () => {
+        // `name = alpha *( alpha / number )` — no hyphens. This previously
+        // asserted `submission-type` was accepted, which the NSID grammar
+        // forbids and the regex in `@atproto/syntax` rejects. Hyphens remain
+        // valid in the authority segments, which are domain labels.
         const filter = new EventFilter({ strictValidation: true });
+
+        expect(
+          filter.shouldProcess({
+            action: 'create',
+            path: 'pub.chive.eprint-app.submission/abc',
+          })
+        ).toBe(true);
 
         expect(
           filter.shouldProcess({
             action: 'create',
             path: 'pub.chive.eprint-app.submission-type/abc',
           })
-        ).toBe(true);
+        ).toBe(false);
       });
 
       it('accepts NSIDs with digits in later segments', () => {

--- a/tests/unit/services/indexing/observed-collections.test.ts
+++ b/tests/unit/services/indexing/observed-collections.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for observing foreign collections on the firehose.
+ *
+ * @remarks
+ * Chive's backlink plugins subscribe to `firehose.<collection>` for other
+ * applications' lexicons. `EventFilter` rejected every collection outside
+ * `pub.chive.*` before the event processor ran, so five registered plugins were
+ * subscribed to events that could not fire. These tests pin the admission rule
+ * in both directions: the observed collections get through, and nothing else
+ * foreign does.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import { EventFilter } from '../../../../src/services/indexing/event-filter.js';
+import {
+  INDEXED_COLLECTIONS,
+  OBSERVED_COLLECTIONS,
+  OBSERVED_COLLECTIONS_HIGH_VOLUME,
+  isObservedCollection,
+} from '../../../../src/services/indexing/indexed-collections.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+
+function filterWithObserved(highVolume = false) {
+  return new EventFilter({
+    observedCollections: [
+      ...OBSERVED_COLLECTIONS,
+      ...(highVolume ? OBSERVED_COLLECTIONS_HIGH_VOLUME : []),
+    ],
+    strictValidation: true,
+  });
+}
+
+describe('observed collections', () => {
+  describe('EventFilter admission', () => {
+    it.each(OBSERVED_COLLECTIONS)('admits %s', (collection) => {
+      expect(
+        filterWithObserved().shouldProcess({ action: 'create', path: `${collection}/abc123` })
+      ).toBe(true);
+    });
+
+    it('still admits Chive collections', () => {
+      expect(
+        filterWithObserved().shouldProcess({
+          action: 'create',
+          path: 'pub.chive.eprint.submission/abc123',
+        })
+      ).toBe(true);
+    });
+
+    it('still rejects a foreign collection nothing observes', () => {
+      // The rule is an allow-list, not "anything non-Chive".
+      expect(
+        filterWithObserved().shouldProcess({ action: 'create', path: 'com.example.random/abc123' })
+      ).toBe(false);
+    });
+
+    it('rejects every foreign collection when none are configured', () => {
+      // The state that starved the plugins, kept as a regression.
+      const bare = new EventFilter({ strictValidation: true });
+      for (const collection of OBSERVED_COLLECTIONS) {
+        expect(bare.shouldProcess({ action: 'create', path: `${collection}/abc123` })).toBe(false);
+      }
+    });
+
+    it('does not admit the Bluesky timeline by default', () => {
+      // app.bsky.feed.post is the whole network: millions of records a day
+      // against Chive's thousands. Reading it is a capacity decision.
+      expect(
+        filterWithObserved().shouldProcess({ action: 'create', path: 'app.bsky.feed.post/abc123' })
+      ).toBe(false);
+    });
+
+    it('admits the Bluesky timeline when the high-volume set is enabled', () => {
+      expect(
+        filterWithObserved(true).shouldProcess({
+          action: 'create',
+          path: 'app.bsky.feed.post/abc123',
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe('isObservedCollection', () => {
+    it('reports the observed set', () => {
+      expect(isObservedCollection('at.margin.note')).toBe(true);
+    });
+
+    it('excludes high-volume collections unless asked', () => {
+      expect(isObservedCollection('app.bsky.feed.post')).toBe(false);
+      expect(isObservedCollection('app.bsky.feed.post', true)).toBe(true);
+    });
+
+    it('does not report Chive collections as observed', () => {
+      // Chive's own records go through the processor's switch with full service
+      // access; they are not forwarded to the plugin bus.
+      expect(isObservedCollection('pub.chive.eprint.submission')).toBe(false);
+    });
+  });
+
+  describe('the two lists stay disjoint', () => {
+    it('no collection is both indexed and observed', () => {
+      // Indexed means Chive stores it; observed means Chive forwards it and
+      // stores nothing. A collection in both would be indexed and emitted.
+      const indexed = new Set<string>(INDEXED_COLLECTIONS);
+      const overlap = OBSERVED_COLLECTIONS.filter((c) => indexed.has(c));
+      expect(overlap).toEqual([]);
+    });
+
+    it('no observed collection is in the Chive namespace', () => {
+      expect(OBSERVED_COLLECTIONS.filter((c) => c.startsWith('pub.chive.'))).toEqual([]);
+    });
+  });
+
+  describe('NSID validation admits camelCase name segments', () => {
+    // The filter's validator required every segment to be lowercase. An NSID is
+    // a domain authority plus a name, and only the authority is a domain label;
+    // the name segment is where camelCase lives. With strictValidation on —
+    // which is what IndexingService sets — this dropped SEVEN of Chive's own
+    // twenty indexed collections from the live firehose. User tags, related
+    // works, entity links, collaboration acceptances and both proposal types
+    // were never indexed from a firehose event.
+    const strict = new EventFilter({ strictValidation: true });
+
+    it.each(INDEXED_COLLECTIONS)('accepts %s', (collection) => {
+      expect(strict.shouldProcess({ action: 'create', path: `${collection}/abc123` })).toBe(true);
+    });
+
+    it('accepts the camelCase NSIDs used across ATProto', () => {
+      // Admitted via the observed set, so the only gate left is NSID validity —
+      // otherwise these would be rejected for their namespace and the test
+      // would prove nothing about camelCase.
+      const nsids = ['com.atproto.repo.createRecord', 'app.bsky.feed.getTimeline'];
+      const observing = new EventFilter({ observedCollections: nsids, strictValidation: true });
+      for (const nsid of nsids) {
+        expect(observing.shouldProcess({ action: 'create', path: `${nsid}/abc` })).toBe(true);
+      }
+    });
+
+    it('still rejects a name segment with characters the spec forbids', () => {
+      // `name = alpha *( alpha / number )`: no underscores or hyphens, and no
+      // leading digit. Digits after the first letter are fine — `submission3`
+      // is a valid NSID, so that case is not listed here.
+      // Observed here too, so a rejection can only be the NSID rule.
+      const nsids = [
+        'pub.chive.eprint.user_tag',
+        'pub.chive.eprint.2tag',
+        'pub.chive.eprint.user-tag',
+      ];
+      const observing = new EventFilter({ observedCollections: nsids, strictValidation: true });
+      for (const nsid of nsids) {
+        expect(observing.shouldProcess({ action: 'create', path: `${nsid}/abc` })).toBe(false);
+      }
+    });
+
+    it('still rejects uppercase in the domain authority', () => {
+      // The authority is a domain name and stays lowercase.
+      const observing = new EventFilter({
+        observedCollections: ['pub.Chive.eprint.submission'],
+        strictValidation: true,
+      });
+      expect(
+        observing.shouldProcess({ action: 'create', path: 'pub.Chive.eprint.submission/abc' })
+      ).toBe(false);
+    });
+
+    it('still rejects a collection with too few segments', () => {
+      expect(strict.shouldProcess({ action: 'create', path: 'pub.chive/abc' })).toBe(false);
+    });
+  });
+
+  describe('every observed collection has a plugin that consumes it', () => {
+    it('matches a trackedCollection or firehose subscription in src/plugins/builtin', () => {
+      // A collection admitted with no subscriber is filter work for nothing,
+      // and makes the list look like it does more than it does.
+      const dir = join(REPO_ROOT, 'src', 'plugins', 'builtin');
+      const sources = readdirSync(dir)
+        .filter((f) => f.endsWith('.ts'))
+        .map((f) => readFileSync(join(dir, f), 'utf8'))
+        .join('\n');
+
+      const unconsumed = OBSERVED_COLLECTIONS.filter((c) => !sources.includes(c));
+      expect(unconsumed).toEqual([]);
+    });
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,5 +8,17 @@
     "removeComments": true
   },
   "include": ["src/**/*", "scripts/**/*"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "tests/**/*", "node_modules"]
+  // Mirrors the base exclude and adds only what the build must additionally
+  // drop. Listing a wholly separate set is what let typecheck and build
+  // diverge: a path exempted in one and compiled in the other is a failure
+  // that only appears in the Docker build.
+  "exclude": [
+    "node_modules",
+    "dist",
+    ".turbo",
+    "tests/e2e",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "tests/**/*"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,12 +47,7 @@
     "vitest.config.ts",
     "playwright.config.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    ".turbo",
-    "tests/e2e",
-    "src/lexicons/validators",
-    "tests/integration/lexicons/codegen.test.ts"
-  ]
+  // `tests/e2e` is excluded because Playwright's types conflict with Vitest's
+  // globals in the same program; it has its own typecheck.
+  "exclude": ["node_modules", "dist", ".turbo", "tests/e2e"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,18 @@ export default defineConfig({
     environment: 'node',
     globalSetup: ['./tests/setup/global-setup.ts'],
     fileParallelism: false,
+    // This suite talks to PostgreSQL, Elasticsearch, Neo4j and Redis over the
+    // network. Vitest's 5s default is sized for pure functions, so a slow CI
+    // runner turned an ordinary test into a failed build: on the v0.11.0
+    // release run, `tracks PDS source for staleness detection` timed out at
+    // 5000ms with 5509 of 5513 passing, in a run where Elasticsearch and Neo4j
+    // both reported slow starts. The same file passes locally in 697ms.
+    //
+    // The unit config deliberately keeps the 5s default, so a genuine hang in
+    // code with no I/O still fails fast there.
+    testTimeout: 30_000,
+    // Setup migrates and seeds four datastores; container start dominates.
+    hookTimeout: 120_000,
     // Mock native modules that require compilation
     alias: {
       'isolated-vm': path.resolve(__dirname, './__mocks__/isolated-vm.ts'),

--- a/web/components/auth/handle-input.tsx
+++ b/web/components/auth/handle-input.tsx
@@ -33,6 +33,21 @@ export interface HandleInputProps {
   disabled?: boolean;
   /** Additional CSS classes */
   className?: string;
+  /**
+   * Input id.
+   *
+   * @remarks
+   * Supplied by shadcn's `FormControl`, which clones its child to pass `id`,
+   * `aria-describedby` and `aria-invalid`. Without accepting and forwarding
+   * them the `<label for>` never matches the input, so the field has no
+   * accessible name at all — a screen reader announces an unlabelled text box,
+   * and `getByRole('textbox', { name })` cannot find it.
+   */
+  id?: string;
+  /** Ids of the elements describing this input, from `FormControl` */
+  'aria-describedby'?: string;
+  /** Whether the field is in an error state, from `FormControl` */
+  'aria-invalid'?: boolean;
 }
 
 /**
@@ -49,6 +64,9 @@ export function HandleInput({
   placeholder = 'yourhandle.example.com',
   disabled = false,
   className,
+  id,
+  'aria-describedby': ariaDescribedBy,
+  'aria-invalid': ariaInvalid,
 }: HandleInputProps) {
   const [suggestions, setSuggestions] = useState<ActorSuggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -156,6 +174,9 @@ export function HandleInput({
         <AtSign className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           ref={inputRef}
+          id={id}
+          aria-describedby={ariaDescribedBy}
+          aria-invalid={ariaInvalid}
           type="text"
           value={value}
           onChange={handleChange}

--- a/web/components/eprints/repositories-panel.tsx
+++ b/web/components/eprints/repositories-panel.tsx
@@ -83,6 +83,12 @@ const CODE_PLATFORM_CONFIG: Record<string, PlatformConfig> = {
     color: 'text-gray-600',
     bgColor: 'bg-gray-50 dark:bg-gray-900',
   },
+  tangled: {
+    label: 'Tangled',
+    icon: Code,
+    color: 'text-purple-600',
+    bgColor: 'bg-purple-50 dark:bg-purple-950',
+  },
   software_heritage: {
     label: 'Software Heritage',
     icon: Code,

--- a/web/components/forms/autocomplete-a11y.test.tsx
+++ b/web/components/forms/autocomplete-a11y.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Tests for the combobox accessibility pattern.
+ *
+ * @remarks
+ * Chive has around twenty autocompletes. Two implemented the WAI-ARIA combobox
+ * pattern; the shared base implemented none of it, and `node-autocomplete` —
+ * the single-select behind every knowledge-graph field — handled Escape and no
+ * other key. A keyboard user could open a list of suggestions and had no way to
+ * reach one, and a screen reader was told nothing about the list existing.
+ *
+ * These tests pin the contract on the two components the rest are meant to
+ * consolidate onto.
+ *
+ * @see {@link https://www.w3.org/WAI/ARIA/apg/patterns/combobox/}
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { renderWithProviders } from '@/tests/test-utils';
+
+import { AutocompleteInput } from './autocomplete-input';
+
+interface Fruit {
+  id: string;
+  name: string;
+}
+
+const FRUITS: Fruit[] = [
+  { id: 'a', name: 'Apple' },
+  { id: 'b', name: 'Banana' },
+  { id: 'c', name: 'Cherry' },
+];
+
+function renderAutocomplete(onSelect = vi.fn()) {
+  const queryFn = vi.fn().mockResolvedValue(FRUITS);
+  renderWithProviders(
+    <AutocompleteInput<Fruit>
+      queryFn={queryFn}
+      queryKeyPrefix="fruit"
+      onSelect={onSelect}
+      getItemKey={(f) => f.id}
+      getItemValue={(f) => f.name}
+      renderItem={(f) => <span>{f.name}</span>}
+      placeholder="Search fruit"
+      minChars={1}
+      // No debounce: this suite is about keyboard behaviour, and waiting out a
+      // real debounce in every case only makes it slow and flaky.
+      debounceMs={0}
+    />
+  );
+  return { queryFn, onSelect };
+}
+
+describe('AutocompleteInput combobox pattern', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('announces itself as a combobox', () => {
+    renderAutocomplete();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('reports collapsed before anything is typed', () => {
+    renderAutocomplete();
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('points at the listbox it controls', () => {
+    renderAutocomplete();
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-controls');
+  });
+
+  it('declares that suggestions are a list', () => {
+    renderAutocomplete();
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('reports expanded once suggestions are showing', async () => {
+    const user = userEvent.setup();
+    renderAutocomplete();
+
+    await user.type(screen.getByRole('combobox'), 'a');
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-expanded', 'true')
+    );
+  });
+
+  it('moves a virtual cursor with the down arrow', async () => {
+    const user = userEvent.setup();
+    renderAutocomplete();
+    const input = screen.getByRole('combobox');
+
+    await user.type(input, 'a');
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBeGreaterThan(0));
+    await user.keyboard('{ArrowDown}');
+
+    // DOM focus stays in the input; the cursor is announced through
+    // aria-activedescendant, which is the whole point of the pattern.
+    await waitFor(() => expect(input).toHaveAttribute('aria-activedescendant'));
+    expect(input).toHaveFocus();
+  });
+
+  it('wraps from the last option back to the first', async () => {
+    const user = userEvent.setup();
+    renderAutocomplete();
+    const input = screen.getByRole('combobox');
+
+    await user.type(input, 'a');
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(3));
+
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}');
+    const atLast = input.getAttribute('aria-activedescendant');
+    await user.keyboard('{ArrowDown}');
+    const wrapped = input.getAttribute('aria-activedescendant');
+
+    expect(wrapped).not.toBe(atLast);
+    expect(wrapped).toMatch(/option-0$/);
+  });
+
+  it('selects the highlighted option with Enter', async () => {
+    const user = userEvent.setup();
+    const { onSelect } = renderAutocomplete();
+
+    await user.type(screen.getByRole('combobox'), 'a');
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBeGreaterThan(0));
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    expect(onSelect).toHaveBeenCalledWith(FRUITS[0]);
+  });
+
+  it('leaves Enter to the form when nothing is highlighted', async () => {
+    // A user typing free text and pressing Enter means to submit, not to pick
+    // a suggestion they never moved to.
+    const user = userEvent.setup();
+    const { onSelect } = renderAutocomplete();
+
+    await user.type(screen.getByRole('combobox'), 'a');
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBeGreaterThan(0));
+    await user.keyboard('{Enter}');
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape without selecting', async () => {
+    const user = userEvent.setup();
+    const { onSelect } = renderAutocomplete();
+    const input = screen.getByRole('combobox');
+
+    await user.type(input, 'a');
+    await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'true'));
+    await user.keyboard('{ArrowDown}{Escape}');
+
+    await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'false'));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('marks options as options', async () => {
+    const user = userEvent.setup();
+    renderAutocomplete();
+
+    await user.type(screen.getByRole('combobox'), 'a');
+
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(3));
+  });
+
+  it('marks exactly one option selected at a time', async () => {
+    const user = userEvent.setup();
+    renderAutocomplete();
+
+    await user.type(screen.getByRole('combobox'), 'a');
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(3));
+    await user.keyboard('{ArrowDown}');
+
+    await waitFor(() => {
+      const selected = screen
+        .getAllByRole('option')
+        .filter((o) => o.getAttribute('aria-selected') === 'true');
+      expect(selected).toHaveLength(1);
+    });
+  });
+});

--- a/web/components/forms/autocomplete-input.tsx
+++ b/web/components/forms/autocomplete-input.tsx
@@ -25,7 +25,7 @@
  */
 
 import * as React from 'react';
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useId } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Loader2, Check, X } from 'lucide-react';
 import { logger } from '@/lib/observability';
@@ -149,6 +149,25 @@ export function AutocompleteInput<T>({
     }
   }, [selectedValue, getItemValue]);
 
+  // Index of the option keyboard focus is on, or -1 for none.
+  //
+  // The combobox pattern keeps DOM focus in the input and moves a *virtual*
+  // cursor over the listbox, announced through `aria-activedescendant`. Moving
+  // real focus into the list would take it off the text field the user is
+  // typing in.
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  // Stable ids so `aria-controls` and `aria-activedescendant` can point at the
+  // listbox and the active option.
+  const generatedId = useId();
+  const listboxId = `${id ?? generatedId}-listbox`;
+  const optionId = (index: number) => `${listboxId}-option-${index}`;
+
+  // A new result set invalidates the cursor.
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [results]);
+
   // Handle input change
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -192,6 +211,67 @@ export function AutocompleteInput<T>({
     setTimeout(() => setOpen(false), 200);
   }, []);
 
+  /**
+   * Keyboard interaction for the combobox pattern.
+   *
+   * @remarks
+   * Previously the only key handled anywhere in this family was Escape, so a
+   * keyboard user could open a list of suggestions and had no way to choose
+   * one. Arrow keys move the virtual cursor, Home and End jump to the ends,
+   * Enter commits, and Escape closes without committing — which is the whole
+   * contract a screen reader user is entitled to expect from `role="combobox"`.
+   */
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        setActiveIndex(-1);
+        return;
+      }
+
+      if (!open || results.length === 0) {
+        // Down opens a closed list rather than doing nothing.
+        if (event.key === 'ArrowDown' && inputValue.length >= minChars) {
+          event.preventDefault();
+          setOpen(true);
+        }
+        return;
+      }
+
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          setActiveIndex((i) => (i + 1) % results.length);
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          setActiveIndex((i) => (i <= 0 ? results.length - 1 : i - 1));
+          break;
+        case 'Home':
+          event.preventDefault();
+          setActiveIndex(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          setActiveIndex(results.length - 1);
+          break;
+        case 'Enter': {
+          const item = results[activeIndex];
+          if (item !== undefined) {
+            // Only when a suggestion is actually highlighted; otherwise Enter
+            // belongs to the surrounding form.
+            event.preventDefault();
+            handleSelect(item);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [open, results, activeIndex, handleSelect, inputValue.length, minChars]
+  );
+
   const showClearButton = clearable && inputValue.length > 0 && !disabled;
 
   return (
@@ -208,8 +288,14 @@ export function AutocompleteInput<T>({
               onChange={handleInputChange}
               onFocus={handleFocus}
               onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
               disabled={disabled}
               className={cn(showClearButton && 'pr-10')}
+              role="combobox"
+              aria-expanded={open && shouldSearch}
+              aria-controls={listboxId}
+              aria-autocomplete="list"
+              aria-activedescendant={activeIndex >= 0 && open ? optionId(activeIndex) : undefined}
             />
             {isLoading && shouldSearch && (
               <div className="absolute right-3 top-1/2 -translate-y-1/2">
@@ -238,20 +324,25 @@ export function AutocompleteInput<T>({
             onOpenAutoFocus={(e) => e.preventDefault()}
           >
             <Command>
-              <CommandList>
+              <CommandList id={listboxId} role="listbox">
                 {results.length === 0 && !isLoading ? (
                   <CommandEmpty>{emptyMessage}</CommandEmpty>
                 ) : (
                   <CommandGroup heading={groupLabel}>
-                    {results.map((item) => {
+                    {results.map((item, index) => {
                       const key = getItemKey(item);
                       const isSelected = selectedValue != null && getItemKey(selectedValue) === key;
+                      const isActive = index === activeIndex;
                       return (
                         <CommandItem
                           key={key}
+                          id={optionId(index)}
+                          role="option"
+                          aria-selected={isActive}
                           value={key}
                           onSelect={() => handleSelect(item)}
-                          className="cursor-pointer"
+                          onMouseEnter={() => setActiveIndex(index)}
+                          className={cn('cursor-pointer', isActive && 'bg-accent')}
                         >
                           {isSelected && <Check className="mr-2 h-4 w-4 shrink-0" />}
                           <div className={cn(!isSelected && 'ml-6', 'flex-1')}>

--- a/web/components/forms/node-autocomplete.tsx
+++ b/web/components/forms/node-autocomplete.tsx
@@ -41,7 +41,7 @@
  */
 
 import * as React from 'react';
-import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef, useId } from 'react';
 import { Tags, Search, Loader2, X, ExternalLink, Plus } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 
@@ -617,18 +617,95 @@ export function NodeAutocomplete({
     [onSelect]
   );
 
+  // The options as a keyboard user walks them: personal first, then global,
+  // matching the render order below. Both lists are sliced to `limit`, so the
+  // cursor must walk the sliced arrays rather than the full ones.
+  const visibleOptions = useMemo(
+    () => [...personalSuggestions.slice(0, limit), ...globalSuggestions.slice(0, limit)],
+    [personalSuggestions, globalSuggestions, limit]
+  );
+
+  // Virtual cursor for the combobox pattern. DOM focus stays in the input;
+  // this is what `aria-activedescendant` points at.
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const generatedId = useId();
+  const listboxId = `${id ?? generatedId}-listbox`;
+  const optionDomId = (index: number) => `${listboxId}-option-${index}`;
+  const indexOfOption = (uri: string) => visibleOptions.findIndex((s) => s.uri === uri);
+
+  // A new result set invalidates the cursor.
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [visibleOptions]);
+
   const handleClear = useCallback(() => {
     setSelectedValue(null);
     setQuery('');
     onClear?.();
+    setActiveIndex(-1);
   }, [onClear]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Escape') {
-      setIsOpen(false);
-      setShowInlineCreate(false);
-    }
-  }, []);
+  /**
+   * Keyboard interaction for the combobox pattern.
+   *
+   * @remarks
+   * This handled Escape and nothing else, which meant a keyboard user could
+   * open a list of suggestions and had no way to reach one — the component
+   * offered choices only to a mouse. Arrow keys move the virtual cursor, Home
+   * and End jump to the ends, Enter commits the highlighted suggestion, and
+   * Escape closes without committing.
+   */
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+        setShowInlineCreate(false);
+        setActiveIndex(-1);
+        return;
+      }
+
+      if (!isOpen || visibleOptions.length === 0) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setIsOpen(true);
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setActiveIndex((i) => (i + 1) % visibleOptions.length);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setActiveIndex((i) => (i <= 0 ? visibleOptions.length - 1 : i - 1));
+          break;
+        case 'Home':
+          e.preventDefault();
+          setActiveIndex(0);
+          break;
+        case 'End':
+          e.preventDefault();
+          setActiveIndex(visibleOptions.length - 1);
+          break;
+        case 'Enter': {
+          const suggestion = visibleOptions[activeIndex];
+          if (suggestion !== undefined) {
+            // Only when a suggestion is highlighted; otherwise Enter belongs to
+            // the surrounding form.
+            e.preventDefault();
+            handleSelect(suggestion);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [isOpen, visibleOptions, activeIndex, handleSelect]
+  );
 
   const handleFocus = useCallback(() => {
     setIsOpen(true);
@@ -747,6 +824,13 @@ export function NodeAutocomplete({
             disabled={disabled}
             className="pl-9"
             aria-label={`Search ${label}`}
+            role="combobox"
+            aria-expanded={isOpen}
+            aria-controls={listboxId}
+            aria-autocomplete="list"
+            aria-activedescendant={
+              activeIndex >= 0 && isOpen ? optionDomId(activeIndex) : undefined
+            }
           />
           {isLoading && (
             <Loader2 className="absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
@@ -779,9 +863,16 @@ export function NodeAutocomplete({
                 {personalSuggestions.slice(0, limit).map((suggestion) => (
                   <CommandItem
                     key={suggestion.uri}
+                    id={optionDomId(indexOfOption(suggestion.uri))}
+                    role="option"
+                    aria-selected={indexOfOption(suggestion.uri) === activeIndex}
                     value={suggestion.uri}
                     onSelect={() => handleSelect(suggestion)}
-                    className="cursor-pointer"
+                    onMouseEnter={() => setActiveIndex(indexOfOption(suggestion.uri))}
+                    className={cn(
+                      'cursor-pointer',
+                      indexOfOption(suggestion.uri) === activeIndex && 'bg-accent'
+                    )}
                   >
                     <div className="flex items-center justify-between gap-2 w-full">
                       <div className="flex flex-col gap-0.5 flex-1 min-w-0">
@@ -821,9 +912,16 @@ export function NodeAutocomplete({
                   return (
                     <CommandItem
                       key={suggestion.id}
+                      id={optionDomId(indexOfOption(suggestion.uri))}
+                      role="option"
+                      aria-selected={indexOfOption(suggestion.uri) === activeIndex}
                       value={suggestion.id}
                       onSelect={() => handleSelect(suggestion)}
-                      className="cursor-pointer"
+                      onMouseEnter={() => setActiveIndex(indexOfOption(suggestion.uri))}
+                      className={cn(
+                        'cursor-pointer',
+                        indexOfOption(suggestion.uri) === activeIndex && 'bg-accent'
+                      )}
                     >
                       <div className="flex items-center justify-between gap-2 w-full">
                         <div className="flex flex-col gap-0.5 flex-1 min-w-0">

--- a/web/components/submit/submission-wizard.tsx
+++ b/web/components/submit/submission-wizard.tsx
@@ -998,15 +998,38 @@ export function SubmissionWizard({
         targetAgent
       );
 
-      // Optionally create a standard.site document for cross-platform discovery
-      if (values.enableCrossPlatformDiscovery && agent) {
+      // Create the standard.site document for cross-platform discovery.
+      //
+      // Emitted by default: the toggle now has to be turned off rather than on.
+      // A standard.site document is how an eprint becomes legible to the rest
+      // of the publishing ecosystem — a Bluesky card, a Leaflet embed, a
+      // standard.site reader — and there is no reason a public eprint would
+      // want to be invisible to it.
+      if ((values.enableCrossPlatformDiscovery ?? true) && agent) {
         try {
           submitLogger.info('Creating standard.site document', { eprintUri: result.uri });
           await createStandardDocument(agent, {
             title: values.title,
-            description: values.abstract?.substring(0, 2000),
+            description: values.abstract?.substring(0, 30000),
             eprintUri: result.uri,
             eprintCid: result.cid,
+            siteUrl: process.env.NEXT_PUBLIC_SITE_URL ?? 'https://chive.pub',
+            publishedAt: new Date().toISOString(),
+            // The abstract is the document's plaintext; `textContent` is
+            // specified as carrying no markdown or other formatting.
+            ...(values.abstract ? { textContent: values.abstract } : {}),
+            // Chive's authorship maps onto standard.site contributors. Only
+            // authors with a DID can be expressed: `contributor.did` is
+            // required, and an external collaborator without one has no
+            // ATProto identity to name.
+            contributors: transformedAuthors
+              .filter((a): a is typeof a & { did: string } => typeof a.did === 'string' && !!a.did)
+              .map((a) => ({
+                did: a.did,
+                ...(a.name ? { displayName: a.name.substring(0, 1000) } : {}),
+                ...(a.isCorrespondingAuthor ? { role: 'corresponding-author' } : {}),
+              })),
+            ...(values.keywords && values.keywords.length > 0 ? { tags: values.keywords } : {}),
           });
           submitLogger.info('Standard.site document created for cross-platform discovery');
         } catch (standardDocError) {

--- a/web/lib/atproto/index.ts
+++ b/web/lib/atproto/index.ts
@@ -29,6 +29,12 @@ export {
   // Standard.site records
   createStandardDocument,
   updateStandardDocument,
+  attachBlueskyPostToDocument,
+  describesEprint,
+  eprintPath,
+  type StrongRef,
+  type StandardCitationLink,
+  type StandardCitationTarget,
   // Layers records
   createLayersDataLinks,
   LAYERS_DATA_KINDS,

--- a/web/lib/atproto/record-creator.test.ts
+++ b/web/lib/atproto/record-creator.test.ts
@@ -23,7 +23,9 @@ import {
   getAuthenticatedDid,
   buildAtUri,
   parseAtUri,
+  attachBlueskyPostToDocument,
   createStandardDocument,
+  describesEprint,
   createLayersDataLinks,
   updateStandardDocument,
   deleteStandardDocumentsForEprint,
@@ -928,90 +930,26 @@ describe('createStandardDocument', () => {
     );
   });
 
-  it('includes content reference with uri and cid', async () => {
+  // Five tests here asserted the invalid shape: `content: {uri, cid}`,
+  // `visibility`, `createdAt`, and a 2000-character description cap. None of
+  // those are properties of `site.standard.document`. They are replaced by the
+  // conformance block at the end of this file, which checks the record against
+  // the published lexicon instead.
+
+  it('truncates a description to the length the lexicon allows', async () => {
     const did = 'did:plc:test123';
     const agent = createMockAgent({ did });
-    const eprintUri = `at://${did}/pub.chive.eprint.submission/abc123`;
-    const eprintCid = 'bafyeprint123';
 
     await createStandardDocument(agent, {
       title: 'Test Paper',
-      eprintUri,
-      eprintCid,
-    });
-
-    const createRecordCall = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
-      .calls[0][0];
-    expect(createRecordCall.record.content).toEqual({
-      uri: eprintUri,
-      cid: eprintCid,
-    });
-  });
-
-  it('omits cid from content reference when not provided', async () => {
-    const did = 'did:plc:test123';
-    const agent = createMockAgent({ did });
-    const eprintUri = `at://${did}/pub.chive.eprint.submission/abc123`;
-
-    await createStandardDocument(agent, {
-      title: 'Test Paper',
-      eprintUri,
-    });
-
-    const createRecordCall = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
-      .calls[0][0];
-    expect(createRecordCall.record.content).toEqual({
-      uri: eprintUri,
-    });
-    expect(createRecordCall.record.content.cid).toBeUndefined();
-  });
-
-  it('truncates description to 2000 characters', async () => {
-    const did = 'did:plc:test123';
-    const agent = createMockAgent({ did });
-    const longDescription = 'x'.repeat(3000);
-
-    await createStandardDocument(agent, {
-      title: 'Test Paper',
-      description: longDescription,
+      description: 'x'.repeat(40000),
       eprintUri: `at://${did}/pub.chive.eprint.submission/abc123`,
     });
 
     const createRecordCall = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
       .calls[0][0];
-    expect(createRecordCall.record.description).toHaveLength(2000);
-  });
-
-  it('sets visibility to public', async () => {
-    const did = 'did:plc:test123';
-    const agent = createMockAgent({ did });
-
-    await createStandardDocument(agent, {
-      title: 'Test Paper',
-      eprintUri: `at://${did}/pub.chive.eprint.submission/abc123`,
-    });
-
-    const createRecordCall = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
-      .calls[0][0];
-    expect(createRecordCall.record.visibility).toBe('public');
-  });
-
-  it('includes createdAt timestamp', async () => {
-    const did = 'did:plc:test123';
-    const agent = createMockAgent({ did });
-
-    await createStandardDocument(agent, {
-      title: 'Test Paper',
-      eprintUri: `at://${did}/pub.chive.eprint.submission/abc123`,
-    });
-
-    const createRecordCall = (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock
-      .calls[0][0];
-    expect(createRecordCall.record.createdAt).toBeDefined();
-    // Should be a valid ISO date string
-    expect(new Date(createRecordCall.record.createdAt).toISOString()).toBe(
-      createRecordCall.record.createdAt
-    );
+    // 30000, not 2000: the lexicon's maxLength.
+    expect(createRecordCall.record.description).toHaveLength(30000);
   });
 
   it('throws when not authenticated', async () => {
@@ -1102,12 +1040,16 @@ describe('updateStandardDocument', () => {
     expect(result.cid).toBeDefined();
   });
 
-  it('preserves original createdAt and visibility', async () => {
+  it('repairs a legacy document while updating it', async () => {
+    // This used to assert `createdAt` and `visibility` survived an update.
+    // Neither is a field of `site.standard.document`. A document written before
+    // the schema fix has that shape and is invalid, so updating one is the
+    // moment to make it valid: the required `site` and `publishedAt` are filled
+    // in, and the eprint link moves from `content.uri` to `path`.
     const did = 'did:plc:test123';
     const agent = createMockAgent({ did });
-    const originalCreatedAt = '2024-01-15T00:00:00.000Z';
+    const eprintUri = `at://${did}/pub.chive.eprint.submission/abc123`;
 
-    // Mock getRecord
     (agent.com.atproto.repo.getRecord as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       data: {
         uri: `at://${did}/site.standard.document/doc123`,
@@ -1115,11 +1057,9 @@ describe('updateStandardDocument', () => {
         value: {
           $type: 'site.standard.document',
           title: 'Original Title',
-          content: {
-            uri: `at://${did}/pub.chive.eprint.submission/abc123`,
-          },
+          content: { uri: eprintUri },
           visibility: 'public',
-          createdAt: originalCreatedAt,
+          createdAt: '2024-01-15T00:00:00.000Z',
         },
       },
     });
@@ -1129,10 +1069,13 @@ describe('updateStandardDocument', () => {
       title: 'Updated Title',
     });
 
-    const putRecordCall = (agent.com.atproto.repo.putRecord as ReturnType<typeof vi.fn>).mock
-      .calls[0][0];
-    expect(putRecordCall.record.createdAt).toBe(originalCreatedAt);
-    expect(putRecordCall.record.visibility).toBe('public');
+    const record = (agent.com.atproto.repo.putRecord as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      .record;
+    expect(record.site).toEqual(expect.any(String));
+    expect(record.publishedAt).toEqual(expect.any(String));
+    expect(record.path).toBe(`/eprints/${encodeURIComponent(eprintUri)}`);
+    expect(record).not.toHaveProperty('visibility');
+    expect(record).not.toHaveProperty('createdAt');
   });
 
   it('adds updatedAt timestamp', async () => {
@@ -1339,5 +1282,306 @@ describe('createLayersDataLinks', () => {
     await expect(
       createLayersDataLinks(agent, { eprintUri, dataLinks: [{ dataKind: 'corpus' }] })
     ).rejects.toThrow('not authenticated');
+  });
+});
+
+// =============================================================================
+// STANDARD.SITE SCHEMA CONFORMANCE
+// =============================================================================
+
+describe('createStandardDocument conforms to the published lexicon', () => {
+  const did = 'did:plc:test123';
+  const eprintUri = `at://${did}/pub.chive.eprint.submission/abc123`;
+
+  function writtenRecord(agent: ReturnType<typeof createMockAgent>) {
+    return (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      .record as Record<string, unknown>;
+  }
+
+  it('writes the three fields the lexicon requires', async () => {
+    // `site`, `title` and `publishedAt`. Two of the three were missing before,
+    // so every document Chive had written was invalid and no standard.site
+    // reader could accept one.
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, { title: 'A paper', eprintUri });
+
+    const record = writtenRecord(agent);
+    expect(record.site).toEqual(expect.any(String));
+    expect(record.title).toBe('A paper');
+    expect(record.publishedAt).toEqual(expect.any(String));
+  });
+
+  it('no longer writes fields the lexicon does not define', async () => {
+    // `visibility` and `createdAt` are not properties of this record type, and
+    // `content` is an open union rather than a `{uri, cid}` object.
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, { title: 'A paper', eprintUri });
+
+    const record = writtenRecord(agent);
+    expect(record).not.toHaveProperty('visibility');
+    expect(record).not.toHaveProperty('createdAt');
+    expect(record.content).toBeUndefined();
+  });
+
+  it('sets a path that resolves to the eprint page under the site origin', async () => {
+    // `site` + `path` is the canonical URL, and how a reader verifies that the
+    // document and the page describe the same work.
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, {
+      title: 'A paper',
+      eprintUri,
+      siteUrl: 'https://staging.chive.pub',
+    });
+
+    const record = writtenRecord(agent);
+    expect(record.site).toBe('https://staging.chive.pub');
+    expect(record.path).toBe(`/eprints/${encodeURIComponent(eprintUri)}`);
+    expect(String(record.path).startsWith('/')).toBe(true);
+  });
+
+  it('carries contributors, tags and plaintext when given them', async () => {
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, {
+      title: 'A paper',
+      eprintUri,
+      textContent: 'The abstract in plain text.',
+      tags: ['semantics', 'parsing'],
+      contributors: [
+        { did: 'did:plc:author1', displayName: 'A. Author', role: 'corresponding-author' },
+      ],
+    });
+
+    const record = writtenRecord(agent);
+    expect(record.textContent).toBe('The abstract in plain text.');
+    expect(record.tags).toEqual(['semantics', 'parsing']);
+    expect(record.contributors).toEqual([
+      { did: 'did:plc:author1', displayName: 'A. Author', role: 'corresponding-author' },
+    ]);
+  });
+
+  it('omits optional arrays rather than writing empty ones', async () => {
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, {
+      title: 'A paper',
+      eprintUri,
+      contributors: [],
+      tags: [],
+    });
+
+    const record = writtenRecord(agent);
+    expect(record).not.toHaveProperty('contributors');
+    expect(record).not.toHaveProperty('tags');
+  });
+
+  it('defaults the site origin when none is supplied', async () => {
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, { title: 'A paper', eprintUri });
+
+    expect(writtenRecord(agent).site).toBe('https://chive.pub');
+  });
+
+  it('does not put a trailing slash on the site origin', async () => {
+    // The lexicon says to avoid one, because site is concatenated with path.
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, { title: 'A paper', eprintUri });
+
+    expect(String(writtenRecord(agent).site).endsWith('/')).toBe(false);
+  });
+});
+
+describe('describesEprint', () => {
+  const eprintUri = 'at://did:plc:a/pub.chive.eprint.submission/abc';
+
+  it('matches a document by its path', () => {
+    expect(describesEprint({ path: `/eprints/${encodeURIComponent(eprintUri)}` }, eprintUri)).toBe(
+      true
+    );
+  });
+
+  it('still matches a legacy document by content.uri', () => {
+    // Documents written before the schema fix carry `content.uri` and no
+    // `path`. They must stay findable, or deleting an eprint strands every
+    // document already in a user's repository.
+    expect(describesEprint({ content: { uri: eprintUri } }, eprintUri)).toBe(true);
+  });
+
+  it('does not match a different eprint', () => {
+    const other = 'at://did:plc:b/pub.chive.eprint.submission/xyz';
+    expect(describesEprint({ path: `/eprints/${encodeURIComponent(other)}` }, eprintUri)).toBe(
+      false
+    );
+  });
+
+  it('does not match a record with neither field', () => {
+    expect(describesEprint({ title: 'Unrelated' }, eprintUri)).toBe(false);
+  });
+
+  it('survives values that are not records', () => {
+    for (const value of [null, undefined, 'string', 7]) {
+      expect(describesEprint(value, eprintUri)).toBe(false);
+    }
+  });
+});
+
+describe('citation links in the standard.site links union', () => {
+  const did = 'did:plc:test123';
+  const eprintUri = `at://${did}/pub.chive.eprint.submission/abc123`;
+
+  function writtenRecord(agent: ReturnType<typeof createMockAgent>) {
+    return (agent.com.atproto.repo.createRecord as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      .record as Record<string, unknown>;
+  }
+
+  it('writes nothing into links when no citations are given', async () => {
+    // Opt-in: an unratified extension should not appear in every document
+    // Chive writes into a user's repository.
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, { title: 'A paper', eprintUri });
+
+    expect(writtenRecord(agent)).not.toHaveProperty('links');
+  });
+
+  it('writes typed citations into the reserved links union', async () => {
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, {
+      title: 'A paper',
+      eprintUri,
+      citations: [
+        {
+          $type: 'pub.chive.site.citationLink',
+          relation: 'replicates',
+          target: { title: 'The 2019 result', doi: '10.1000/abc' },
+          context: 'Section 4',
+        },
+      ],
+    });
+
+    expect(writtenRecord(agent).links).toEqual([
+      {
+        $type: 'pub.chive.site.citationLink',
+        relation: 'replicates',
+        target: { title: 'The 2019 result', doi: '10.1000/abc' },
+        context: 'Section 4',
+      },
+    ]);
+  });
+
+  it('gives every link a $type, which the union requires', async () => {
+    // `links` is an open union: a member with no $type cannot be dispatched on
+    // by any consumer.
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, {
+      title: 'A paper',
+      eprintUri,
+      citations: [
+        { $type: 'pub.chive.site.citationLink', relation: 'cites', target: { title: 'A work' } },
+      ],
+    });
+
+    const links = writtenRecord(agent).links as Array<{ $type?: string }>;
+    expect(links.every((l) => typeof l.$type === 'string')).toBe(true);
+  });
+
+  it('omits an empty citation list rather than writing an empty union', async () => {
+    const agent = createMockAgent({ did });
+
+    await createStandardDocument(agent, { title: 'A paper', eprintUri, citations: [] });
+
+    expect(writtenRecord(agent)).not.toHaveProperty('links');
+  });
+});
+
+describe('attachBlueskyPostToDocument', () => {
+  const did = 'did:plc:test123';
+  const eprintUri = `at://${did}/pub.chive.eprint.submission/abc123`;
+  const postRef = { uri: `at://${did}/app.bsky.feed.post/post1`, cid: 'bafypost' };
+
+  // The base mock agent has no listRecords; build one that answers with the
+  // given documents in a single page.
+  function agentListing(records: unknown[]) {
+    const agent = createMockAgent({ did });
+    const listRecords = vi.fn().mockResolvedValue({ data: { records, cursor: undefined } });
+    (agent.com.atproto.repo as unknown as { listRecords: typeof listRecords }).listRecords =
+      listRecords;
+    return agent;
+  }
+
+  it('records the post on the document describing that eprint', async () => {
+    const docUri = `at://${did}/site.standard.document/doc1`;
+    const agent = agentListing([
+      { uri: docUri, value: { path: `/eprints/${encodeURIComponent(eprintUri)}` } },
+    ]);
+    (agent.com.atproto.repo.getRecord as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { uri: docUri, cid: 'bafydoc', value: { title: 'A paper', site: 'https://chive.pub' } },
+    });
+
+    const result = await attachBlueskyPostToDocument(agent, eprintUri, postRef);
+
+    expect(result).toBe(docUri);
+    const written = (agent.com.atproto.repo.putRecord as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      .record;
+    expect(written.bskyPostRef).toEqual(postRef);
+  });
+
+  it('finds a legacy document by its content.uri', async () => {
+    const docUri = `at://${did}/site.standard.document/legacy`;
+    const agent = agentListing([{ uri: docUri, value: { content: { uri: eprintUri } } }]);
+    (agent.com.atproto.repo.getRecord as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        uri: docUri,
+        cid: 'bafydoc',
+        value: { title: 'A paper', content: { uri: eprintUri } },
+      },
+    });
+
+    expect(await attachBlueskyPostToDocument(agent, eprintUri, postRef)).toBe(docUri);
+  });
+
+  it('returns null when the eprint has no document', async () => {
+    // Sharing an eprint whose submitter turned cross-platform discovery off is
+    // ordinary. The share has already succeeded; this must not throw.
+    const agent = agentListing([
+      { uri: 'at://x/site.standard.document/other', value: { path: '/other' } },
+    ]);
+
+    expect(await attachBlueskyPostToDocument(agent, eprintUri, postRef)).toBeNull();
+    expect(agent.com.atproto.repo.putRecord).not.toHaveBeenCalled();
+  });
+
+  it('refuses to write for an unauthenticated agent', async () => {
+    const agent = createMockAgent({ authenticated: false });
+
+    await expect(attachBlueskyPostToDocument(agent, eprintUri, postRef)).rejects.toThrow(
+      'not authenticated'
+    );
+  });
+
+  it('keeps an existing post ref when updating for other reasons', async () => {
+    const agent = createMockAgent({ did });
+    const docUri = `at://${did}/site.standard.document/doc1`;
+    (agent.com.atproto.repo.getRecord as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        uri: docUri,
+        cid: 'bafydoc',
+        value: { title: 'A paper', site: 'https://chive.pub', bskyPostRef: postRef },
+      },
+    });
+
+    await updateStandardDocument(agent, { uri: docUri, title: 'Renamed' });
+
+    const written = (agent.com.atproto.repo.putRecord as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      .record;
+    // Renaming a document must not discard its discussion thread.
+    expect(written.bskyPostRef).toEqual(postRef);
   });
 });

--- a/web/lib/atproto/record-creator.ts
+++ b/web/lib/atproto/record-creator.ts
@@ -2053,6 +2053,71 @@ export function parseAtUri(uri: string): {
 // =============================================================================
 
 /**
+ * The eprint URI a legacy document pointed at.
+ *
+ * @param value - A record that may predate the schema fix
+ * @returns The URI from `content.uri`, or undefined
+ *
+ * @internal
+ */
+function legacyEprintUri(value: unknown): string | undefined {
+  if (value === null || typeof value !== 'object') return undefined;
+  const content = (value as { content?: { uri?: unknown } }).content;
+  return typeof content?.uri === 'string' ? content.uri : undefined;
+}
+
+/**
+ * Whether a standard.site document describes a given eprint.
+ *
+ * @param value - The record as stored
+ * @param eprintUri - AT-URI of the eprint
+ * @returns True when the document is about that eprint
+ *
+ * @remarks
+ * Matches on `path`, which is where the link now lives, and also on the legacy
+ * `content.uri`. The legacy branch is not optional: documents written before
+ * this change carry `content.uri` and no `path`, and they still need to be
+ * findable so deleting an eprint can clean them up. Dropping it would strand
+ * every document already in a user's repository.
+ *
+ * @public
+ */
+export function describesEprint(value: unknown, eprintUri: string): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  const record = value as { path?: unknown; content?: unknown };
+
+  if (record.path === eprintPath(eprintUri)) return true;
+
+  const legacyContent = record.content as { uri?: unknown } | undefined;
+  return legacyContent?.uri === eprintUri;
+}
+
+/**
+ * Default origin for `site.standard.document.site`.
+ *
+ * @remarks
+ * Matches `NEXT_PUBLIC_SITE_URL`'s default. No trailing slash: the lexicon
+ * says to avoid one, because `site` is concatenated with `path`.
+ */
+const DEFAULT_SITE_URL = 'https://chive.pub';
+
+/**
+ * The path of an eprint's page under the site origin.
+ *
+ * @param eprintUri - AT-URI of the eprint
+ * @returns Path beginning with a slash
+ *
+ * @remarks
+ * Mirrors the frontend route `/eprints/[...uri]`, so `site + path` resolves to
+ * the page describing the same eprint.
+ *
+ * @public
+ */
+export function eprintPath(eprintUri: string): string {
+  return `/eprints/${encodeURIComponent(eprintUri)}`;
+}
+
+/**
  * Standard document record as stored in ATProto (site.standard.document).
  *
  * @remarks
@@ -2063,15 +2128,98 @@ export function parseAtUri(uri: string): {
 export interface StandardDocumentRecord {
   [key: string]: unknown;
   $type: 'site.standard.document';
+  /** Publication record or site URL this document belongs to. Required. */
+  site: string;
   title: string;
+  /** When the document was published. Required. */
+  publishedAt: string;
+  /** Path under `site`, with a leading slash, forming the canonical URL */
+  path?: string;
   description?: string;
-  content: {
-    uri: string;
-    cid?: string;
-  };
-  visibility: 'public' | 'private' | 'unlisted';
-  createdAt: string;
+  /** Plaintext of the document, with no markdown or other formatting */
+  textContent?: string;
+  /** Everyone credited on the document beyond the record's author */
+  contributors?: StandardDocumentContributor[];
+  /** Typed citations, written into the lexicon's reserved `links` union */
+  links?: StandardCitationLink[];
+  /**
+   * Strong reference to the Bluesky post announcing this document.
+   *
+   * @remarks
+   * The lexicon describes this as "useful to keep track of comments
+   * off-platform", which is exactly its use here: the announcing post's reply
+   * thread is the discussion of the eprint that happens on Bluesky rather than
+   * on Chive.
+   */
+  bskyPostRef?: StrongRef;
+  tags?: string[];
   updatedAt?: string;
+}
+
+/**
+ * A typed citation written into a standard.site document's `links` union.
+ *
+ * @remarks
+ * `site.standard.document.links` is declared as a union with no members —
+ * reserved, and left open for extensions. `pub.chive.site.citationLink` is
+ * Chive's proposal for what belongs there: a document-to-work link with a
+ * CiTO-style relation, so a consumer that knows the Citation Typing Ontology
+ * can read a Chive citation without knowing anything about Chive.
+ *
+ * Shipping it in Chive's emissions is the proposal. It is staged behind
+ * {@link CreateStandardDocumentInput.citations} rather than emitted for every
+ * document, because writing an unratified extension into other people's
+ * records by default would be presumptuous.
+ *
+ * @public
+ */
+export interface StandardCitationLink {
+  $type: 'pub.chive.site.citationLink';
+  /** CiTO-style relation; `cites` when nothing more specific is known */
+  relation: string;
+  target: StandardCitationTarget;
+  /** Where in the document the citation occurs, or the citing sentence */
+  context?: string;
+}
+
+/**
+ * The work a {@link StandardCitationLink} points at.
+ *
+ * @public
+ */
+export interface StandardCitationTarget {
+  title: string;
+  uri?: string;
+  doi?: string;
+  url?: string;
+  authors?: string[];
+  year?: number;
+  venue?: string;
+}
+
+/**
+ * A strong reference to another record: its URI and the CID it had.
+ *
+ * @remarks
+ * `com.atproto.repo.strongRef`. The CID pins the version, so a reader can tell
+ * whether the record has changed since the reference was made.
+ *
+ * @public
+ */
+export interface StrongRef {
+  uri: string;
+  cid: string;
+}
+
+/**
+ * A participant on a standard.site document beyond its author.
+ *
+ * @public
+ */
+export interface StandardDocumentContributor {
+  did: string;
+  role?: string;
+  displayName?: string;
 }
 
 /**
@@ -2080,12 +2228,37 @@ export interface StandardDocumentRecord {
 export interface CreateStandardDocumentInput {
   /** Title of the document */
   title: string;
-  /** Brief description or abstract (max 2000 chars) */
+  /** Brief description or abstract */
   description?: string;
-  /** AT-URI of the platform-specific content record (e.g., eprint) */
+  /** AT-URI of the eprint this document describes */
   eprintUri: string;
-  /** CID of the content record for verification */
+  /** CID of the eprint record */
   eprintCid?: string;
+  /**
+   * Origin this deployment serves from, without a trailing slash.
+   *
+   * @remarks
+   * Becomes the record's `site`. Combined with `path` it is the canonical URL
+   * of the eprint, which is how a standard.site reader verifies that the
+   * document and the page describe the same thing.
+   */
+  siteUrl?: string;
+  /** When the eprint was published; defaults to now */
+  publishedAt?: string;
+  /** Plaintext abstract */
+  textContent?: string;
+  /** Authors, mapped to standard.site contributors */
+  contributors?: StandardDocumentContributor[];
+  /** Keywords */
+  tags?: string[];
+  /**
+   * Typed citations to write into the document's `links` union.
+   *
+   * @remarks
+   * Omitted, no `links` are written. See {@link StandardCitationLink} for why
+   * this is opt-in rather than automatic.
+   */
+  citations?: StandardCitationLink[];
 }
 
 /**
@@ -2126,18 +2299,39 @@ export async function createStandardDocument(
 
   const record: StandardDocumentRecord = {
     $type: 'site.standard.document',
+    // `site` and `publishedAt` are required by the lexicon, and neither was
+    // being written. `content` was an object with `uri`/`cid`, where the schema
+    // has an open union whose members carry a `$type`, and `visibility` and
+    // `createdAt` are not fields at all. Every document written before this was
+    // therefore invalid, which is why nothing in the standard.site ecosystem
+    // ever picked one up.
+    site: input.siteUrl ?? DEFAULT_SITE_URL,
     title: input.title,
-    content: {
-      uri: input.eprintUri,
-      ...(input.eprintCid && { cid: input.eprintCid }),
-    },
-    visibility: 'public',
-    createdAt: new Date().toISOString(),
+    publishedAt: input.publishedAt ?? new Date().toISOString(),
+    // `site` + `path` is the canonical URL of the eprint page. A reader
+    // fetching it and finding the same document is how verification works, and
+    // it is what replaces the invented `content.uri` as the link back.
+    path: eprintPath(input.eprintUri),
   };
 
-  // Add optional description (truncated to 2000 chars per lexicon spec)
   if (input.description) {
-    record.description = input.description.substring(0, 2000);
+    record.description = input.description.substring(0, 30000);
+  }
+
+  if (input.textContent) {
+    record.textContent = input.textContent;
+  }
+
+  if (input.contributors && input.contributors.length > 0) {
+    record.contributors = input.contributors;
+  }
+
+  if (input.tags && input.tags.length > 0) {
+    record.tags = input.tags;
+  }
+
+  if (input.citations && input.citations.length > 0) {
+    record.links = input.citations;
   }
 
   const response = await agent.com.atproto.repo.createRecord({
@@ -2291,6 +2485,63 @@ export async function createLayersDataLinks(
 }
 
 /**
+ * Attach the announcing Bluesky post to an eprint's standard.site document.
+ *
+ * @param agent - Authenticated agent for the repo holding the document
+ * @param eprintUri - AT-URI of the eprint that was shared
+ * @param postRef - Strong reference to the Bluesky post
+ * @returns AT-URI of the document updated, or null when there is none
+ *
+ * @throws Error if the agent is not authenticated
+ *
+ * @remarks
+ * `site.standard.document.bskyPostRef` exists to "keep track of comments
+ * off-platform". Recording it makes the announcing post's reply thread
+ * discoverable from the document, which is what lets a reader — Chive's own
+ * eprint page, or any other standard.site consumer — show the Bluesky
+ * discussion of a paper alongside it.
+ *
+ * Returns null rather than throwing when no document exists: sharing an eprint
+ * whose submitter turned cross-platform discovery off is an ordinary thing to
+ * do, and the share has already succeeded by the time this runs. A share must
+ * never fail because a secondary record could not be updated.
+ *
+ * @public
+ */
+export async function attachBlueskyPostToDocument(
+  agent: Agent,
+  eprintUri: string,
+  postRef: StrongRef
+): Promise<string | null> {
+  const did = getAgentDid(agent);
+  if (!did) {
+    throw new Error('Agent is not authenticated');
+  }
+
+  let cursor: string | undefined;
+
+  do {
+    const response = await agent.com.atproto.repo.listRecords({
+      repo: did,
+      collection: 'site.standard.document',
+      limit: 100,
+      cursor,
+    });
+
+    for (const record of response.data.records) {
+      if (describesEprint(record.value, eprintUri)) {
+        await updateStandardDocument(agent, { uri: record.uri, bskyPostRef: postRef });
+        return record.uri;
+      }
+    }
+
+    cursor = response.data.cursor;
+  } while (cursor);
+
+  return null;
+}
+
+/**
  * Find and delete every `site.standard.document` record in a repo that points
  * at a given eprint.
  *
@@ -2339,8 +2590,7 @@ export async function deleteStandardDocumentsForEprint(
     });
 
     for (const record of response.data.records) {
-      const value = record.value as StandardDocumentRecord;
-      if (value.content?.uri === eprintUri) {
+      if (describesEprint(record.value, eprintUri)) {
         await deleteRecord(agent, record.uri);
         deleted.push(record.uri);
       }
@@ -2366,6 +2616,8 @@ export interface UpdateStandardDocumentInput {
   eprintUri?: string;
   /** Updated eprint CID */
   eprintCid?: string;
+  /** Bluesky post announcing the document, recorded as its discussion thread */
+  bskyPostRef?: StrongRef;
 }
 
 /**
@@ -2416,26 +2668,51 @@ export async function updateStandardDocument(
 
   const existing = existingResponse.data.value as StandardDocumentRecord;
 
-  // Build updated record, preserving existing values for fields not specified
+  // Build the updated record, keeping what the caller did not supply.
+  //
+  // An existing record may predate the schema fix and carry neither `site` nor
+  // `publishedAt`. Both are required, so they are filled in rather than copied
+  // blindly — updating a document is also the moment an invalid one becomes
+  // valid.
   const record: StandardDocumentRecord = {
     $type: 'site.standard.document',
+    site: existing.site ?? DEFAULT_SITE_URL,
     title: input.title ?? existing.title,
-    content: {
-      uri: input.eprintUri ?? existing.content.uri,
-      ...(input.eprintCid
-        ? { cid: input.eprintCid }
-        : existing.content.cid && { cid: existing.content.cid }),
-    },
-    visibility: existing.visibility,
-    createdAt: existing.createdAt,
+    publishedAt: existing.publishedAt ?? new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
 
-  // Update description if provided, otherwise preserve existing
+  const linkedUri = input.eprintUri ?? legacyEprintUri(existing);
+  if (linkedUri) {
+    record.path = eprintPath(linkedUri);
+  } else if (existing.path) {
+    record.path = existing.path;
+  }
+
   if (input.description !== undefined) {
-    record.description = input.description.substring(0, 2000);
+    record.description = input.description.substring(0, 30000);
   } else if (existing.description) {
     record.description = existing.description;
+  }
+
+  if (existing.textContent !== undefined) {
+    record.textContent = existing.textContent;
+  }
+  if (existing.contributors !== undefined) {
+    record.contributors = existing.contributors;
+  }
+  if (existing.tags !== undefined) {
+    record.tags = existing.tags;
+  }
+  if (existing.links !== undefined) {
+    record.links = existing.links;
+  }
+
+  // A newly supplied post ref replaces whatever was there; otherwise the
+  // existing one survives, so updating a title does not discard the thread.
+  const bskyPostRef = input.bskyPostRef ?? existing.bskyPostRef;
+  if (bskyPostRef !== undefined) {
+    record.bskyPostRef = bskyPostRef;
   }
 
   const response = await agent.com.atproto.repo.putRecord({

--- a/web/lib/bluesky/types.ts
+++ b/web/lib/bluesky/types.ts
@@ -33,6 +33,14 @@ export interface CreateBlueskyPostInput {
   text: string;
   /** External embed for link preview card */
   embed: ExternalEmbed;
+  /**
+   * AT-URI of the eprint being announced, when there is one.
+   *
+   * @remarks
+   * Not part of the Bluesky record. It tells the caller which eprint's
+   * standard.site document should record this post as its `bskyPostRef`.
+   */
+  eprintUri?: string;
 }
 
 /**
@@ -108,6 +116,15 @@ export interface ShareContent {
   description: string;
   /** URL to the OG image */
   ogImageUrl: string;
+  /**
+   * AT-URI of the eprint being shared, when the content is one.
+   *
+   * @remarks
+   * Supplied so the announcing post can be recorded on the eprint's
+   * standard.site document as `bskyPostRef`, which is what makes the post's
+   * reply thread findable as the discussion of that paper.
+   */
+  eprintUri?: string;
 }
 
 /**

--- a/web/lib/hooks/use-share-to-bluesky.ts
+++ b/web/lib/hooks/use-share-to-bluesky.ts
@@ -11,6 +11,8 @@ import { useCallback } from 'react';
 import { useMutation, type UseMutationResult } from '@tanstack/react-query';
 
 import { useAgent, useAuth } from '@/lib/auth';
+import { attachBlueskyPostToDocument } from '@/lib/atproto';
+import { createLogger } from '@/lib/observability/logger';
 import {
   createBlueskyPost,
   type CreateBlueskyPostInput,
@@ -77,6 +79,8 @@ interface UseShareToBlueskyResult {
  * }
  * ```
  */
+const shareLogger = createLogger({ context: { component: 'use-share-to-bluesky' } });
+
 export function useShareToBluesky(options?: UseShareToBlueskyOptions): UseShareToBlueskyResult {
   const agent = useAgent();
   const { isAuthenticated } = useAuth();
@@ -86,7 +90,28 @@ export function useShareToBluesky(options?: UseShareToBlueskyOptions): UseShareT
       if (!agent) {
         throw new Error('Not authenticated');
       }
-      return createBlueskyPost(agent, input);
+      const result = await createBlueskyPost(agent, input);
+
+      // Record the announcing post on the eprint's standard.site document, so
+      // its reply thread is discoverable as the paper's off-platform
+      // discussion. Deliberately after the post and deliberately swallowed: the
+      // share has already succeeded, and an eprint whose submitter turned
+      // cross-platform discovery off simply has no document to update.
+      if (input.eprintUri) {
+        try {
+          await attachBlueskyPostToDocument(agent, input.eprintUri, {
+            uri: result.uri,
+            cid: result.cid,
+          });
+        } catch (error) {
+          shareLogger.warn('Could not record the Bluesky post on the standard.site document', {
+            eprintUri: input.eprintUri,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      return result;
     },
     onSuccess: options?.onSuccess,
     onError: options?.onError,
@@ -100,6 +125,7 @@ export function useShareToBluesky(options?: UseShareToBlueskyOptions): UseShareT
     ): Promise<CreateBlueskyPostResult> => {
       const input: CreateBlueskyPostInput = {
         text,
+        ...(content.eprintUri ? { eprintUri: content.eprintUri } : {}),
         embed: {
           uri: content.url,
           title: content.title,

--- a/web/lib/schemas/eprint.ts
+++ b/web/lib/schemas/eprint.ts
@@ -645,6 +645,9 @@ export const stepPublicationSchema = z.object({
         .array(
           z.object({
             url: z.string().optional(),
+            // AT-URI of the repository record, for hosts that are ATProto
+            // applications (Tangled publishes `sh.tangled.repo`).
+            recordUri: z.string().optional(),
             platformUri: z.string().optional(),
             platformSlug: z.string().optional(),
             label: z.string().optional(),

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Promotes staging to production as **0.12.0**. Three merged PRs (#179, #180, #181) covering the interop epic — the original ask of this backlog — plus the correctness debt found underneath it.

### Added

- **Leaflet documents and comments are read for references to eprints.** Leaflet's schemas are vendored under `lexicons/vendor/leaflet/`, taken from its own lexicon repository. A document reaches an eprint by four routes and all four are followed: a comment's `subject`, a `website` block's `src`, an inline richtext link, and a `standardSitePost` block naming an eprint directly.
- **standard.site documents that describe an eprint are recorded as backlinks**, whoever wrote them. This is also the mapping that lets a reference addressed to a _document_ — a standard.site recommend, an embedded document block — resolve to the work it ultimately means.
- **Talks and presentations appear as backlinks.** A `community.lexicon.calendar.event` naming an eprint among its URIs is evidence the work was presented, and where. Cancelled and postponed events are skipped.
- **`pub.chive.site.citationLink`**, a typed document-to-work link for `site.standard.document`'s reserved `links` union, with a CiTO-style vocabulary. A consumer that knows CiTO can read a Chive citation without knowing anything about Chive. Opt-in.
- **The Bluesky post announcing an eprint is recorded on its standard.site document** as `bskyPostRef`, which makes the post's reply thread findable as the paper's off-platform discussion.
- **An MCP server over the public read API** (`pnpm mcp`): search, resolve-by-identifier, citations and reviews. It calls the same unauthenticated XRPC a browser does, so it holds no credentials and can be pointed at any deployment. Every tool is read-only.
- **Tangled repositories are a first-class code artifact.** A repository hosted there is an ATProto record, so `codeRepository` gains `recordUri` alongside `url` — an address on the network rather than at one web host.
- The external identifier resolver is documented for other applications at `docs/api-reference/resolving-identifiers.md`.

### Fixed

- **The firehose filter was dropping seven of the twenty collections Chive indexes.** Its NSID validator required every segment to be lowercase. An NSID is a domain authority followed by a name, and only the authority is a domain label; the name segment is where camelCase lives. With strict validation on — which is what the indexing service sets — `pub.chive.eprint.userTag`, `eprint.relatedWork`, `annotation.entityLink`, `collaboration.inviteAcceptance`, `actor.profileConfig` and both graph proposal types were rejected before the processor saw them. Each is in the indexed set, each has a handler, and the PDS scanner backfills each; only the live firehose path refused them, silently. The name rule now matches the grammar `@atproto/syntax` implements.
- **Five registered backlink plugins could never be called.** The event processor already forwarded foreign records to the plugin bus, and the plugins already subscribed; the filter rejected every collection outside `pub.chive.*` upstream. Cosmik backlinks, connections, follows and link removals, and Margin annotations were constructed, subscribed, and unreachable.
- **Every `site.standard.document` Chive had written was invalid.** The lexicon requires `site` and `publishedAt`; neither was written. `content` was an object where the schema has an open union, and `visibility` and `createdAt` are not properties at all. No standard.site consumer could accept such a record, which is why the cross-platform discovery this feature promised never appeared. Documents now carry the required fields and a `path`, so `site` + `path` is the canonical URL of the eprint page — which is how a reader verifies that document and page describe the same work.
- Deleting an eprint still finds its documents. The lookup matched the invented `content.uri`; it now matches `path` and the legacy field both, because documents already in users' repositories carry the old shape. Updating one repairs it in place.
- **`/.well-known/site.standard.publication` advertised a record that cannot exist.** The collection is absent from the service repository, and `self` is not a legal record key for a lexicon whose key is `tid`. It is now `CHIVE_PUBLICATION_URI`, and unset the endpoint answers 404 — an unconfigured publication rather than a broken one.
- **The Leaflet plugin matched no record that any repository holds.** It tracked `xyz.leaflet.list`, an NSID Leaflet does not publish, and parsed an invented shape; its `shouldProcess` filtered on a `visibility` field that does not exist, so even repointed it would have skipped everything.
- **The sign-in field had no accessible name.** `FormControl` passes `id` and `aria-*` to its child; `HandleInput` accepted none of them and forwarded none, so the label never associated and a screen reader announced an unlabelled text box on the first field of the login page.
- **The autocompletes could not be operated from a keyboard.** Around twenty of them, of which two implemented the combobox pattern; the shared base implemented none of it and `node-autocomplete` — behind every knowledge-graph field — handled Escape and no other key. A keyboard user could open a list of suggestions and had no way to reach one. Both now implement the pattern: arrow keys, Home, End, Enter, Escape, with `aria-activedescendant` and marked-up options.
- **Cancelling an admin operation did not stop it.** `startOperation` returns an AbortSignal that the governance sync and DID sync handlers dropped, so the work ran to completion and reported success against a cancelled operation.
- **`triggerBackfill` recorded operations nothing ran.** It called `startOperation` and returned, leaving an operation pending forever. It now names the endpoint that does the work for the requested type.
- The Helm chart still set the governance PDS DID to `did:plc:chive-governance`, which is not a PLC identifier. Every other configuration was corrected in 0.10.0; a Helm deployment would have carried it. A test now sweeps every tracked config rather than the ones someone remembers.
- Integration tests ran under Vitest's 5-second default while talking to four datastores, so a slow runner failed the build with no defect behind it. The datastore-backed suite gets 30 seconds; the unit suite keeps the 5-second default.
- A type error in a test file removed the generated code reference from the documentation site, and the only symptom was a link check naming every page that pointed at the missing section.

### Changed

- Dependency updates target `staging`. Work reaches production through staging here, so nine dependency PRs had accumulated against a branch the normal flow cannot merge them into.
- `traefik` and the PDS image are pinned in production compose, to the versions production already runs. `latest` meant a `compose pull` could replace the ingress every request passes through without anyone choosing to.
- The README names the plugins that actually register. It advertised GitHub, ORCID, DOI registration and Wikidata — the four that are written and not constructed by any service.
- A clean clone can typecheck: `pnpm lexicons:generate` is documented as the step that must precede it.
- E2E runs in CI again, for the unauthenticated project. Seventeen assertions of the form `expect(true).toBe(true)` now assert something.

## Deployment notes

- **`CHIVE_PUBLICATION_URI`** is new and has no default. Unset, `/.well-known/site.standard.publication` answers 404 instead of advertising a record that cannot resolve. Setting it needs the publication record to exist in the service repository first, which needs write access to that PDS.
- **`FIREHOSE_OBSERVE_HIGH_VOLUME`** defaults to false. It adds `app.bsky.feed.post` — the whole Bluesky timeline — to the observed set. That is a capacity decision, not a filter tweak.
- **`CHIVE_API_URL`** configures which deployment the MCP server reads from; it defaults to production and matters only when running `pnpm mcp`.
- One migration, `1742200000000_leaflet-source-types`, rewrites `leaflet.list` backlink rows and widens the source-type constraint. Applied, reversed and re-applied against a real database.
- After deploy the indexer begins indexing seven collections it was silently dropping. Records missed while they were rejected are recoverable by a PDS scan, which was already reaching them.

## Verification

Green on staging: unit (4733), compliance (276), frontend (2676), integration, E2E, build, Docker smoke, pre-deployment.

After deploy:

```bash
curl -sf https://chive.pub/api/health | jq -r .version
curl -s -o /dev/null -w '%{http_code}\n' https://api.chive.pub/ready
curl -s -o /dev/null -w '%{http_code}\n' https://api.chive.pub/.well-known/site.standard.publication
```

Expect `0.12.0`, `200`, and `404` for the third until a publication record exists.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` - 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Foreign records are forwarded to plugins and never stored as Chive records; backlinks are derived data, rebuildable by replay. This release *improves* rebuildability: seven collections the firehose path could not index now can be. The standard.site and Layers writes are the user's own browser agent writing to the user's own repository.

### Breaking Changes

- [x] N/A - no breaking changes

`leaflet.list` is replaced by `leaflet.document` and `leaflet.comment` as a backlink source type; the migration rewrites any existing row.
