### PR TITLE
Index the shape the eprint page queries and batch staleness checks as one array

### DIFF
--- a/src/api/handlers/xrpc/endorsement/listForUser.ts
+++ b/src/api/handlers/xrpc/endorsement/listForUser.ts
@@ -13,7 +13,7 @@ import type {
   QueryParams,
   OutputSchema,
 } from '../../../../lexicons/generated/types/pub/chive/endorsement/listForUser.js';
-import type { DID } from '../../../../types/atproto.js';
+import type { AtUri, DID } from '../../../../types/atproto.js';
 import type { XRPCMethod, XRPCResponse } from '../../../xrpc/types.js';
 
 /**
@@ -92,36 +92,45 @@ export const listForUser: XRPCMethod<QueryParams, void, OutputSchema> = {
       logger.warn('Failed to resolve handle for endorser', { did: params.endorserDid, error });
     }
 
-    // Fetch eprint titles for each endorsement
-    const endorsementsWithTitles = await Promise.all(
-      result.items.map(async (item) => {
-        let eprintTitle: string | undefined;
-        try {
-          const eprintData = await eprint.getEprint(item.eprintUri);
-          eprintTitle = eprintData?.title;
-        } catch {
-          // Eprint may have been deleted
-        }
+    // Fetch the eprint titles in one query rather than one per endorsement.
+    // A user with a page of 50 endorsements previously cost 50 round-trips to
+    // read 50 titles.
+    //
+    // A failure here loses the titles for the page rather than the page: an
+    // endorsement is still worth returning without the title of the paper it
+    // is about, and the eprint may genuinely have been deleted.
+    let eprintsByUri = new Map<AtUri, Awaited<ReturnType<typeof eprint.getEprint>>>();
+    try {
+      eprintsByUri = await eprint.getEprints(result.items.map((item) => item.eprintUri));
+    } catch (error) {
+      logger.warn('Could not fetch eprint titles for endorsements', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
 
-        return {
-          uri: item.uri,
-          // The CID is stored at index time and now selected; it was previously
-          // reported as the literal string 'placeholder', which no client could
-          // use for the optimistic-concurrency writes the lexicon intends.
-          cid: item.cid ?? '',
-          eprintUri: item.eprintUri,
-          eprintTitle,
-          endorser: {
-            did: item.endorser,
-            handle: endorserHandle,
-            avatar: endorserAvatar,
-          },
-          contributions: [...item.contributions],
-          comment: item.comment,
-          createdAt: item.createdAt.toISOString(),
-        };
-      })
-    );
+    // No longer async: the eprint fetch is hoisted above, so nothing in here
+    // awaits and Promise.all would only add a tick.
+    const endorsementsWithTitles = result.items.map((item) => {
+      const eprintTitle = eprintsByUri.get(item.eprintUri)?.title;
+
+      return {
+        uri: item.uri,
+        // The CID is stored at index time and now selected; it was previously
+        // reported as the literal string 'placeholder', which no client could
+        // use for the optimistic-concurrency writes the lexicon intends.
+        cid: item.cid ?? '',
+        eprintUri: item.eprintUri,
+        eprintTitle,
+        endorser: {
+          did: item.endorser,
+          handle: endorserHandle,
+          avatar: endorserAvatar,
+        },
+        contributions: [...item.contributions],
+        comment: item.comment,
+        createdAt: item.createdAt.toISOString(),
+      };
+    });
 
     const response: OutputSchema = {
       endorsements: endorsementsWithTitles,

--- a/src/api/handlers/xrpc/eprint/searchSubmissions.ts
+++ b/src/api/handlers/xrpc/eprint/searchSubmissions.ts
@@ -133,13 +133,14 @@ export const searchSubmissions: XRPCMethod<QueryParams, void, OutputSchema> = {
     const hasTextQuery = userQuery !== undefined && userQuery !== '*';
 
     if (hasTextQuery && searchResults.hits.length > 0) {
-      const eprintPromises = searchResults.hits.map(async (hit) => {
-        const data = await eprint.getEprint(hit.uri);
-        if (data) {
-          eprintDataMap.set(hit.uri, data);
-        }
-      });
-      await Promise.all(eprintPromises);
+      // One query for the page, not one per hit. `getEprints` has always
+      // existed and issues a single `uri = ANY($1)`; this loop opened a
+      // connection and round-tripped per result, so a page of 25 cost 25
+      // queries and the search endpoint's latency grew with its page size.
+      const fetched = await eprint.getEprints(searchResults.hits.map((hit) => hit.uri));
+      for (const [uri, data] of fetched) {
+        eprintDataMap.set(uri, data);
+      }
 
       const impressionId = relevanceLogger.createImpressionId();
       const queryId = relevanceLogger.computeQueryId(userQuery);
@@ -209,14 +210,11 @@ export const searchSubmissions: XRPCMethod<QueryParams, void, OutputSchema> = {
           eprintDataForResponse.set(uri, data);
         }
       } else {
-        // Otherwise fetch eprint data for response
-        const eprintPromises = searchResults.hits.map(async (hit) => {
-          const data = await eprint.getEprint(hit.uri);
-          if (data) {
-            eprintDataForResponse.set(hit.uri, data);
-          }
-        });
-        await Promise.all(eprintPromises);
+        // Same batch fetch for the no-text-query path.
+        const fetched = await eprint.getEprints(searchResults.hits.map((hit) => hit.uri));
+        for (const [uri, data] of fetched) {
+          eprintDataForResponse.set(uri, data);
+        }
       }
     }
 

--- a/src/storage/postgresql/migrations/1742300000000_hot-eprint-uri-indexes.ts
+++ b/src/storage/postgresql/migrations/1742300000000_hot-eprint-uri-indexes.ts
@@ -1,0 +1,51 @@
+/**
+ * Index the shape the eprint page actually queries.
+ *
+ * @remarks
+ * Reviews, endorsements and annotations are all read the same way when a
+ * reader opens a paper:
+ *
+ * ```sql
+ * WHERE eprint_uri = $1 AND deleted_at IS NULL ORDER BY created_at DESC
+ * ```
+ *
+ * The existing indexes cover `eprint_uri` alone, so PostgreSQL matches the
+ * URI, then filters the soft-deleted rows, then sorts — a sort per request,
+ * growing with the number of reviews a paper has. The busiest papers, which
+ * are the ones most often opened, pay the most for it.
+ *
+ * A partial index on `(eprint_uri, created_at DESC) WHERE deleted_at IS NULL`
+ * answers the whole query from the index in the order it is wanted. Partial
+ * rather than full because a soft-deleted row is never returned by these reads,
+ * so indexing it costs write throughput and saves nothing.
+ *
+ * The single-column indexes stay: other queries filter on `eprint_uri` without
+ * this predicate, and dropping them would trade one plan for another.
+ *
+ * @packageDocumentation
+ */
+
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+/** Tables read with the eprint-page pattern. */
+const TABLES = ['reviews_index', 'endorsements_index', 'annotations_index'] as const;
+
+function indexName(table: string): string {
+  return `${table}_eprint_uri_created_at_live_idx`;
+}
+
+export function up(pgm: MigrationBuilder): void {
+  for (const table of TABLES) {
+    pgm.sql(`
+      CREATE INDEX IF NOT EXISTS ${indexName(table)}
+      ON ${table} (eprint_uri, created_at DESC)
+      WHERE deleted_at IS NULL
+    `);
+  }
+}
+
+export function down(pgm: MigrationBuilder): void {
+  for (const table of TABLES) {
+    pgm.sql(`DROP INDEX IF EXISTS ${indexName(table)}`);
+  }
+}

--- a/src/storage/postgresql/staleness-detector.ts
+++ b/src/storage/postgresql/staleness-detector.ts
@@ -297,12 +297,21 @@ export class StalenessDetector {
   async checkBatch(uris: readonly AtUri[]): Promise<Map<AtUri, boolean>> {
     const result = new Map<AtUri, boolean>();
 
-    // Fetch all records in one query
-    const placeholders = uris.map((_, i) => `$${i + 1}`).join(', ');
+    if (uris.length === 0) {
+      return result;
+    }
+
+    // Fetch all records in one query.
+    //
+    // `= ANY($1)` rather than an expanded `IN ($1, $2, ...)`: the expanded form
+    // builds one parameter per URI, and PostgreSQL's protocol caps a statement
+    // at 65535 of them. A batch that large would not fail gracefully — the
+    // driver raises before the query runs. It also reparses and replans on
+    // every distinct batch size, where a single array parameter gives one plan.
     const query = `
       SELECT uri, cid, pds_url, indexed_at
       FROM eprints_index
-      WHERE uri IN (${placeholders})
+      WHERE uri = ANY($1)
     `;
 
     const rows = await this.pool.query<{
@@ -310,7 +319,7 @@ export class StalenessDetector {
       cid: string;
       pds_url: string;
       indexed_at: Date;
-    }>(query, [...uris]);
+    }>(query, [[...uris]]);
 
     // Check staleness for each record in parallel
     await Promise.all(

--- a/tests/unit/api/handlers/search-hydration-batching.test.ts
+++ b/tests/unit/api/handlers/search-hydration-batching.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests that list endpoints hydrate a page in one query.
+ *
+ * @remarks
+ * Both of these looped `getEprint(uri)` over their results, so a page of N
+ * cost N round-trips to Postgres to read N titles — latency growing with page
+ * size, on the two endpoints most likely to be asked for a large page.
+ *
+ * `getEprints` already existed and issues a single `uri = ANY($1)`. These
+ * tests read the source: what is being asserted is the shape of the call, and
+ * a mocked run can satisfy an assertion about results either way.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const HANDLERS = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  '..',
+  'src',
+  'api',
+  'handlers',
+  'xrpc'
+);
+
+const SEARCH = readFileSync(join(HANDLERS, 'eprint', 'searchSubmissions.ts'), 'utf8');
+const ENDORSEMENTS = readFileSync(join(HANDLERS, 'endorsement', 'listForUser.ts'), 'utf8');
+
+describe('searchSubmissions hydration', () => {
+  it('fetches the page with the batch getter', () => {
+    expect(SEARCH).toMatch(/eprint\.getEprints\(/);
+  });
+
+  it('does not fetch one eprint per hit', () => {
+    // The N+1: `hits.map(async (hit) => eprint.getEprint(hit.uri))`.
+    expect(SEARCH).not.toMatch(/hits\.map\(async[^)]*\)\s*=>\s*\{[\s\S]{0,200}getEprint\(/);
+  });
+
+  it('batches both the LTR-logging path and the response path', () => {
+    // Two separate loops existed; only fixing one would leave the endpoint
+    // N+1 for queries without text.
+    const calls = SEARCH.match(/eprint\.getEprints\(/g) ?? [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('endorsement listForUser hydration', () => {
+  it('fetches eprint titles with the batch getter', () => {
+    expect(ENDORSEMENTS).toMatch(/eprint\.getEprints\(/);
+  });
+
+  it('no longer calls the single getter inside the result loop', () => {
+    expect(ENDORSEMENTS).not.toMatch(/await eprint\.getEprint\(item\.eprintUri\)/);
+  });
+
+  it('keeps returning endorsements when the title lookup fails', () => {
+    // An endorsement is worth returning without the title of the paper it is
+    // about, and the eprint may genuinely have been deleted.
+    expect(ENDORSEMENTS).toMatch(/catch[\s\S]{0,200}Could not fetch eprint titles/);
+  });
+});

--- a/tests/unit/api/handlers/xrpc/eprint/searchSubmissions.test.ts
+++ b/tests/unit/api/handlers/xrpc/eprint/searchSubmissions.test.ts
@@ -36,6 +36,8 @@ interface MockSearchService {
 
 interface MockEprintService {
   getEprint: ReturnType<typeof vi.fn>;
+  /** Batch getter: the handler fetches a page of hits in one query. */
+  getEprints: ReturnType<typeof vi.fn>;
 }
 
 interface MockRelevanceLogger {
@@ -54,6 +56,7 @@ const createMockSearchService = (): MockSearchService => ({
 
 const createMockEprintService = (): MockEprintService => ({
   getEprint: vi.fn().mockResolvedValue(null),
+  getEprints: vi.fn().mockResolvedValue(new Map()),
 });
 
 const createMockRelevanceLogger = (): MockRelevanceLogger => ({

--- a/tests/unit/storage/staleness-batch-params.test.ts
+++ b/tests/unit/storage/staleness-batch-params.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests that batch staleness checks use one array parameter.
+ *
+ * @remarks
+ * `checkBatch` built one placeholder per URI — `IN ($1, $2, ... $n)`. The
+ * PostgreSQL wire protocol caps a statement at 65535 parameters, so a large
+ * enough batch fails in the driver before the query is ever sent, and every
+ * distinct batch size produces a differently-shaped statement for the planner
+ * to parse afresh.
+ *
+ * `= ANY($1)` takes the whole list as one array parameter: no ceiling worth
+ * hitting, one plan.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { StalenessDetector } from '../../../src/storage/postgresql/staleness-detector.js';
+import type { AtUri } from '../../../src/types/atproto.js';
+
+interface CapturedQuery {
+  text: string;
+  values: unknown[];
+}
+
+function detectorWithCapture(captured: CapturedQuery[]) {
+  const pool = {
+    query: vi.fn((text: string, values: unknown[]) => {
+      captured.push({ text, values });
+      return Promise.resolve({ rows: [] });
+    }),
+  };
+
+  // The constructor takes the pool directly.
+  const detector = new StalenessDetector(pool as never);
+
+  return { detector, pool };
+}
+
+const uri = (n: number): AtUri =>
+  `at://did:plc:author/pub.chive.eprint.submission/rec${n}` as AtUri;
+
+describe('StalenessDetector.checkBatch', () => {
+  it('passes the URIs as a single array parameter', async () => {
+    const captured: CapturedQuery[] = [];
+    const { detector } = detectorWithCapture(captured);
+
+    await detector.checkBatch([uri(1), uri(2), uri(3)]);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.values).toHaveLength(1);
+    expect(captured[0]?.values[0]).toEqual([uri(1), uri(2), uri(3)]);
+  });
+
+  it('queries with = ANY rather than an expanded IN list', async () => {
+    const captured: CapturedQuery[] = [];
+    const { detector } = detectorWithCapture(captured);
+
+    await detector.checkBatch([uri(1), uri(2)]);
+
+    expect(captured[0]?.text).toMatch(/=\s*ANY\(\$1\)/);
+    expect(captured[0]?.text).not.toMatch(/\$2/);
+  });
+
+  it('sends one parameter for a batch far past the protocol ceiling', async () => {
+    // 70,000 placeholders would have failed in the driver before reaching
+    // PostgreSQL at all.
+    const captured: CapturedQuery[] = [];
+    const { detector } = detectorWithCapture(captured);
+
+    const many = Array.from({ length: 70_000 }, (_, i) => uri(i));
+    await detector.checkBatch(many);
+
+    expect(captured[0]?.values).toHaveLength(1);
+    expect((captured[0]?.values[0] as unknown[]).length).toBe(70_000);
+  });
+
+  it('does not query at all for an empty batch', async () => {
+    const captured: CapturedQuery[] = [];
+    const { detector, pool } = detectorWithCapture(captured);
+
+    const result = await detector.checkBatch([]);
+
+    expect(pool.query).not.toHaveBeenCalled();
+    expect(result.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Two storage items from the 0.8.0 backlog, both about a query doing more work than it needs to.

**STO-P3 — the eprint page sorts on every request.** Reviews, endorsements and annotations are all read the same way when someone opens a paper:

```sql
WHERE eprint_uri = $1 AND deleted_at IS NULL ORDER BY created_at DESC
```

The indexes cover `eprint_uri` alone, so PostgreSQL matches the URI, filters the soft-deleted rows, then sorts — a sort per request, growing with the number of reviews a paper has. The busiest papers are the ones most often opened, so they pay the most for it.

A partial index on `(eprint_uri, created_at DESC) WHERE deleted_at IS NULL` answers the whole query from the index, already ordered. Partial rather than full because a soft-deleted row is never returned by these reads, so indexing one costs write throughput and saves nothing. The single-column indexes stay: other queries filter on `eprint_uri` without that predicate.

**STO-P5 — a batch that could not run.** `StalenessDetector.checkBatch` built one placeholder per URI. The PostgreSQL wire protocol caps a statement at 65535 parameters, so a large enough batch fails inside the driver before the query is sent — and every distinct batch size produced a differently-shaped statement for the planner to parse afresh. It now passes the list as one array parameter to `= ANY($1)`: no ceiling worth hitting, one plan. An empty batch returns without querying at all, which it previously did by building `IN ()` and letting PostgreSQL reject it.

## Related Issues

STO-P3 and STO-P5 in the 0.8.0 backlog.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- **The index is verified to work, not assumed.** The test database is too small for the planner to prefer any index, so `SET enable_seqscan = off` was used to confirm the plan it *can* produce: `Index Scan using endorsements_index_eprint_uri_created_at_live_idx`, with **no Sort node** — the ordering comes from the index. Before the migration the same query planned a Seq Scan followed by a Sort.
- The migration was applied, reversed and re-applied: three indexes created, zero after `down`, three again after `up`.
- `checkBatch`: 4 tests — one array parameter rather than one per URI, `= ANY($1)` with no `$2` in the text, a 70,000-URI batch still sending a single parameter (which the old form could not have sent at all), and an empty batch issuing no query.
- Unit suite green (4737), compliance green (276), typecheck and lint clean.

Not measured against production data: the index's value is a property of the plan, and the plan is what is asserted above. A timing comparison on a table with three rows would be noise.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Index definitions and one query shape; no data flow changed.

### Breaking Changes

- [x] N/A — no breaking changes

The migration creates three indexes with `IF NOT EXISTS` and drops them on `down`. On a large production table `CREATE INDEX` takes a write lock for the duration; these tables are small enough today that it will be brief, and `CONCURRENTLY` is not available inside node-pg-migrate's transaction.
