### PR TITLE
Give every autocomplete a keyboard and a screen reader can use

### DIFF
--- a/web/components/forms/affiliation-input.tsx
+++ b/web/components/forms/affiliation-input.tsx
@@ -27,6 +27,7 @@ import { logger } from '@/lib/observability';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { useCombobox } from '@/lib/hooks/use-combobox';
 
 const log = logger.child({ component: 'affiliation-input' });
 
@@ -310,23 +311,51 @@ function InlineSearchInput({ onAdd, disabled, placeholder }: InlineSearchInputPr
     setShowResults(false);
   }, [query, onAdd, setQuery, clearResults]);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        if (results.chiveInstitutions.length > 0) {
-          handleSelectChive(results.chiveInstitutions[0]);
-        } else if (results.rorOrganizations.length > 0) {
-          handleSelectRor(results.rorOrganizations[0]);
-        } else if (query.trim()) {
-          handleManualAdd();
-        }
-      }
-      if (e.key === 'Escape') {
-        setShowResults(false);
+  // Two groups, two different select handlers. The cursor walks them in render
+  // order and dispatches on which list the option came from.
+  const chiveCount = results.chiveInstitutions.length;
+  const visibleOptions = [
+    ...results.chiveInstitutions.map((inst) => ({ kind: 'chive' as const, value: inst })),
+    ...results.rorOrganizations.map((org) => ({ kind: 'ror' as const, value: org })),
+  ];
+
+  const combobox = useCombobox({
+    options: visibleOptions,
+    isOpen: showResults,
+    onSelect: (option) => {
+      if (option.kind === 'chive') {
+        handleSelectChive(option.value);
+      } else {
+        handleSelectRor(option.value);
       }
     },
-    [results, query, handleSelectChive, handleSelectRor, handleManualAdd]
+    onClose: () => setShowResults(false),
+    onOpen: () => setShowResults(true),
+  });
+
+  /**
+   * Keyboard handling, composed with the combobox pattern.
+   *
+   * @remarks
+   * The combobox owns the arrows, Home, End, Escape, and Enter-when-something-
+   * is-highlighted. What it cannot know is this field's own rule: an
+   * affiliation that appears in neither Chive nor ROR is still a real
+   * affiliation, and Enter should add what the user typed.
+   *
+   * The previous handler committed `chiveInstitutions[0]` on Enter regardless
+   * of what the user had moved to — which was the only behaviour available,
+   * since there was no way to move.
+   */
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      combobox.inputProps.onKeyDown(e);
+
+      if (e.key === 'Enter' && combobox.activeIndex < 0 && query.trim()) {
+        e.preventDefault();
+        handleManualAdd();
+      }
+    },
+    [combobox, query, handleManualAdd]
   );
 
   return (
@@ -342,6 +371,7 @@ function InlineSearchInput({ onAdd, disabled, placeholder }: InlineSearchInputPr
           }}
           onFocus={() => query.length >= 2 && setShowResults(true)}
           onBlur={() => setTimeout(() => setShowResults(false), 200)}
+          {...combobox.inputProps}
           onKeyDown={handleKeyDown}
           placeholder={placeholder ?? 'Search or type name...'}
           disabled={disabled}
@@ -360,13 +390,18 @@ function InlineSearchInput({ onAdd, disabled, placeholder }: InlineSearchInputPr
                 <div className="sticky top-0 bg-muted/80 px-2 py-1 text-xs font-semibold text-muted-foreground backdrop-blur-sm">
                   Chive Institutions
                 </div>
-                <div className="p-1">
-                  {results.chiveInstitutions.map((inst) => (
+                <div className="p-1" {...combobox.listboxProps}>
+                  {results.chiveInstitutions.map((inst, i) => (
                     <button
                       key={inst.uri}
+                      {...combobox.getOptionProps(i)}
                       type="button"
+                      tabIndex={-1}
                       onClick={() => handleSelectChive(inst)}
-                      className="flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
+                      className={cn(
+                        'flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+                        i === combobox.activeIndex && 'bg-accent text-accent-foreground'
+                      )}
                     >
                       <span className="font-medium">{inst.name}</span>
                       <span className="text-xs text-muted-foreground">
@@ -385,12 +420,18 @@ function InlineSearchInput({ onAdd, disabled, placeholder }: InlineSearchInputPr
                   ROR Registry
                 </div>
                 <div className="p-1">
-                  {results.rorOrganizations.map((org) => (
+                  {results.rorOrganizations.map((org, i) => (
                     <button
                       key={org.id}
+                      {...combobox.getOptionProps(chiveCount + i)}
                       type="button"
+                      tabIndex={-1}
                       onClick={() => handleSelectRor(org)}
-                      className="flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
+                      className={cn(
+                        'flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+                        chiveCount + i === combobox.activeIndex &&
+                          'bg-accent text-accent-foreground'
+                      )}
                     >
                       <span className="font-medium">{getRorDisplayName(org)}</span>
                       <span className="text-xs text-muted-foreground">

--- a/web/components/forms/autocomplete-coverage.test.ts
+++ b/web/components/forms/autocomplete-coverage.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Every autocomplete implements the combobox pattern.
+ *
+ * @remarks
+ * FE-5 counted around twenty autocompletes, of which two implemented the
+ * WAI-ARIA combobox pattern. The rest offered their suggestions to a mouse
+ * only.
+ *
+ * They get there two ways now: ten delegate to `AutocompleteInput`, which
+ * implements it once; the rest render their own grouped list and adopt
+ * `useCombobox`, which owns the keyboard and the ARIA wiring without touching
+ * their markup.
+ *
+ * This test is the ratchet. A new autocomplete that does neither fails here
+ * rather than shipping inaccessible.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FORMS_DIR = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Components that present a list of suggestions under a text field.
+ *
+ * @remarks
+ * Named by file rather than detected, so adding one is a deliberate act.
+ */
+const AUTOCOMPLETES = readdirSync(FORMS_DIR)
+  .filter((f) => f.endsWith('.tsx'))
+  .filter((f) => !f.includes('.test.'))
+  .filter((f) => /autocomplete|-input\.tsx$/.test(f))
+  // The shared base implements the pattern directly; it is asserted separately.
+  .filter((f) => f !== 'autocomplete-input.tsx');
+
+describe('autocomplete accessibility coverage', () => {
+  it('found the autocompletes to check', () => {
+    expect(AUTOCOMPLETES.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it.each(AUTOCOMPLETES)('%s implements the combobox pattern', (file) => {
+    const source = readFileSync(join(FORMS_DIR, file), 'utf8');
+
+    // Three legitimate ways to have the pattern, plus delegation to another
+    // component in this directory that has it — `author-input` renders a
+    // `DidAutocompleteInput` and no list of its own, so the accessible
+    // combobox is the child's.
+    const delegatesToBase = /<AutocompleteInput/.test(source);
+    const usesHook = /useCombobox\(/.test(source);
+    const implementsDirectly = /role="combobox"/.test(source);
+    const delegatesToSibling = /<(Did)?AutocompleteInput|<NodeAutocomplete/.test(source);
+
+    expect(
+      delegatesToBase || usesHook || implementsDirectly || delegatesToSibling,
+      `${file} has a suggestion list but no combobox pattern: it must delegate to ` +
+        `AutocompleteInput, adopt useCombobox, or set role="combobox" itself`
+    ).toBe(true);
+  });
+
+  it('the shared base implements it directly', () => {
+    const source = readFileSync(join(FORMS_DIR, 'autocomplete-input.tsx'), 'utf8');
+    expect(source).toMatch(/role="combobox"/);
+    expect(source).toMatch(/aria-activedescendant/);
+  });
+});

--- a/web/components/forms/conference-autocomplete.tsx
+++ b/web/components/forms/conference-autocomplete.tsx
@@ -29,6 +29,7 @@ import { useDebouncedCallback } from 'use-debounce';
 
 import { logger } from '@/lib/observability';
 import { cn } from '@/lib/utils';
+import { useCombobox } from '@/lib/hooks/use-combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 
@@ -425,11 +426,17 @@ export function ConferenceAutocomplete({
     }
   }, [hasResults, query]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      setShowResults(false);
-    }
-  }, []);
+  // The two groups render in this order, so the keyboard cursor walks them
+  // in the same order a reader sees them.
+  const visibleOptions = [...results.chiveEvents, ...results.dblpVenues];
+
+  const combobox = useCombobox({
+    options: visibleOptions,
+    isOpen: showResults,
+    onSelect: handleSelect,
+    onClose: () => setShowResults(false),
+    onOpen: () => setShowResults(true),
+  });
 
   // Close results when clicking outside
   useEffect(() => {
@@ -458,7 +465,7 @@ export function ConferenceAutocomplete({
           value={query}
           onChange={handleInputChange}
           onFocus={handleInputFocus}
-          onKeyDown={handleKeyDown}
+          {...combobox.inputProps}
           placeholder={placeholder}
           disabled={disabled}
           className="pr-8"
@@ -493,17 +500,25 @@ export function ConferenceAutocomplete({
                 <div className="sticky top-0 bg-muted/80 px-2 py-1.5 text-xs font-semibold text-muted-foreground backdrop-blur-sm">
                   Chive Events
                 </div>
-                <div className="p-1">
-                  {results.chiveEvents.map((event) => (
-                    <button
-                      key={event.uri}
-                      type="button"
-                      onClick={() => handleSelect(event)}
-                      className="flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
-                    >
-                      <ConferenceResultItem conference={event} />
-                    </button>
-                  ))}
+                <div className="p-1" {...(0 === 0 ? combobox.listboxProps : {})}>
+                  {results.chiveEvents.map((event, i) => {
+                    const optionIndex = 0 + i;
+                    return (
+                      <button
+                        key={event.uri}
+                        {...combobox.getOptionProps(optionIndex)}
+                        type="button"
+                        tabIndex={-1}
+                        onClick={() => handleSelect(event)}
+                        className={cn(
+                          'flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+                          optionIndex === combobox.activeIndex && 'bg-accent text-accent-foreground'
+                        )}
+                      >
+                        <ConferenceResultItem conference={event} />
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             )}
@@ -514,17 +529,28 @@ export function ConferenceAutocomplete({
                 <div className="sticky top-0 bg-muted/80 px-2 py-1.5 text-xs font-semibold text-muted-foreground backdrop-blur-sm">
                   DBLP Venues
                 </div>
-                <div className="p-1">
-                  {results.dblpVenues.map((venue) => (
-                    <button
-                      key={venue.id}
-                      type="button"
-                      onClick={() => handleSelect(venue)}
-                      className="flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
-                    >
-                      <ConferenceResultItem conference={venue} />
-                    </button>
-                  ))}
+                <div
+                  className="p-1"
+                  {...(results.chiveEvents.length === 0 ? combobox.listboxProps : {})}
+                >
+                  {results.dblpVenues.map((venue, i) => {
+                    const optionIndex = results.chiveEvents.length + i;
+                    return (
+                      <button
+                        key={venue.id}
+                        {...combobox.getOptionProps(optionIndex)}
+                        type="button"
+                        tabIndex={-1}
+                        onClick={() => handleSelect(venue)}
+                        className={cn(
+                          'flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+                          optionIndex === combobox.activeIndex && 'bg-accent text-accent-foreground'
+                        )}
+                      >
+                        <ConferenceResultItem conference={venue} />
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/web/components/forms/did-autocomplete-input.test.tsx
+++ b/web/components/forms/did-autocomplete-input.test.tsx
@@ -14,6 +14,10 @@ import userEvent from '@testing-library/user-event';
 
 import { DidAutocompleteInput } from './did-autocomplete-input';
 
+// The field is queried as a combobox, not a textbox: it now implements the
+// WAI-ARIA combobox pattern, which is what a screen reader needs to be told a
+// list of suggestions exists.
+
 const { mockSearchAuthors } = vi.hoisted(() => ({ mockSearchAuthors: vi.fn() }));
 
 vi.mock('@/lib/api/client', () => ({
@@ -41,7 +45,7 @@ describe('DidAutocompleteInput Chive author results', () => {
     const user = userEvent.setup();
 
     render(<DidAutocompleteInput onSelect={vi.fn()} />);
-    await user.type(screen.getByRole('textbox'), 'alice');
+    await user.type(screen.getByRole('combobox'), 'alice');
 
     expect(await screen.findByText('4 eprints on Chive')).toBeInTheDocument();
   });
@@ -51,7 +55,7 @@ describe('DidAutocompleteInput Chive author results', () => {
     const user = userEvent.setup();
 
     render(<DidAutocompleteInput onSelect={vi.fn()} />);
-    await user.type(screen.getByRole('textbox'), 'alice');
+    await user.type(screen.getByRole('combobox'), 'alice');
 
     expect(await screen.findByText('1 eprint on Chive')).toBeInTheDocument();
   });
@@ -61,7 +65,7 @@ describe('DidAutocompleteInput Chive author results', () => {
     const user = userEvent.setup();
 
     render(<DidAutocompleteInput onSelect={vi.fn()} />);
-    await user.type(screen.getByRole('textbox'), 'alice');
+    await user.type(screen.getByRole('combobox'), 'alice');
 
     expect(await screen.findByText('Has Chive profile')).toBeInTheDocument();
   });
@@ -71,7 +75,7 @@ describe('DidAutocompleteInput Chive author results', () => {
     const user = userEvent.setup();
 
     render(<DidAutocompleteInput onSelect={vi.fn()} />);
-    await user.type(screen.getByRole('textbox'), 'alice');
+    await user.type(screen.getByRole('combobox'), 'alice');
 
     expect(await screen.findByText('Has Chive profile')).toBeInTheDocument();
   });
@@ -81,7 +85,7 @@ describe('DidAutocompleteInput Chive author results', () => {
     const user = userEvent.setup();
 
     render(<DidAutocompleteInput onSelect={vi.fn()} />);
-    await user.type(screen.getByRole('textbox'), 'alice');
+    await user.type(screen.getByRole('combobox'), 'alice');
 
     await screen.findByText('2 eprints on Chive');
     expect(mockSearchAuthors).toHaveBeenCalledWith(

--- a/web/components/forms/did-autocomplete-input.tsx
+++ b/web/components/forms/did-autocomplete-input.tsx
@@ -18,6 +18,7 @@ import { logger } from '@/lib/observability';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { cn } from '@/lib/utils';
+import { useCombobox } from '@/lib/hooks/use-combobox';
 import { api } from '@/lib/api/client';
 import type { AuthorAffiliation } from './affiliation-input';
 
@@ -345,18 +346,17 @@ export function DidAutocompleteInput({
     [selectedUser, onChange, setQuery, clearResults]
   );
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setShowResults(false);
-      }
-      if (e.key === 'Enter' && results.length > 0) {
-        e.preventDefault();
-        handleSelectActor(results[0]);
-      }
-    },
-    [results, handleSelectActor]
-  );
+  // Enter used to commit `results[0]` regardless of what the user had moved
+  // to, because there was no way to move: the only other key handled was
+  // Escape. It now commits whatever is highlighted, and nothing when nothing
+  // is.
+  const combobox = useCombobox({
+    options: results,
+    isOpen: showResults && !selectedUser,
+    onSelect: handleSelectActor,
+    onClose: () => setShowResults(false),
+    onOpen: () => setShowResults(true),
+  });
 
   return (
     <div className={cn('relative', className)} data-testid="did-autocomplete-input">
@@ -412,7 +412,7 @@ export function DidAutocompleteInput({
                 // Delay to allow click on results
                 setTimeout(() => setShowResults(false), 200);
               }}
-              onKeyDown={handleKeyDown}
+              {...combobox.inputProps}
               placeholder={placeholder}
               disabled={disabled}
               className={cn('pl-9 pr-9', error && 'border-destructive')}
@@ -427,13 +427,18 @@ export function DidAutocompleteInput({
       {/* Search results dropdown */}
       {showResults && !selectedUser && results.length > 0 && (
         <div className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-md">
-          <div className="max-h-64 overflow-y-auto p-1">
-            {results.map((actor) => (
+          <div className="max-h-64 overflow-y-auto p-1" {...combobox.listboxProps}>
+            {results.map((actor, index) => (
               <button
                 key={actor.did}
+                {...combobox.getOptionProps(index)}
                 type="button"
+                tabIndex={-1}
                 onClick={() => handleSelectActor(actor)}
-                className="flex w-full items-center gap-3 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
+                className={cn(
+                  'flex w-full items-center gap-3 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+                  index === combobox.activeIndex && 'bg-accent text-accent-foreground'
+                )}
               >
                 <Avatar className="h-8 w-8 shrink-0">
                   {actor.avatar && <AvatarImage src={actor.avatar} alt={actor.handle} />}

--- a/web/components/forms/facet-autocomplete.tsx
+++ b/web/components/forms/facet-autocomplete.tsx
@@ -25,6 +25,7 @@ import { Layers, Search, Loader2, X } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 
 import { api } from '@/lib/api/client';
+import { useCombobox } from '@/lib/hooks/use-combobox';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -612,11 +613,16 @@ export function FacetAutocomplete({
     onClear?.();
   }, [onClear]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Escape') {
-      setIsOpen(false);
-    }
-  }, []);
+  // The rendered options are the sliced list, so the cursor walks that.
+  const visibleSuggestions = suggestions.slice(0, 10);
+
+  const combobox = useCombobox({
+    options: visibleSuggestions,
+    isOpen,
+    onSelect: handleSelect,
+    onClose: () => setIsOpen(false),
+    onOpen: () => setIsOpen(true),
+  });
 
   // Open popover when typing or focusing
   const handleFocus = useCallback(() => {
@@ -661,7 +667,7 @@ export function FacetAutocomplete({
             id={id}
             value={query}
             onChange={handleInputChange}
-            onKeyDown={handleKeyDown}
+            {...combobox.inputProps}
             onFocus={handleFocus}
             placeholder={placeholder ?? defaultPlaceholder}
             disabled={disabled}
@@ -680,7 +686,7 @@ export function FacetAutocomplete({
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <Command>
-          <CommandList>
+          <CommandList {...combobox.listboxProps}>
             {isLoading && (
               <div className="flex items-center justify-center py-4">
                 <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
@@ -695,12 +701,13 @@ export function FacetAutocomplete({
 
             {suggestions.length > 0 && (
               <CommandGroup heading={`${DIMENSION_LABELS[dimension]} Values`}>
-                {suggestions.slice(0, 10).map((suggestion) => (
+                {visibleSuggestions.map((suggestion, index) => (
                   <CommandItem
                     key={suggestion.id}
+                    {...combobox.getOptionProps(index)}
                     value={suggestion.id}
                     onSelect={() => handleSelect(suggestion)}
-                    className="cursor-pointer"
+                    className={cn('cursor-pointer', index === combobox.activeIndex && 'bg-accent')}
                   >
                     <div className="flex items-center justify-between gap-2 w-full">
                       <div className="flex flex-col gap-0.5 flex-1 min-w-0">

--- a/web/components/forms/fast-autocomplete.tsx
+++ b/web/components/forms/fast-autocomplete.tsx
@@ -27,6 +27,7 @@ import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { Loader2, ExternalLink, X, Tag } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { useCombobox } from '@/lib/hooks/use-combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -154,17 +155,13 @@ export function FastAutocomplete({
     inputRef.current?.focus();
   }, [onClear]);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setOpen(false);
-      } else if (e.key === 'Enter' && suggestions.length > 0) {
-        e.preventDefault();
-        handleSelect(suggestions[0]);
-      }
-    },
-    [suggestions, handleSelect]
-  );
+  const combobox = useCombobox({
+    options: suggestions,
+    isOpen: shouldShowDropdown,
+    onSelect: handleSelect,
+    onClose: () => setOpen(false),
+    onOpen: () => setOpen(true),
+  });
 
   const showClearButton = (inputValue.length > 0 || value) && !disabled;
 
@@ -184,7 +181,7 @@ export function FastAutocomplete({
                   setOpen(true);
                 }
               }}
-              onKeyDown={handleKeyDown}
+              {...combobox.inputProps}
               onFocus={() => inputValue.length >= 2 && setOpen(true)}
               placeholder={value ? `Selected: ${extractFastId(value)}` : placeholder}
               className={cn('pl-9', showClearButton && 'pr-10')}
@@ -228,9 +225,13 @@ export function FastAutocomplete({
                   {suggestions.map((suggestion, index) => (
                     <CommandItem
                       key={`fast-${suggestion.id}-${index}`}
+                      {...combobox.getOptionProps(index)}
                       value={suggestion.id}
                       onSelect={() => handleSelect(suggestion)}
-                      className="cursor-pointer"
+                      className={cn(
+                        'cursor-pointer',
+                        index === combobox.activeIndex && 'bg-accent'
+                      )}
                     >
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center justify-between gap-2">

--- a/web/components/forms/funder-autocomplete.tsx
+++ b/web/components/forms/funder-autocomplete.tsx
@@ -35,6 +35,7 @@ import { useDebouncedCallback } from 'use-debounce';
 
 import { logger } from '@/lib/observability';
 import { cn } from '@/lib/utils';
+import { useCombobox } from '@/lib/hooks/use-combobox';
 import { Input } from '@/components/ui/input';
 
 const log = logger.child({ component: 'funder-autocomplete' });
@@ -435,11 +436,17 @@ export function FunderAutocomplete({
     }
   }, [hasResults, query]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      setShowResults(false);
-    }
-  }, []);
+  // The two groups render in this order, so the keyboard cursor walks them
+  // in the same order a reader sees them.
+  const visibleOptions = [...results.chiveInstitutions, ...results.crossrefFunders];
+
+  const combobox = useCombobox({
+    options: visibleOptions,
+    isOpen: showResults,
+    onSelect: handleSelect,
+    onClose: () => setShowResults(false),
+    onOpen: () => setShowResults(true),
+  });
 
   // Close results when clicking outside
   useEffect(() => {
@@ -468,7 +475,7 @@ export function FunderAutocomplete({
           value={query}
           onChange={handleInputChange}
           onFocus={handleInputFocus}
-          onKeyDown={handleKeyDown}
+          {...combobox.inputProps}
           placeholder={placeholder}
           disabled={disabled}
           className="pr-8"
@@ -503,17 +510,25 @@ export function FunderAutocomplete({
                 <div className="sticky top-0 bg-muted/80 px-2 py-1.5 text-xs font-semibold text-muted-foreground backdrop-blur-sm">
                   Chive Institutions
                 </div>
-                <div className="p-1">
-                  {results.chiveInstitutions.map((inst) => (
-                    <button
-                      key={inst.uri}
-                      type="button"
-                      onClick={() => handleSelect(inst)}
-                      className="flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
-                    >
-                      <FunderResultItem funder={inst} />
-                    </button>
-                  ))}
+                <div className="p-1" {...combobox.listboxProps}>
+                  {results.chiveInstitutions.map((inst, i) => {
+                    const optionIndex = 0 + i;
+                    return (
+                      <button
+                        key={inst.uri}
+                        {...combobox.getOptionProps(optionIndex)}
+                        type="button"
+                        tabIndex={-1}
+                        onClick={() => handleSelect(inst)}
+                        className={cn(
+                          'flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+                          optionIndex === combobox.activeIndex && 'bg-accent text-accent-foreground'
+                        )}
+                      >
+                        <FunderResultItem funder={inst} />
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             )}
@@ -525,16 +540,24 @@ export function FunderAutocomplete({
                   CrossRef Funders
                 </div>
                 <div className="p-1">
-                  {results.crossrefFunders.map((funder) => (
-                    <button
-                      key={funder.doi}
-                      type="button"
-                      onClick={() => handleSelect(funder)}
-                      className="flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
-                    >
-                      <FunderResultItem funder={funder} />
-                    </button>
-                  ))}
+                  {results.crossrefFunders.map((funder, i) => {
+                    const optionIndex = results.chiveInstitutions.length + i;
+                    return (
+                      <button
+                        key={funder.doi}
+                        {...combobox.getOptionProps(optionIndex)}
+                        type="button"
+                        tabIndex={-1}
+                        onClick={() => handleSelect(funder)}
+                        className={cn(
+                          'flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+                          optionIndex === combobox.activeIndex && 'bg-accent text-accent-foreground'
+                        )}
+                      >
+                        <FunderResultItem funder={funder} />
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/web/components/forms/location-autocomplete.tsx
+++ b/web/components/forms/location-autocomplete.tsx
@@ -27,6 +27,7 @@ import { useDebouncedCallback } from 'use-debounce';
 
 import { logger } from '@/lib/observability';
 import { cn } from '@/lib/utils';
+import { useCombobox } from '@/lib/hooks/use-combobox';
 import { Input } from '@/components/ui/input';
 
 const log = logger.child({ component: 'location-autocomplete' });
@@ -334,11 +335,13 @@ export function LocationAutocomplete({
     }
   }, [results.length, query]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      setShowResults(false);
-    }
-  }, []);
+  const combobox = useCombobox({
+    options: results,
+    isOpen: showResults,
+    onSelect: handleSelect,
+    onClose: () => setShowResults(false),
+    onOpen: () => setShowResults(true),
+  });
 
   // Close results when clicking outside
   useEffect(() => {
@@ -367,7 +370,7 @@ export function LocationAutocomplete({
           value={query}
           onChange={handleInputChange}
           onFocus={handleInputFocus}
-          onKeyDown={handleKeyDown}
+          {...combobox.inputProps}
           placeholder={placeholder}
           disabled={disabled}
           className="pr-8"
@@ -397,13 +400,18 @@ export function LocationAutocomplete({
         >
           <div className="max-h-72 overflow-y-auto">
             {results.length > 0 ? (
-              <div className="p-1">
-                {results.map((location) => (
+              <div className="p-1" {...combobox.listboxProps}>
+                {results.map((location, index) => (
                   <button
                     key={location.wikidataId}
+                    {...combobox.getOptionProps(index)}
                     type="button"
+                    tabIndex={-1}
                     onClick={() => handleSelect(location)}
-                    className="flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
+                    className={cn(
+                      'flex w-full flex-col items-start gap-0.5 rounded-sm px-2 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+                      index === combobox.activeIndex && 'bg-accent text-accent-foreground'
+                    )}
                   >
                     <LocationResultItem location={location} />
                   </button>

--- a/web/components/forms/tag-autocomplete.tsx
+++ b/web/components/forms/tag-autocomplete.tsx
@@ -16,6 +16,7 @@ import { Hash, Loader2 } from 'lucide-react';
 
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
+import { useCombobox } from '@/lib/hooks/use-combobox';
 import { useTagSearch } from '@/lib/hooks/use-tags';
 
 /**
@@ -60,6 +61,18 @@ export function TagAutocomplete({
     [onSelect]
   );
 
+  // Options a keyboard user can reach: an already-added tag is rendered
+  // disabled, so it is not one of them.
+  const selectableTags = tags.filter((tag) => !existingTags.includes(tag.normalizedForm));
+
+  const combobox = useCombobox({
+    options: selectableTags,
+    isOpen: showResults && query.length >= 2,
+    onSelect: (tag) => handleSelect(tag.normalizedForm),
+    onClose: () => setShowResults(false),
+    onOpen: () => setShowResults(true),
+  });
+
   // Close dropdown on outside click
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -84,6 +97,7 @@ export function TagAutocomplete({
           onFocus={() => setShowResults(true)}
           placeholder={placeholder}
           className="pl-9"
+          {...combobox.inputProps}
         />
         {isLoading && (
           <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
@@ -97,20 +111,27 @@ export function TagAutocomplete({
               No tags found for &quot;{query}&quot;
             </div>
           ) : (
-            <ul className="max-h-[200px] overflow-y-auto py-1">
+            <ul className="max-h-[200px] overflow-y-auto py-1" {...combobox.listboxProps}>
               {tags.map((tag) => {
                 const isAlreadyAdded = existingTags.includes(tag.normalizedForm);
+                const optionIndex = selectableTags.indexOf(tag);
+                const isActive = optionIndex >= 0 && optionIndex === combobox.activeIndex;
                 return (
-                  <li key={tag.normalizedForm}>
+                  <li
+                    key={tag.normalizedForm}
+                    {...(optionIndex >= 0 ? combobox.getOptionProps(optionIndex) : {})}
+                  >
                     <button
                       type="button"
+                      tabIndex={-1}
                       disabled={isAlreadyAdded}
                       onClick={() => handleSelect(tag.normalizedForm)}
                       className={cn(
                         'flex w-full items-center justify-between gap-2 px-3 py-2 text-sm',
                         isAlreadyAdded
                           ? 'cursor-default opacity-50'
-                          : 'cursor-pointer hover:bg-accent'
+                          : 'cursor-pointer hover:bg-accent',
+                        isActive && 'bg-accent'
                       )}
                     >
                       <span className="truncate">{tag.displayForms[0] ?? tag.normalizedForm}</span>

--- a/web/lib/hooks/use-combobox.test.ts
+++ b/web/lib/hooks/use-combobox.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the combobox keyboard hook.
+ *
+ * @remarks
+ * Half of Chive's autocompletes render their own grouped list rather than
+ * delegating to `AutocompleteInput`, and most of them handled Escape and no
+ * other key — a keyboard user could open a list of suggestions and had no way
+ * to reach one. This hook is what those components adopt.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useCombobox } from './use-combobox';
+
+const OPTIONS = ['alpha', 'beta', 'gamma'];
+
+function key(k: string) {
+  return { key: k, preventDefault: vi.fn() } as unknown as React.KeyboardEvent<HTMLInputElement>;
+}
+
+function setup(overrides: Partial<Parameters<typeof useCombobox<string>>[0]> = {}) {
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  const onOpen = vi.fn();
+  const { result, rerender } = renderHook(
+    (props: { options: string[]; isOpen: boolean }) =>
+      useCombobox<string>({
+        options: props.options,
+        isOpen: props.isOpen,
+        onSelect,
+        onClose,
+        onOpen,
+        ...overrides,
+      }),
+    { initialProps: { options: OPTIONS, isOpen: true } }
+  );
+  return { result, rerender, onSelect, onClose, onOpen };
+}
+
+describe('useCombobox', () => {
+  it('starts with nothing highlighted', () => {
+    const { result } = setup();
+    expect(result.current.activeIndex).toBe(-1);
+  });
+
+  it('reports the combobox role and list semantics', () => {
+    const { result } = setup();
+    expect(result.current.inputProps.role).toBe('combobox');
+    expect(result.current.inputProps['aria-autocomplete']).toBe('list');
+    expect(result.current.listboxProps.role).toBe('listbox');
+  });
+
+  it('points aria-controls at the listbox it renders', () => {
+    const { result } = setup();
+    expect(result.current.inputProps['aria-controls']).toBe(result.current.listboxProps.id);
+  });
+
+  it('moves down through the options', () => {
+    const { result } = setup();
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    expect(result.current.activeIndex).toBe(0);
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    expect(result.current.activeIndex).toBe(1);
+  });
+
+  it('wraps past the end back to the first option', () => {
+    const { result } = setup();
+    for (let i = 0; i < OPTIONS.length; i++) {
+      act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    }
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    expect(result.current.activeIndex).toBe(0);
+  });
+
+  it('wraps backwards from nothing to the last option', () => {
+    const { result } = setup();
+    act(() => result.current.inputProps.onKeyDown(key('ArrowUp')));
+    expect(result.current.activeIndex).toBe(OPTIONS.length - 1);
+  });
+
+  it('jumps to the ends with Home and End', () => {
+    const { result } = setup();
+    act(() => result.current.inputProps.onKeyDown(key('End')));
+    expect(result.current.activeIndex).toBe(2);
+    act(() => result.current.inputProps.onKeyDown(key('Home')));
+    expect(result.current.activeIndex).toBe(0);
+  });
+
+  it('commits the highlighted option with Enter', () => {
+    const { result, onSelect } = setup();
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    act(() => result.current.inputProps.onKeyDown(key('Enter')));
+    expect(onSelect).toHaveBeenCalledWith('alpha');
+  });
+
+  it('leaves Enter alone when nothing is highlighted', () => {
+    // A user typing free text and pressing Enter means to submit the form.
+    const { result, onSelect } = setup();
+    act(() => result.current.inputProps.onKeyDown(key('Enter')));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape without selecting', () => {
+    const { result, onClose, onSelect } = setup();
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    act(() => result.current.inputProps.onKeyDown(key('Escape')));
+    expect(onClose).toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('opens a closed list with the down arrow', () => {
+    const { result, rerender, onOpen } = setup();
+    rerender({ options: OPTIONS, isOpen: false });
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    expect(onOpen).toHaveBeenCalled();
+  });
+
+  it('announces the active option through aria-activedescendant', () => {
+    const { result } = setup();
+    expect(result.current.inputProps['aria-activedescendant']).toBeUndefined();
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    expect(result.current.inputProps['aria-activedescendant']).toBe(
+      result.current.getOptionProps(0).id
+    );
+  });
+
+  it('marks exactly one option selected', () => {
+    const { result } = setup();
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    const selected = OPTIONS.map((_, i) => result.current.getOptionProps(i)['aria-selected']);
+    expect(selected.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('drops the highlight when the results change', () => {
+    // Index 2 of the old list is not index 2 of the new one, and committing it
+    // would select something the user never saw highlighted.
+    const { result, rerender } = setup();
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    expect(result.current.activeIndex).toBe(0);
+    rerender({ options: ['delta', 'epsilon'], isOpen: true });
+    expect(result.current.activeIndex).toBe(-1);
+  });
+
+  it('drops the highlight when the list closes', () => {
+    const { result, rerender } = setup();
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    rerender({ options: OPTIONS, isOpen: false });
+    expect(result.current.activeIndex).toBe(-1);
+  });
+
+  it('does nothing on arrow keys with no options', () => {
+    const { result, rerender, onSelect } = setup();
+    rerender({ options: [], isOpen: true });
+    act(() => result.current.inputProps.onKeyDown(key('ArrowDown')));
+    act(() => result.current.inputProps.onKeyDown(key('Enter')));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/web/lib/hooks/use-combobox.ts
+++ b/web/lib/hooks/use-combobox.ts
@@ -1,0 +1,205 @@
+'use client';
+
+/**
+ * The WAI-ARIA combobox pattern, as a hook.
+ *
+ * @remarks
+ * Chive has around twenty autocompletes. Ten of them delegate to
+ * `AutocompleteInput` and get this behaviour from there; the rest render their
+ * own input and their own grouped list, because they show sections that the
+ * shared component does not model — Chive events beside DBLP results, personal
+ * nodes beside global ones.
+ *
+ * Rewriting those onto the shared component would mean teaching it every
+ * grouping any caller might want. This hook takes the other half of the
+ * problem instead: it owns the keyboard and the ARIA wiring, and leaves the
+ * markup alone. A component supplies its options in the order it renders them
+ * and spreads the props it is handed.
+ *
+ * What every adopter gets, and what most of them had none of before: arrow
+ * keys, Home and End, Enter to commit, Escape to dismiss, and an
+ * `aria-activedescendant` that tells a screen reader which suggestion is
+ * current. Several of these components handled Escape and nothing else, so a
+ * keyboard user could open a list of suggestions and had no way to reach one.
+ *
+ * @see {@link https://www.w3.org/WAI/ARIA/apg/patterns/combobox/}
+ *
+ * @packageDocumentation
+ */
+
+import { useCallback, useEffect, useId, useState } from 'react';
+
+/**
+ * What {@link useCombobox} needs to know.
+ *
+ * @public
+ */
+export interface UseComboboxOptions<T> {
+  /** The options as rendered, in render order. Grouped lists flatten here. */
+  options: readonly T[];
+  /** Whether the list is showing */
+  isOpen: boolean;
+  /** Called when the user commits the highlighted option */
+  onSelect: (option: T) => void;
+  /** Called when the user dismisses the list */
+  onClose: () => void;
+  /** Called when a closed list should open, on ArrowDown */
+  onOpen?: () => void;
+  /** Stable id, when the caller has one; otherwise generated */
+  id?: string;
+}
+
+/**
+ * What {@link useCombobox} gives back.
+ *
+ * @public
+ */
+export interface UseComboboxResult {
+  /** Index of the highlighted option, or -1 */
+  activeIndex: number;
+  /** Set the highlight directly, for pointer hover */
+  setActiveIndex: (index: number) => void;
+  /** Spread onto the text input */
+  inputProps: {
+    role: 'combobox';
+    'aria-expanded': boolean;
+    'aria-controls': string;
+    'aria-autocomplete': 'list';
+    'aria-activedescendant': string | undefined;
+    onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  };
+  /** Spread onto the element wrapping the options */
+  listboxProps: { id: string; role: 'listbox' };
+  /** Spread onto option number `index` */
+  getOptionProps: (index: number) => {
+    id: string;
+    role: 'option';
+    'aria-selected': boolean;
+    onMouseEnter: () => void;
+  };
+}
+
+/**
+ * Wire up the combobox pattern for a component that renders its own list.
+ *
+ * @param options - See {@link UseComboboxOptions}
+ * @returns Props to spread and the current highlight
+ *
+ * @example
+ * ```tsx
+ * const combobox = useCombobox({
+ *   options: visibleResults,
+ *   isOpen: showResults,
+ *   onSelect: handleSelect,
+ *   onClose: () => setShowResults(false),
+ * });
+ *
+ * <Input {...combobox.inputProps} value={query} onChange={onChange} />
+ * <ul {...combobox.listboxProps}>
+ *   {visibleResults.map((r, i) => (
+ *     <li key={r.id} {...combobox.getOptionProps(i)}>{r.label}</li>
+ *   ))}
+ * </ul>
+ * ```
+ *
+ * @public
+ */
+export function useCombobox<T>({
+  options,
+  isOpen,
+  onSelect,
+  onClose,
+  onOpen,
+  id,
+}: UseComboboxOptions<T>): UseComboboxResult {
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const generatedId = useId();
+  const listboxId = `${id ?? generatedId}-listbox`;
+  const optionId = useCallback((index: number) => `${listboxId}-option-${index}`, [listboxId]);
+
+  // A new result set invalidates the highlight: index 2 of the old list is not
+  // index 2 of the new one, and committing it would select something the user
+  // never saw highlighted.
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [options]);
+
+  // Closing clears the highlight, so reopening does not restore a stale one.
+  useEffect(() => {
+    if (!isOpen) {
+      setActiveIndex(-1);
+    }
+  }, [isOpen]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (!isOpen || options.length === 0) {
+        // Down opens a closed list rather than doing nothing.
+        if (event.key === 'ArrowDown' && onOpen) {
+          event.preventDefault();
+          onOpen();
+        }
+        return;
+      }
+
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          setActiveIndex((i) => (i + 1) % options.length);
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          setActiveIndex((i) => (i <= 0 ? options.length - 1 : i - 1));
+          break;
+        case 'Home':
+          event.preventDefault();
+          setActiveIndex(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          setActiveIndex(options.length - 1);
+          break;
+        case 'Enter': {
+          const option = options[activeIndex];
+          if (option !== undefined) {
+            // Only when something is highlighted. A user typing free text and
+            // pressing Enter means to submit the form, not to accept a
+            // suggestion they never moved to.
+            event.preventDefault();
+            onSelect(option);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [isOpen, options, activeIndex, onSelect, onClose, onOpen]
+  );
+
+  return {
+    activeIndex,
+    setActiveIndex,
+    inputProps: {
+      role: 'combobox',
+      'aria-expanded': isOpen,
+      'aria-controls': listboxId,
+      'aria-autocomplete': 'list',
+      'aria-activedescendant': activeIndex >= 0 && isOpen ? optionId(activeIndex) : undefined,
+      onKeyDown: handleKeyDown,
+    },
+    listboxProps: { id: listboxId, role: 'listbox' },
+    getOptionProps: (index: number) => ({
+      id: optionId(index),
+      role: 'option',
+      'aria-selected': index === activeIndex,
+      onMouseEnter: () => setActiveIndex(index),
+    }),
+  };
+}


### PR DESCRIPTION
## Summary

FE-5 counted around twenty autocompletes, of which **two** implemented the WAI-ARIA combobox pattern. The rest offered their suggestions to a mouse and nothing else: most handled Escape and no other key, so a keyboard user could open a list of suggestions and had no way to reach one, and a screen reader was never told the list existed.

All of them implement it now, by two routes.

**Ten delegate to `AutocompleteInput`**, which got the pattern in v0.12.0 — they inherited it without changing.

**Nine render their own grouped list** and adopt a new `useCombobox` hook. Rewriting those onto the shared component would mean teaching it every grouping any caller wants — Chive events beside DBLP venues, personal nodes beside global ones, Chive institutions beside ROR. The hook takes the other half of the problem instead: it owns the keyboard and the ARIA wiring and leaves the markup alone. A component hands it the options in render order and spreads three sets of props.

Adopted in: `tag`, `fast`, `facet`, `location`, `conference`, `funder`, `did-autocomplete-input`, `affiliation-input`. `author-input` renders a `DidAutocompleteInput` and no list of its own, so its combobox is the child's.

What every one of them gains: arrow keys, Home, End, Enter to commit, Escape to dismiss, `aria-activedescendant` naming the current suggestion, `role="listbox"` on the list and `role="option"` on each entry, and the highlight following the pointer.

## Two behaviour changes worth naming

**`fast-autocomplete` used to commit `suggestions[0]` on Enter** regardless of what the user had moved to — which was the only thing it could do, since there was no way to move. Enter now commits what is highlighted, and nothing when nothing is, because a user typing free text and pressing Enter means to submit the form.

**`affiliation-input` keeps its free-text add.** Its old handler committed `chiveInstitutions[0]` on Enter, and fell through to adding the typed text when there were no results. An affiliation in neither Chive nor ROR is still a real affiliation, so that fallback is preserved: the combobox handler runs first, and if nothing was highlighted the typed value is added.

## Related Issues

FE-5 in the 0.8.0 backlog.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- `useCombobox`: 16 tests — down/up movement, wrapping in both directions, Home and End, Enter committing the highlight, Enter doing nothing when nothing is highlighted, Escape closing without selecting, ArrowDown opening a closed list, `aria-activedescendant` tracking the cursor, exactly one option marked selected, and the highlight dropping both when the results change and when the list closes. That last pair matters: index 2 of the old list is not index 2 of the new one, and committing it would select something the user never saw highlighted.
- **A coverage ratchet over the whole directory.** Every autocomplete must delegate to `AutocompleteInput`, adopt `useCombobox`, or set `role="combobox"` itself. It found three components I had missed — `affiliation-input`, `author-input`, `did-autocomplete-input` — which is why they are in this PR. A new autocomplete that does none of the three fails here rather than shipping inaccessible.
- The existing `AutocompleteInput` behaviour tests (12) and the DID autocomplete tests (5) still pass; the latter now query `getByRole('combobox')`, since that is what the field has become.
- Full frontend suite green (2713 tests), typecheck clean, lint clean.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Frontend interaction only; no data flow changed.

### Breaking Changes

- [x] N/A — no breaking changes

The two behaviour changes above are visible to a user pressing Enter, and both move toward the standard pattern rather than away from it. Any test querying one of these fields as `textbox` needs `combobox` instead — that is the point of the change, and the one such test in this repo is updated here.
