### PR TITLE
Release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-09-01
+
+### Fixed
+
+- **Author search reported the wrong number of eprints beside each author.** The count was built by tallying how often an author appeared in the page of search hits, which is bounded by the page size and by the loop's own early break — so an author with 58 eprints was shown as having 1. It now reports how many eprints the author actually has, fetched for the whole page in one query, because author autocomplete runs this on every keystroke and a query per suggestion would be a round trip per suggestion per character.
+
 ## [0.13.0] - 2026-08-31
 
 ### Added
@@ -960,7 +966,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/chive-pub/chive/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/chive-pub/chive/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/chive-pub/chive/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/chive-pub/chive/compare/v0.11.0...v0.11.1

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/src/api/handlers/xrpc/author/searchAuthors.ts
+++ b/src/api/handlers/xrpc/author/searchAuthors.ts
@@ -77,14 +77,16 @@ async function searchAuthorsInIndex(
             );
 
           if (matches) {
-            const existing = authorMap.get(author.did);
-            if (existing) {
-              existing.eprintCount += 1;
-            } else {
+            // Counting appearances here would count how often the author shows
+            // up in this page of search hits, which is what `eprintCount` used
+            // to report — bounded above by `limit * 3` and by the break below,
+            // so an author with 58 eprints could report 1. The real count is
+            // fetched for the whole page after this loop.
+            if (!authorMap.has(author.did)) {
               authorMap.set(author.did, {
                 did: author.did,
                 name: author.name,
-                eprintCount: 1,
+                eprintCount: 0,
               });
             }
           }
@@ -94,7 +96,20 @@ async function searchAuthorsInIndex(
       if (authorMap.size >= limit) break;
     }
 
-    return Array.from(authorMap.values()).slice(0, limit);
+    const authors = Array.from(authorMap.values()).slice(0, limit);
+
+    // One query for the page. This runs on every keystroke of author
+    // autocomplete, so a count per author would put a round trip per
+    // suggestion on that path — the same mistake the batched record fetch
+    // above exists to avoid.
+    const counts = await c
+      .get('services')
+      .eprint.countEprintsByAuthors(authors.map((a) => a.did as DID));
+
+    return authors.map((author) => ({
+      ...author,
+      eprintCount: counts.get(author.did) ?? 0,
+    }));
   } catch (error) {
     logger.error('Author search failed', error instanceof Error ? error : undefined, {
       query,

--- a/src/services/eprint/eprint-service.ts
+++ b/src/services/eprint/eprint-service.ts
@@ -759,6 +759,18 @@ export class EprintService {
     return this.storage.countEprintsByAuthor(did);
   }
 
+  /**
+   * Counts eprints for several authors in one query.
+   *
+   * @param dids - Author DIDs
+   * @returns A map from DID to eprint count, omitting authors with none
+   *
+   * @public
+   */
+  async countEprintsByAuthors(dids: readonly DID[]): Promise<Map<string, number>> {
+    return this.storage.countEprintsByAuthors(dids);
+  }
+
   async getVersionHistory(uri: AtUri): Promise<readonly EprintVersion[]> {
     const chain = await this.versionManager.getVersionChain(uri);
     return chain.versions;

--- a/src/storage/postgresql/adapter.ts
+++ b/src/storage/postgresql/adapter.ts
@@ -241,6 +241,22 @@ export class PostgreSQLAdapter implements IStorageBackend {
   }
 
   /**
+   * Counts eprints for several authors in one query.
+   *
+   * @param authors - Author DIDs
+   * @returns A map from DID to eprint count, omitting authors with none
+   *
+   * @remarks
+   * Author autocomplete needs a count per suggestion on every keystroke; one
+   * query for the page keeps that off the per-author path.
+   *
+   * @public
+   */
+  async countEprintsByAuthors(authors: readonly DID[]): Promise<Map<string, number>> {
+    return this.eprintsRepo.countByAuthors(authors);
+  }
+
+  /**
    * Lists all eprint URIs with pagination.
    *
    * @param options - Query options including limit

--- a/src/storage/postgresql/eprints-repository.ts
+++ b/src/storage/postgresql/eprints-repository.ts
@@ -565,6 +565,53 @@ export class EprintsRepository {
   }
 
   /**
+   * Counts eprints for several authors in one query.
+   *
+   * @param authors - Author DIDs
+   * @returns A map from DID to eprint count, omitting authors with none
+   *
+   * @remarks
+   * Author autocomplete needs a count per author on every keystroke, and
+   * calling {@link EprintsRepository.countByAuthor} per author would put a
+   * round trip per suggestion on that path. This unnests the `authors` array
+   * once and groups, so a page of suggestions costs one query.
+   *
+   * `COUNT(DISTINCT uri)` rather than `COUNT(*)`: an author listed twice in one
+   * eprint's author array — which happens with a corrected record — would
+   * otherwise count that eprint twice.
+   *
+   * The predicate matches {@link EprintsRepository.countByAuthor} and
+   * {@link EprintsRepository.findByAuthor}, so all three agree on what counts.
+   *
+   * @public
+   */
+  async countByAuthors(authors: readonly DID[]): Promise<Map<string, number>> {
+    if (authors.length === 0) {
+      return new Map();
+    }
+
+    try {
+      const query = `
+        SELECT author_did AS did, COUNT(DISTINCT uri)::int AS count
+        FROM eprints_index,
+             LATERAL jsonb_array_elements(authors) AS author(obj),
+             LATERAL (SELECT author.obj->>'did') AS a(author_did)
+        WHERE author_did = ANY($1)
+          AND deleted_at IS NULL
+        GROUP BY author_did
+      `;
+
+      const result = await this.pool.query<{ did: string; count: number }>(query, [[...authors]]);
+
+      return new Map(result.rows.map((row) => [row.did, row.count]));
+    } catch (error) {
+      throw error instanceof Error
+        ? error
+        : new Error(`Failed to count eprints by authors: ${String(error)}`);
+    }
+  }
+
+  /**
    * Lists all eprint URIs with pagination.
    *
    * @param options - Query options including limit

--- a/src/types/interfaces/storage.interface.ts
+++ b/src/types/interfaces/storage.interface.ts
@@ -526,6 +526,24 @@ export interface IStorageBackend {
   countEprintsByAuthor(author: DID): Promise<number>;
 
   /**
+   * Counts eprints for several authors in one query.
+   *
+   * @param authors - Author DIDs
+   * @returns A map from DID to eprint count, omitting authors with none
+   *
+   * @remarks
+   * For paths that need a count per author across a page of authors, where a
+   * call per author would be a round trip per author.
+   *
+   * @example
+   * ```typescript
+   * const counts = await storage.countEprintsByAuthors([didA, didB]);
+   * console.log(counts.get(didA) ?? 0);
+   * ```
+   */
+  countEprintsByAuthors(authors: readonly DID[]): Promise<Map<string, number>>;
+
+  /**
    * Lists all eprint URIs with pagination.
    *
    * @param options - Query options including limit

--- a/tests/compliance/core-services-compliance.test.ts
+++ b/tests/compliance/core-services-compliance.test.ts
@@ -125,6 +125,10 @@ function createTrackedStorage(): IStorageBackend & {
       operations.push({ method: 'countEprintsByAuthor', args: [author] });
       return Promise.resolve(0);
     }),
+    countEprintsByAuthors: vi.fn().mockImplementation((authors: readonly DID[]) => {
+      operations.push({ method: 'countEprintsByAuthors', args: [authors] });
+      return Promise.resolve(new Map<string, number>());
+    }),
     listEprintUris: vi.fn().mockImplementation(() => {
       operations.push({ method: 'listEprintUris', args: [] });
       return Promise.resolve([]);

--- a/tests/integration/services/metrics/metrics-service.integration.test.ts
+++ b/tests/integration/services/metrics/metrics-service.integration.test.ts
@@ -75,6 +75,7 @@ function createMockStorage(): IStorageBackend {
     listDeletedEprintUris: vi.fn().mockResolvedValue([]),
     getEprintsByAuthor: vi.fn().mockResolvedValue([]),
     countEprintsByAuthor: vi.fn().mockResolvedValue(0),
+    countEprintsByAuthors: vi.fn().mockResolvedValue(new Map()),
     listEprintUris: vi.fn().mockResolvedValue([]),
     listEprintUrisByFieldUri: vi.fn().mockResolvedValue([]),
     trackPDSSource: vi.fn().mockResolvedValue({ ok: true, value: undefined }),

--- a/tests/unit/api/handlers/search-authors-eprint-count.test.ts
+++ b/tests/unit/api/handlers/search-authors-eprint-count.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Guards the eprint count author autocomplete shows beside each suggestion.
+ *
+ * @remarks
+ * The count used to be built by tallying how often an author appeared in the
+ * page of search hits. That number is bounded twice over — the search runs with
+ * `limit * 3` hits and the loop stops once `limit` distinct authors are found —
+ * so an author with 58 eprints could be shown as having 1. It is a different
+ * quantity from the one the label claims.
+ *
+ * @packageDocumentation
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const handler = readFileSync(
+  join(process.cwd(), 'src/api/handlers/xrpc/author/searchAuthors.ts'),
+  'utf8'
+);
+
+describe('searchAuthors eprint count', () => {
+  it('does not tally appearances in the search page', () => {
+    expect(handler).not.toContain('existing.eprintCount += 1');
+  });
+
+  it('asks the datastore for the real count', () => {
+    expect(handler).toContain('countEprintsByAuthors');
+  });
+
+  it('fetches the counts for the whole page in one call', () => {
+    // A call per suggestion would be a round trip per keystroke per author,
+    // which is the cost the batched record fetch in the same function exists
+    // to avoid.
+    const calls = handler.match(/countEprintsByAuthors/g) ?? [];
+    expect(calls).toHaveLength(1);
+  });
+
+  it('defaults to zero rather than showing nothing', () => {
+    expect(handler).toMatch(/counts\.get\([^)]+\)\s*\?\?\s*0/);
+  });
+});
+
+describe('batched author count query', () => {
+  const repository = readFileSync(
+    join(process.cwd(), 'src/storage/postgresql/eprints-repository.ts'),
+    'utf8'
+  );
+
+  it('counts distinct eprints, not author-array entries', () => {
+    // An author listed twice in one eprint's author array would otherwise make
+    // that eprint count twice. Verified against Postgres: COUNT(*) reports 2
+    // for such a record where COUNT(DISTINCT uri) reports 1.
+    expect(repository).toContain('COUNT(DISTINCT uri)');
+  });
+
+  it('excludes soft-deleted eprints, as the single-author count does', () => {
+    const batched = repository.slice(repository.indexOf('async countByAuthors'));
+    expect(batched.slice(0, 1200)).toContain('deleted_at IS NULL');
+  });
+
+  it('returns an empty map for no authors without querying', () => {
+    const batched = repository.slice(repository.indexOf('async countByAuthors'));
+    expect(batched.slice(0, 400)).toContain('authors.length === 0');
+  });
+});

--- a/tests/unit/api/handlers/xrpc/author/searchAuthors.test.ts
+++ b/tests/unit/api/handlers/xrpc/author/searchAuthors.test.ts
@@ -29,6 +29,7 @@ interface MockSearch {
 interface MockEprint {
   getEprint: ReturnType<typeof vi.fn>;
   getEprints: ReturnType<typeof vi.fn>;
+  countEprintsByAuthors: ReturnType<typeof vi.fn>;
 }
 
 // =============================================================================
@@ -69,6 +70,13 @@ describe('searchAuthors', () => {
         }
         return found;
       }),
+      // `eprintCount` is the author's real total now, not how often they
+      // appeared in this page of hits. The default gives every author 7 so a
+      // test asserting the count is asserting something the search page could
+      // not have produced.
+      countEprintsByAuthors: vi.fn((dids: readonly string[]) =>
+        Promise.resolve(new Map(dids.map((did) => [did, 7])))
+      ),
     };
     mockRedis = {
       get: vi.fn().mockResolvedValue(null),
@@ -180,6 +188,97 @@ describe('searchAuthors', () => {
       });
 
       expect(result.body.authors).toHaveLength(1);
+    });
+
+    it("reports the author's eprint count, not their appearances in the page", async () => {
+      // This is the bug: the count was built by tallying how often an author
+      // showed up among the search hits, which is bounded by the page size and
+      // by the loop's own early break. An author with many eprints who matched
+      // two hits was shown as having 2.
+      mockSearch.search.mockResolvedValue({
+        hits: [
+          { uri: 'at://did:plc:test1/pub.chive.eprint.submission/123', score: 1 },
+          { uri: 'at://did:plc:test2/pub.chive.eprint.submission/456', score: 0.9 },
+        ],
+        total: 2,
+      });
+
+      mockEprint.getEprint
+        .mockResolvedValueOnce({
+          uri: 'at://did:plc:test1/pub.chive.eprint.submission/123',
+          authors: [{ did: 'did:plc:author1', name: 'John Doe' }],
+        })
+        .mockResolvedValueOnce({
+          uri: 'at://did:plc:test2/pub.chive.eprint.submission/456',
+          authors: [{ did: 'did:plc:author1', name: 'John Doe' }],
+        });
+
+      mockEprint.countEprintsByAuthors.mockResolvedValue(new Map([['did:plc:author1', 58]]));
+
+      const result = await searchAuthors.handler({
+        params: { q: 'john', limit: 10 },
+        input: undefined,
+        auth: null,
+        c: mockContext as unknown as Parameters<typeof searchAuthors.handler>[0]['c'],
+      });
+
+      expect(result.body.authors[0]?.eprintCount).toBe(58);
+    });
+
+    it('counts the whole page in one call', async () => {
+      mockSearch.search.mockResolvedValue({
+        hits: [
+          { uri: 'at://did:plc:test1/pub.chive.eprint.submission/123', score: 1 },
+          { uri: 'at://did:plc:test2/pub.chive.eprint.submission/456', score: 0.9 },
+        ],
+        total: 2,
+      });
+
+      mockEprint.getEprint
+        .mockResolvedValueOnce({
+          uri: 'at://did:plc:test1/pub.chive.eprint.submission/123',
+          authors: [{ did: 'did:plc:author1', name: 'John Doe' }],
+        })
+        .mockResolvedValueOnce({
+          uri: 'at://did:plc:test2/pub.chive.eprint.submission/456',
+          authors: [{ did: 'did:plc:author2', name: 'John Roe' }],
+        });
+
+      await searchAuthors.handler({
+        params: { q: 'john', limit: 10 },
+        input: undefined,
+        auth: null,
+        c: mockContext as unknown as Parameters<typeof searchAuthors.handler>[0]['c'],
+      });
+
+      // Author autocomplete runs this on every keystroke; a call per
+      // suggestion would be a round trip per suggestion per character.
+      expect(mockEprint.countEprintsByAuthors).toHaveBeenCalledTimes(1);
+      expect(mockEprint.countEprintsByAuthors).toHaveBeenCalledWith([
+        'did:plc:author1',
+        'did:plc:author2',
+      ]);
+    });
+
+    it('shows zero for an author the count query does not return', async () => {
+      mockSearch.search.mockResolvedValue({
+        hits: [{ uri: 'at://did:plc:test1/pub.chive.eprint.submission/123', score: 1 }],
+        total: 1,
+      });
+      mockEprint.getEprint.mockResolvedValueOnce({
+        uri: 'at://did:plc:test1/pub.chive.eprint.submission/123',
+        authors: [{ did: 'did:plc:author1', name: 'John Doe' }],
+      });
+      mockEprint.countEprintsByAuthors.mockResolvedValue(new Map());
+
+      const result = await searchAuthors.handler({
+        params: { q: 'john', limit: 10 },
+        input: undefined,
+        auth: null,
+        c: mockContext as unknown as Parameters<typeof searchAuthors.handler>[0]['c'],
+      });
+
+      expect(result.body.authors[0]?.eprintCount).toBe(0);
     });
 
     it('respects limit parameter', async () => {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Release 0.13.1. One fix, following up on the search and pagination work in 0.13.0.

Author search showed the wrong number of eprints beside each suggestion. `eprintCount` was built by tallying how often an author appeared among the search hits — a different quantity from the one the field names, and bounded twice over, by the `limit * 3` search page and by the loop's own early break. In production `searchAuthors?q=white` reported `eprintCount: 1` for an author whose `listByAuthor` total is 58.

The count now comes from the datastore, fetched for the whole page in one query. Author autocomplete calls this on every keystroke, so a query per suggestion would be a round trip per suggestion per character — the same cost the batched record fetch in that function already exists to avoid.

## Related Issues

Follow-up to v0.13.0.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

All checks passed on #187, including ATProto Compliance, Unit Tests, Type Check, Lint & Format, Integration Tests, E2E, Build and Docker Smoke Test.

Beyond CI:

- The new batched query was run against a real Postgres (183 rows) and agrees exactly with the existing single-author `countByAuthor`, including returning nothing for an author with no eprints.
- `COUNT(DISTINCT uri)` was checked directly: for an eprint listing the same author twice, `COUNT(*)` returns 2 where `COUNT(DISTINCT uri)` returns 1.
- The behavioural test was verified to catch the original bug — reverting the fix makes it fail, restoring it makes it pass.

## Screenshots

N/A

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [ ] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Read path only: one additional `SELECT` against an index Chive already rebuilds from the firehose.

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented
