### PR TITLE
Keep a cache failure from stranding a deploy; clamp long bios and link to sifa.id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,9 @@ jobs:
             ${{ steps.meta-api.outputs.tags }}
             chive:ci
           cache-from: type=gha,scope=backend
-          cache-to: type=gha,mode=max,scope=backend
+          # A cache export failure must not fail the build; see the note in
+          # deploy-staging.yml.
+          cache-to: type=gha,mode=max,scope=backend,ignore-error=true
 
       - name: Push backend image to GHCR
         if: github.event_name != 'pull_request'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -149,7 +149,15 @@ jobs:
             NEXT_PUBLIC_CHIVE_SERVICE_DID=did:web:${{ vars.STAGING_DOMAIN }}
             NEXT_PUBLIC_USE_PERMISSION_SETS=true
           cache-from: type=gha,scope=web-staging
-          cache-to: type=gha,mode=max,scope=web-staging
+          # `ignore-error=true` because a cache export failure is not a build
+          # failure. The staging deploy for 0.14.0 built the web image and
+          # pushed it to ghcr successfully, then died on
+          # "error writing layer blob: failed to reserve cache" while exporting
+          # to the Actions cache — so the image existed but staging never
+          # pulled it, and the branch sat two releases behind with no obvious
+          # sign why. The cache is an optimisation; losing it should cost time,
+          # not a deployment.
+          cache-to: type=gha,mode=max,scope=web-staging,ignore-error=true
 
       - name: Setup Node.js and pnpm for docs build
         uses: ./.github/actions/setup-node-pnpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A cache hiccup could strand a deployment.** The staging deploy for 0.14.0 built the web image and pushed it to the registry, then failed on `error writing layer blob: failed to reserve cache` while exporting to the GitHub Actions cache. The image existed and the job was marked failed, so staging never pulled it and sat two releases behind with nothing in the failure pointing at the cause. The cache export is now marked `ignore-error=true` in both workflows that use it: a cache is an optimisation, and losing it should cost build time rather than a deployment.
+
 ## [0.14.0] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A profile links to the researcher's sifa.id page** when they have one. The link appears only for a researcher whose repository actually holds sifa records, so it never points at an empty page, and it addresses the profile by DID rather than handle, which does not change when someone moves domain.
+
+### Changed
+
+- **A long bio is clamped to a few lines, with a control to read the rest.** A long one used to push the affiliations, identifiers and eprint list off the screen. The control appears only when the text is genuinely clipped, measured rather than guessed from a character count, and re-measured when the element resizes: a bio that fits on a wide window clips on a narrow one.
+- **The bio field is a rich text editor**, the same one the abstract uses, so `@` mentions and `#` tags autocomplete and LaTeX and a preview are available. It was a plain textarea, which accepted the syntax the save path already detected but gave no way to discover it.
+
 ### Fixed
 
 - **A cache hiccup could strand a deployment.** The staging deploy for 0.14.0 built the web image and pushed it to the registry, then failed on `error writing layer blob: failed to reserve cache` while exporting to the GitHub Actions cache. The image existed and the job was marked failed, so staging never pulled it and sat two releases behind with nothing in the failure pointing at the cause. The cache export is now marked `ignore-error=true` in both workflows that use it: a cache is an optimisation, and losing it should cost build time rather than a deployment.

--- a/web/components/eprints/author-header-sifa-link.test.ts
+++ b/web/components/eprints/author-header-sifa-link.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Guards the sifa.id link and the bio editor.
+ *
+ * @remarks
+ * The sifa profile URL was verified against the live site rather than assumed:
+ * `/profile/<handle>` and `/profile/<did>` both answer 200, and
+ * `/profile/<nonexistent>` answers 404 — so the path is real and the 200 is
+ * meaningful.
+ *
+ * @packageDocumentation
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const webRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const header = readFileSync(join(webRoot, 'components/eprints/author-header.tsx'), 'utf8');
+const settings = readFileSync(join(webRoot, 'components/settings/chive-profile-form.tsx'), 'utf8');
+
+describe('sifa.id link', () => {
+  it('uses the profile path the site actually serves', () => {
+    expect(header).toContain('https://sifa.id/profile/');
+  });
+
+  it('addresses the profile by DID, which does not change when a handle does', () => {
+    expect(header).toMatch(/sifa\.id\/profile\/\$\{encodeURIComponent\(profile\.did\)\}/);
+  });
+
+  it('appears only for a researcher who has a sifa profile', () => {
+    // `hasProfile` is set from records read out of the repository, so this
+    // never links to an empty page.
+    expect(header).toMatch(/sifa\?\.hasProfile === true/);
+  });
+
+  it('opens externally without leaking the referrer window', () => {
+    const linkBlock = header.slice(header.indexOf('https://sifa.id/profile/'));
+    expect(linkBlock.slice(0, 400)).toContain('rel="noopener noreferrer"');
+  });
+});
+
+describe('bio editing', () => {
+  it('uses the editor that offers @ and # autocomplete', () => {
+    // A plain textarea accepted the syntax but gave no way to discover it.
+    expect(settings).toContain('MarkdownEditor');
+    expect(settings).toContain('enableMentions');
+    expect(settings).toContain('enableTags');
+  });
+
+  it('no longer uses a bare textarea for the bio', () => {
+    expect(settings).not.toContain('@/components/ui/textarea');
+  });
+});
+
+describe('bio display', () => {
+  it('clamps a long bio rather than letting it push the page down', () => {
+    expect(header).toContain('ExpandableProse');
+  });
+});

--- a/web/components/eprints/author-header.tsx
+++ b/web/components/eprints/author-header.tsx
@@ -10,6 +10,7 @@ import {
   BookOpen,
   Copy,
   Check,
+  UserCircle,
 } from 'lucide-react';
 
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
@@ -23,6 +24,7 @@ import type { SifaProfile } from '@/lib/api/generated/types/pub/chive/author/get
 import type { RichTextItem } from '@/lib/types/rich-text';
 import { RichTextRenderer } from '@/components/editor';
 import { mergeAffiliations } from '@/lib/profile/merge-affiliations';
+import { ExpandableProse } from '@/components/ui/expandable-prose';
 
 /**
  * Props for the AuthorHeader component.
@@ -184,23 +186,55 @@ export function AuthorHeader({ profile, sifa, className }: AuthorHeaderProps) {
             </div>
           )}
 
-          {/* Bio */}
+          {/* Bio.
+
+              Clamped to a few lines: a long bio otherwise pushed the
+              affiliations, identifiers and eprint list off the screen. The
+              control only appears when the text is genuinely clipped, which is
+              measured rather than guessed — a bio that fits on a wide window
+              clips on a narrow one.
+
+              A `div` rather than a `p`: rich text can contain block content,
+              and a heading or list inside a paragraph is invalid markup that
+              browsers silently restructure. */}
           {profile.bio && (
-            <p className="mt-4 max-w-2xl text-muted-foreground">
-              {/* The same renderer reviews and abstracts use. A bio written
+            <div className="mt-4">
+              <ExpandableProse lines={4} className="max-w-2xl text-muted-foreground">
+                {/* The same renderer reviews and abstracts use. A bio written
                   before rich text existed has no `bioRich`, and falls back to
                   its plain text. */}
-              {extendedProfile.bioRich && extendedProfile.bioRich.length > 0 ? (
-                <RichTextRenderer items={extendedProfile.bioRich} mode="block" />
-              ) : (
-                <RichTextRenderer text={profile.bio} mode="block" />
-              )}
-            </p>
+                {extendedProfile.bioRich && extendedProfile.bioRich.length > 0 ? (
+                  <RichTextRenderer items={extendedProfile.bioRich} mode="block" />
+                ) : (
+                  <RichTextRenderer text={profile.bio} mode="block" />
+                )}
+              </ExpandableProse>
+            </div>
           )}
 
           {/* Primary links row */}
           <div className="mt-4 flex flex-wrap items-center justify-center gap-4 sm:justify-start">
             {profile.orcid && <OrcidBadge orcid={profile.orcid} verified={profile.orcidVerified} />}
+
+            {/* sifa.id profile.
+
+                Linked only when they actually have one — `hasProfile` is set
+                from records read out of their repository, not assumed from the
+                DID, so this never points at an empty page. Addressed by DID
+                rather than handle: sifa resolves both, and a DID does not
+                change when someone moves domain. */}
+            {sifa?.hasProfile === true && (
+              <a
+                href={`https://sifa.id/profile/${encodeURIComponent(profile.did)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-sm text-primary hover:underline"
+              >
+                <UserCircle className="h-4 w-4" />
+                sifa.id
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
 
             {profile.website && (
               <a

--- a/web/components/settings/chive-profile-form.tsx
+++ b/web/components/settings/chive-profile-form.tsx
@@ -23,7 +23,6 @@ import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -37,6 +36,7 @@ import { OrcidAutocompleteInput } from './orcid-autocomplete-input';
 import { AuthorIdAutocompleteInput } from './author-id-autocomplete-input';
 import { FieldSearch, type FieldSelection } from '@/components/forms/field-search';
 import { useOrcidOAuth } from '@/lib/hooks/use-orcid-oauth';
+import { MarkdownEditor } from '@/components/editor';
 
 /**
  * Converts API affiliations (may be string[] or structured) to structured format.
@@ -418,11 +418,24 @@ export function ChiveProfileForm() {
 
             <div className="space-y-2">
               <Label htmlFor="bio">Bio</Label>
-              <Textarea
-                id="bio"
+              {/* The same editor the abstract uses, so a bio gets @ mention
+                  and # tag autocomplete, LaTeX and a preview — the facets
+                  detected on save are the ones written here. A plain textarea
+                  accepted the syntax but offered no way to discover it. */}
+              <MarkdownEditor
+                value={form.watch('bio') ?? ''}
+                onChange={(value) => {
+                  form.setValue('bio', value, { shouldDirty: true });
+                }}
                 placeholder="Brief academic bio"
-                rows={4}
-                {...form.register('bio')}
+                maxLength={2000}
+                minHeight="8rem"
+                enableMentions
+                enableTags
+                enableLatex
+                enablePreview
+                ariaLabel="Bio"
+                testId="bio-editor"
               />
               <p className="text-xs text-muted-foreground">
                 Shown on your Chive profile in place of your sifa.id summary or your Bluesky

--- a/web/components/ui/__tests__/expandable-prose.test.tsx
+++ b/web/components/ui/__tests__/expandable-prose.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Tests for clamping long prose.
+ *
+ * @remarks
+ * jsdom reports every element as zero-height, so `scrollHeight > clientHeight`
+ * is never true by accident. Each case that needs an overflowing element says
+ * so explicitly, which also documents what the component measures.
+ *
+ * @packageDocumentation
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+import { ExpandableProse } from '@/components/ui/expandable-prose';
+
+/**
+ * Makes every element report itself as overflowing its clamp.
+ */
+function makeContentOverflow(scrollHeight: number, clientHeight: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get: () => clientHeight,
+  });
+}
+
+beforeEach(() => {
+  // jsdom has no ResizeObserver.
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // @ts-expect-error restoring the prototype descriptors jsdom shipped with
+  delete HTMLElement.prototype.scrollHeight;
+  // @ts-expect-error restoring the prototype descriptors jsdom shipped with
+  delete HTMLElement.prototype.clientHeight;
+});
+
+describe('ExpandableProse', () => {
+  it('always renders its content', () => {
+    render(<ExpandableProse>A short bio.</ExpandableProse>);
+    expect(screen.getByText('A short bio.')).toBeInTheDocument();
+  });
+
+  it('offers no control when the prose is not clipped', () => {
+    // A "Show more" beside three lines that were never truncated is worse than
+    // no control at all.
+    makeContentOverflow(40, 40);
+    render(<ExpandableProse>A short bio.</ExpandableProse>);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('offers a control when the prose is clipped', () => {
+    makeContentOverflow(400, 80);
+    render(<ExpandableProse>A very long bio.</ExpandableProse>);
+
+    expect(screen.getByRole('button', { name: /show more/i })).toBeInTheDocument();
+  });
+
+  it('reveals the rest when asked, and can be collapsed again', async () => {
+    makeContentOverflow(400, 80);
+    const user = userEvent.setup();
+    render(<ExpandableProse>A very long bio.</ExpandableProse>);
+
+    const button = screen.getByRole('button', { name: /show more/i });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(button);
+
+    const collapse = screen.getByRole('button', { name: /show less/i });
+    expect(collapse).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(collapse);
+    expect(screen.getByRole('button', { name: /show more/i })).toBeInTheDocument();
+  });
+
+  it('names the region it controls, so the control is announced usefully', () => {
+    makeContentOverflow(400, 80);
+    render(<ExpandableProse>A very long bio.</ExpandableProse>);
+
+    const button = screen.getByRole('button', { name: /show more/i });
+    const controlled = button.getAttribute('aria-controls');
+
+    expect(controlled).toBeTruthy();
+    expect(document.getElementById(controlled ?? '')).toHaveTextContent('A very long bio.');
+  });
+
+  it('drops the clamp once expanded', async () => {
+    makeContentOverflow(400, 80);
+    const user = userEvent.setup();
+    render(<ExpandableProse lines={4}>A very long bio.</ExpandableProse>);
+
+    const region = document.getElementById(
+      screen.getByRole('button').getAttribute('aria-controls') ?? ''
+    );
+    expect(region?.className).toContain('line-clamp-4');
+
+    await user.click(screen.getByRole('button'));
+    expect(region?.className).not.toContain('line-clamp-4');
+  });
+
+  it('uses a literal clamp class, since Tailwind cannot see an interpolated one', () => {
+    makeContentOverflow(400, 80);
+    render(<ExpandableProse lines={6}>A very long bio.</ExpandableProse>);
+
+    const region = document.getElementById(
+      screen.getByRole('button').getAttribute('aria-controls') ?? ''
+    );
+    expect(region?.className).toContain('line-clamp-6');
+  });
+});

--- a/web/components/ui/expandable-prose.tsx
+++ b/web/components/ui/expandable-prose.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+/**
+ * Clamps long prose to a few lines, with a control to reveal the rest.
+ *
+ * @remarks
+ * A profile bio has no length limit worth relying on, and a long one pushed
+ * everything below it — affiliations, identifiers, the eprint list — off the
+ * screen. This shows the opening and lets the reader ask for the rest.
+ *
+ * The control appears only when the text is actually clipped. Rendering a
+ * "Show more" beside three lines that were never truncated is worse than not
+ * having one, and whether a given bio overflows depends on the viewport, so it
+ * is measured rather than guessed from a character count: the clamped element
+ * is checked for `scrollHeight > clientHeight`, and re-checked when the
+ * element resizes.
+ *
+ * It wraps arbitrary children rather than taking a string, because the bio is
+ * rich text — links, mentions, LaTeX — and clamping is a layout concern that
+ * should not care what it is clamping.
+ *
+ * @packageDocumentation
+ */
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Props for {@link ExpandableProse}.
+ *
+ * @public
+ */
+export interface ExpandableProseProps {
+  /** The prose to clamp */
+  children: React.ReactNode;
+  /** Lines to show when collapsed */
+  lines?: 3 | 4 | 5 | 6;
+  /** Additional class names for the prose container */
+  className?: string;
+}
+
+/**
+ * Tailwind generates these from the literal class names, so they cannot be
+ * built by interpolation.
+ */
+const CLAMP: Record<number, string> = {
+  3: 'line-clamp-3',
+  4: 'line-clamp-4',
+  5: 'line-clamp-5',
+  6: 'line-clamp-6',
+};
+
+/**
+ * Shows the first few lines of some prose, with a toggle for the rest.
+ *
+ * @param props - Component props
+ * @returns The prose, clamped when it is long enough to need it
+ *
+ * @public
+ */
+export function ExpandableProse({ children, lines = 4, className }: ExpandableProseProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [isClipped, setIsClipped] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const contentId = useId();
+
+  const measure = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    // Only meaningful while clamped: expanded, scrollHeight equals clientHeight
+    // and every bio would look un-clipped.
+    if (expanded) return;
+    setIsClipped(el.scrollHeight > el.clientHeight + 1);
+  }, [expanded]);
+
+  useEffect(() => {
+    measure();
+
+    // A bio that fits on a wide window clips on a narrow one, and the profile
+    // header reflows at `sm`. Without this the control would be decided once,
+    // at whatever width the page happened to load at.
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+    };
+  }, [measure, children]);
+
+  return (
+    <div className="space-y-1">
+      <div ref={ref} id={contentId} className={cn(!expanded && CLAMP[lines], className)}>
+        {children}
+      </div>
+
+      {(isClipped || expanded) && (
+        <button
+          type="button"
+          onClick={() => {
+            setExpanded((value) => !value);
+          }}
+          aria-expanded={expanded}
+          aria-controls={contentId}
+          className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          {expanded ? (
+            <>
+              Show less <ChevronUp className="h-3.5 w-3.5" />
+            </>
+          ) : (
+            <>
+              Show more <ChevronDown className="h-3.5 w-3.5" />
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three things: a CI failure mode that stranded a deployment, and two profile changes.

**A cache hiccup could strand a deployment.** The staging deploy for 0.14.0 built the web image and pushed it to the registry:

```
#29 pushing manifest for ghcr.io/chive-pub/chive/web:staging@sha256:3445b35e... 1.7s done
#29 DONE 8.6s
```

then died in the *next* export:

```
#31 exporting to GitHub Actions Cache
#31 ERROR: error writing layer blob: failed to reserve cache
```

The image existed in ghcr, the job was marked failed, the steps that pull it onto the box never ran, and nothing in the failure said "your cache write was rate-limited". Staging sat two releases behind while `git log` said the change was merged. A build cache is an optimisation; failing to write one should cost build time on the next run, not a deployment of an image that already published. Both workflows that export to the Actions cache now pass `ignore-error=true`.

**A long bio is clamped**, with a control to read the rest. A long one pushed the affiliations, identifiers and eprint list off the screen. The control appears only when the text is genuinely clipped — measured from the element rather than guessed from a character count, and re-measured on resize, because a bio that fits on a wide window clips on a narrow one. It wraps children rather than taking a string, since the bio is rich text and clamping is a layout concern.

**A profile links to sifa.id** when the researcher has a profile there, and the bio field is now the rich text editor the abstract uses, so `@` mentions and `#` tags autocomplete. The field was a plain textarea, which accepted the syntax the save path already detected but offered no way to discover it.

The sifa URL was verified against the live site rather than assumed: `/profile/<handle>` and `/profile/<did>` both answer 200 and `/profile/<nonexistent>` answers 404, so the path is real and the 200 is meaningful. The link uses the DID, which does not change when someone moves domain, and appears only when `hasProfile` is true — that flag is set from records actually read out of the repository, so it never points at an empty page.

## Related Issues

The cache failure was found while investigating why a merged change was not visible on staging.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

- The cache failure mode was read from the failing run's own log (run 33549410156): the manifest push completed before the cache export raised `failed to reserve cache`. The subsequent retry, which did not hit the flake, deployed staging to 0.14.0 — confirming only the cache export had failed. I could not induce a cache failure on demand, so `ignore-error=true` rests on the documented buildx behaviour rather than a reproduction.
- 7 tests over the clamp, including that no control is offered when the prose is not clipped, that expanding drops the clamp, and that the control names the region it controls. jsdom reports every element as zero-height, so each case that needs an overflowing element stubs the heights explicitly.
- 7 tests over the sifa link and the bio editor.
- Full frontend suite: 2777 passing. Lint 0 errors, `format:check` clean, `next build` compiles.

## Screenshots

N/A

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [ ] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] N/A — no data flow change
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented
