### PR TITLE
Release 0.14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,9 @@ jobs:
             ${{ steps.meta-api.outputs.tags }}
             chive:ci
           cache-from: type=gha,scope=backend
-          cache-to: type=gha,mode=max,scope=backend
+          # A cache export failure must not fail the build; see the note in
+          # deploy-staging.yml.
+          cache-to: type=gha,mode=max,scope=backend,ignore-error=true
 
       - name: Push backend image to GHCR
         if: github.event_name != 'pull_request'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -149,7 +149,15 @@ jobs:
             NEXT_PUBLIC_CHIVE_SERVICE_DID=did:web:${{ vars.STAGING_DOMAIN }}
             NEXT_PUBLIC_USE_PERMISSION_SETS=true
           cache-from: type=gha,scope=web-staging
-          cache-to: type=gha,mode=max,scope=web-staging
+          # `ignore-error=true` because a cache export failure is not a build
+          # failure. The staging deploy for 0.14.0 built the web image and
+          # pushed it to ghcr successfully, then died on
+          # "error writing layer blob: failed to reserve cache" while exporting
+          # to the Actions cache — so the image existed but staging never
+          # pulled it, and the branch sat two releases behind with no obvious
+          # sign why. The cache is an optimisation; losing it should cost time,
+          # not a deployment.
+          cache-to: type=gha,mode=max,scope=web-staging,ignore-error=true
 
       - name: Setup Node.js and pnpm for docs build
         uses: ./.github/actions/setup-node-pnpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-09-02
+
 ### Added
 
 - **A profile links to the researcher's sifa.id page** when they have one. The link appears only for a researcher whose repository actually holds sifa records, so it never points at an empty page, and it addresses the profile by DID rather than handle, which does not change when someone moves domain.
@@ -995,7 +997,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/chive-pub/chive/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/chive-pub/chive/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/chive-pub/chive/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/chive-pub/chive/compare/v0.12.0...v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.1] - 2026-09-02
 
+### Fixed
+
+- **Affiliations were listed in no particular order.** Merging the Chive profile with the sifa.id one walked the Chive record first and appended whatever sifa alone knew about — an order nobody chose, which on a list showing years read as unsorted. Previous affiliations now order by when the role ended and current ones by when it began, most recent first, with the primary affiliation leading whatever its date. A Chive affiliation carries no dates at all, so an institution both sources name takes its dates from the sifa role, undated entries sort last, and a profile with no dates anywhere is left exactly as its owner arranged it.
+- **A paginated eprint list could repeat, skip or misorder entries.** The queries ordered by date alone, which is a partial order: PostgreSQL gives no guarantee about how it arranges tied rows and may arrange them differently for each query, and every page is a separate query. Publication dates are routinely recorded as just a month or a year, so ties are the norm — 23 of one author's 58 eprints share a timestamp with another. Ordering by the record's URI after the date makes the order total, and identical across pages.
+
 ### Added
 
 - **A profile links to the researcher's sifa.id page** when they have one. The link appears only for a researcher whose repository actually holds sifa records, so it never points at an empty page, and it addresses the profile by DID rather than handle, which does not change when someone moves domain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A cache hiccup could strand a deployment.** The staging deploy for 0.14.0 built the web image and pushed it to the registry, then failed on `error writing layer blob: failed to reserve cache` while exporting to the GitHub Actions cache. The image existed and the job was marked failed, so staging never pulled it and sat two releases behind with nothing in the failure pointing at the cause. The cache export is now marked `ignore-error=true` in both workflows that use it: a cache is an optimisation, and losing it should cost build time rather than a deployment.
+
 ## [0.14.0] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A profile links to the researcher's sifa.id page** when they have one. The link appears only for a researcher whose repository actually holds sifa records, so it never points at an empty page, and it addresses the profile by DID rather than handle, which does not change when someone moves domain.
+
+### Changed
+
+- **A long bio is clamped to a few lines, with a control to read the rest.** A long one used to push the affiliations, identifiers and eprint list off the screen. The control appears only when the text is genuinely clipped, measured rather than guessed from a character count, and re-measured when the element resizes: a bio that fits on a wide window clips on a narrow one.
+- **The bio field is a rich text editor**, the same one the abstract uses, so `@` mentions and `#` tags autocomplete and LaTeX and a preview are available. It was a plain textarea, which accepted the syntax the save path already detected but gave no way to discover it.
+
 ### Fixed
 
 - **A cache hiccup could strand a deployment.** The staging deploy for 0.14.0 built the web image and pushed it to the registry, then failed on `error writing layer blob: failed to reserve cache` while exporting to the GitHub Actions cache. The image existed and the job was marked failed, so staging never pulled it and sat two releases behind with nothing in the failure pointing at the cause. The cache export is now marked `ignore-error=true` in both workflows that use it: a cache is an optimisation, and losing it should cost build time rather than a deployment.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/src/storage/postgresql/eprints-repository.ts
+++ b/src/storage/postgresql/eprints-repository.ts
@@ -493,6 +493,19 @@ export class EprintsRepository {
       // Convert to uppercase for SQL
       const sortDirection = sortOrder.toUpperCase() as 'ASC' | 'DESC';
 
+      // The ORDER BY below breaks ties on `uri`. Without a unique tiebreaker
+      // the sort is a partial order, and PostgreSQL may return tied rows in a
+      // different arrangement for each query. Every page of a paginated list
+      // is a separate query, so a list could show one eprint twice, skip
+      // another entirely, and read as though it were not sorted by date.
+      //
+      // Ties are the norm here rather than an edge case: publication dates are
+      // routinely recorded as just a month or a year. On one author's profile
+      // 23 of 58 eprints share a timestamp with another.
+      //
+      // `uri` is the primary key, so including it makes the order total and
+      // therefore stable across queries.
+
       // Use JSONB containment query to find eprints where the author DID
       // appears anywhere in the authors array (not just submitted_by).
       // The @> operator checks if the authors array contains an object with the given DID.
@@ -507,7 +520,7 @@ export class EprintsRepository {
         FROM eprints_index
         WHERE authors @> $1::jsonb
           AND deleted_at IS NULL
-        ORDER BY ${sortColumn} ${sortDirection}
+        ORDER BY ${sortColumn} ${sortDirection}, uri ASC
         LIMIT $2 OFFSET $3
       `;
 
@@ -1044,7 +1057,7 @@ export class EprintsRepository {
       FROM eprints_index
       WHERE (${conditions.join(' OR ')})
         AND deleted_at IS NULL
-      ORDER BY created_at DESC
+      ORDER BY created_at DESC, uri ASC
       LIMIT $${fieldUris.length + 1}
     `;
 

--- a/tests/unit/storage/postgresql/stable-pagination.test.ts
+++ b/tests/unit/storage/postgresql/stable-pagination.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Guards that paginated eprint queries have a total order.
+ *
+ * @remarks
+ * `ORDER BY created_at DESC` alone is a partial order. PostgreSQL gives no
+ * guarantee about how tied rows are arranged, and it is free to arrange them
+ * differently for each query — a different plan, a parallel scan or an
+ * intervening write is enough. Every page of a paginated list is a separate
+ * query, so tied rows could appear twice, vanish, or land in an order that
+ * reads as unsorted.
+ *
+ * Ties are the norm rather than an edge case here: publication dates are
+ * routinely recorded as a month or a year. On one production profile, 23 of 58
+ * eprints share a timestamp with another.
+ *
+ * `uri` is the primary key, so ordering by it after the sort column makes the
+ * order total and identical across queries.
+ *
+ * @packageDocumentation
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repository = readFileSync(
+  join(process.cwd(), 'src/storage/postgresql/eprints-repository.ts'),
+  'utf8'
+);
+
+describe('paginated eprint queries order deterministically', () => {
+  it('breaks ties on the primary key when listing an author', () => {
+    expect(repository).toContain('ORDER BY ${sortColumn} ${sortDirection}, uri ASC');
+  });
+
+  it('breaks ties when listing by field', () => {
+    expect(repository).toContain('ORDER BY created_at DESC, uri ASC');
+  });
+
+  it('leaves no LIMIT/OFFSET query ordered by a non-unique column alone', () => {
+    // Any ORDER BY that feeds a paged query needs the tiebreaker; this catches
+    // a new one added without it.
+    const paged = repository.match(/ORDER BY [^\n]*\n\s*LIMIT[^\n]*OFFSET/g) ?? [];
+    for (const clause of paged) {
+      expect(clause).toContain('uri ASC');
+    }
+  });
+});

--- a/web/components/eprints/author-header-sifa-link.test.ts
+++ b/web/components/eprints/author-header-sifa-link.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Guards the sifa.id link and the bio editor.
+ *
+ * @remarks
+ * The sifa profile URL was verified against the live site rather than assumed:
+ * `/profile/<handle>` and `/profile/<did>` both answer 200, and
+ * `/profile/<nonexistent>` answers 404 — so the path is real and the 200 is
+ * meaningful.
+ *
+ * @packageDocumentation
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const webRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const header = readFileSync(join(webRoot, 'components/eprints/author-header.tsx'), 'utf8');
+const settings = readFileSync(join(webRoot, 'components/settings/chive-profile-form.tsx'), 'utf8');
+
+describe('sifa.id link', () => {
+  it('uses the profile path the site actually serves', () => {
+    expect(header).toContain('https://sifa.id/profile/');
+  });
+
+  it('addresses the profile by DID, which does not change when a handle does', () => {
+    expect(header).toMatch(/sifa\.id\/profile\/\$\{encodeURIComponent\(profile\.did\)\}/);
+  });
+
+  it('appears only for a researcher who has a sifa profile', () => {
+    // `hasProfile` is set from records read out of the repository, so this
+    // never links to an empty page.
+    expect(header).toMatch(/sifa\?\.hasProfile === true/);
+  });
+
+  it('opens externally without leaking the referrer window', () => {
+    const linkBlock = header.slice(header.indexOf('https://sifa.id/profile/'));
+    expect(linkBlock.slice(0, 400)).toContain('rel="noopener noreferrer"');
+  });
+});
+
+describe('bio editing', () => {
+  it('uses the editor that offers @ and # autocomplete', () => {
+    // A plain textarea accepted the syntax but gave no way to discover it.
+    expect(settings).toContain('MarkdownEditor');
+    expect(settings).toContain('enableMentions');
+    expect(settings).toContain('enableTags');
+  });
+
+  it('no longer uses a bare textarea for the bio', () => {
+    expect(settings).not.toContain('@/components/ui/textarea');
+  });
+});
+
+describe('bio display', () => {
+  it('clamps a long bio rather than letting it push the page down', () => {
+    expect(header).toContain('ExpandableProse');
+  });
+});

--- a/web/components/eprints/author-header.tsx
+++ b/web/components/eprints/author-header.tsx
@@ -10,6 +10,7 @@ import {
   BookOpen,
   Copy,
   Check,
+  UserCircle,
 } from 'lucide-react';
 
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
@@ -23,6 +24,7 @@ import type { SifaProfile } from '@/lib/api/generated/types/pub/chive/author/get
 import type { RichTextItem } from '@/lib/types/rich-text';
 import { RichTextRenderer } from '@/components/editor';
 import { mergeAffiliations } from '@/lib/profile/merge-affiliations';
+import { ExpandableProse } from '@/components/ui/expandable-prose';
 
 /**
  * Props for the AuthorHeader component.
@@ -184,23 +186,55 @@ export function AuthorHeader({ profile, sifa, className }: AuthorHeaderProps) {
             </div>
           )}
 
-          {/* Bio */}
+          {/* Bio.
+
+              Clamped to a few lines: a long bio otherwise pushed the
+              affiliations, identifiers and eprint list off the screen. The
+              control only appears when the text is genuinely clipped, which is
+              measured rather than guessed — a bio that fits on a wide window
+              clips on a narrow one.
+
+              A `div` rather than a `p`: rich text can contain block content,
+              and a heading or list inside a paragraph is invalid markup that
+              browsers silently restructure. */}
           {profile.bio && (
-            <p className="mt-4 max-w-2xl text-muted-foreground">
-              {/* The same renderer reviews and abstracts use. A bio written
+            <div className="mt-4">
+              <ExpandableProse lines={4} className="max-w-2xl text-muted-foreground">
+                {/* The same renderer reviews and abstracts use. A bio written
                   before rich text existed has no `bioRich`, and falls back to
                   its plain text. */}
-              {extendedProfile.bioRich && extendedProfile.bioRich.length > 0 ? (
-                <RichTextRenderer items={extendedProfile.bioRich} mode="block" />
-              ) : (
-                <RichTextRenderer text={profile.bio} mode="block" />
-              )}
-            </p>
+                {extendedProfile.bioRich && extendedProfile.bioRich.length > 0 ? (
+                  <RichTextRenderer items={extendedProfile.bioRich} mode="block" />
+                ) : (
+                  <RichTextRenderer text={profile.bio} mode="block" />
+                )}
+              </ExpandableProse>
+            </div>
           )}
 
           {/* Primary links row */}
           <div className="mt-4 flex flex-wrap items-center justify-center gap-4 sm:justify-start">
             {profile.orcid && <OrcidBadge orcid={profile.orcid} verified={profile.orcidVerified} />}
+
+            {/* sifa.id profile.
+
+                Linked only when they actually have one — `hasProfile` is set
+                from records read out of their repository, not assumed from the
+                DID, so this never points at an empty page. Addressed by DID
+                rather than handle: sifa resolves both, and a DID does not
+                change when someone moves domain. */}
+            {sifa?.hasProfile === true && (
+              <a
+                href={`https://sifa.id/profile/${encodeURIComponent(profile.did)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-sm text-primary hover:underline"
+              >
+                <UserCircle className="h-4 w-4" />
+                sifa.id
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
 
             {profile.website && (
               <a

--- a/web/components/settings/chive-profile-form.tsx
+++ b/web/components/settings/chive-profile-form.tsx
@@ -23,7 +23,6 @@ import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -37,6 +36,7 @@ import { OrcidAutocompleteInput } from './orcid-autocomplete-input';
 import { AuthorIdAutocompleteInput } from './author-id-autocomplete-input';
 import { FieldSearch, type FieldSelection } from '@/components/forms/field-search';
 import { useOrcidOAuth } from '@/lib/hooks/use-orcid-oauth';
+import { MarkdownEditor } from '@/components/editor';
 
 /**
  * Converts API affiliations (may be string[] or structured) to structured format.
@@ -418,11 +418,24 @@ export function ChiveProfileForm() {
 
             <div className="space-y-2">
               <Label htmlFor="bio">Bio</Label>
-              <Textarea
-                id="bio"
+              {/* The same editor the abstract uses, so a bio gets @ mention
+                  and # tag autocomplete, LaTeX and a preview — the facets
+                  detected on save are the ones written here. A plain textarea
+                  accepted the syntax but offered no way to discover it. */}
+              <MarkdownEditor
+                value={form.watch('bio') ?? ''}
+                onChange={(value) => {
+                  form.setValue('bio', value, { shouldDirty: true });
+                }}
                 placeholder="Brief academic bio"
-                rows={4}
-                {...form.register('bio')}
+                maxLength={2000}
+                minHeight="8rem"
+                enableMentions
+                enableTags
+                enableLatex
+                enablePreview
+                ariaLabel="Bio"
+                testId="bio-editor"
               />
               <p className="text-xs text-muted-foreground">
                 Shown on your Chive profile in place of your sifa.id summary or your Bluesky

--- a/web/components/ui/__tests__/expandable-prose.test.tsx
+++ b/web/components/ui/__tests__/expandable-prose.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Tests for clamping long prose.
+ *
+ * @remarks
+ * jsdom reports every element as zero-height, so `scrollHeight > clientHeight`
+ * is never true by accident. Each case that needs an overflowing element says
+ * so explicitly, which also documents what the component measures.
+ *
+ * @packageDocumentation
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+import { ExpandableProse } from '@/components/ui/expandable-prose';
+
+/**
+ * Makes every element report itself as overflowing its clamp.
+ */
+function makeContentOverflow(scrollHeight: number, clientHeight: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get: () => clientHeight,
+  });
+}
+
+beforeEach(() => {
+  // jsdom has no ResizeObserver.
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // @ts-expect-error restoring the prototype descriptors jsdom shipped with
+  delete HTMLElement.prototype.scrollHeight;
+  // @ts-expect-error restoring the prototype descriptors jsdom shipped with
+  delete HTMLElement.prototype.clientHeight;
+});
+
+describe('ExpandableProse', () => {
+  it('always renders its content', () => {
+    render(<ExpandableProse>A short bio.</ExpandableProse>);
+    expect(screen.getByText('A short bio.')).toBeInTheDocument();
+  });
+
+  it('offers no control when the prose is not clipped', () => {
+    // A "Show more" beside three lines that were never truncated is worse than
+    // no control at all.
+    makeContentOverflow(40, 40);
+    render(<ExpandableProse>A short bio.</ExpandableProse>);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('offers a control when the prose is clipped', () => {
+    makeContentOverflow(400, 80);
+    render(<ExpandableProse>A very long bio.</ExpandableProse>);
+
+    expect(screen.getByRole('button', { name: /show more/i })).toBeInTheDocument();
+  });
+
+  it('reveals the rest when asked, and can be collapsed again', async () => {
+    makeContentOverflow(400, 80);
+    const user = userEvent.setup();
+    render(<ExpandableProse>A very long bio.</ExpandableProse>);
+
+    const button = screen.getByRole('button', { name: /show more/i });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(button);
+
+    const collapse = screen.getByRole('button', { name: /show less/i });
+    expect(collapse).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(collapse);
+    expect(screen.getByRole('button', { name: /show more/i })).toBeInTheDocument();
+  });
+
+  it('names the region it controls, so the control is announced usefully', () => {
+    makeContentOverflow(400, 80);
+    render(<ExpandableProse>A very long bio.</ExpandableProse>);
+
+    const button = screen.getByRole('button', { name: /show more/i });
+    const controlled = button.getAttribute('aria-controls');
+
+    expect(controlled).toBeTruthy();
+    expect(document.getElementById(controlled ?? '')).toHaveTextContent('A very long bio.');
+  });
+
+  it('drops the clamp once expanded', async () => {
+    makeContentOverflow(400, 80);
+    const user = userEvent.setup();
+    render(<ExpandableProse lines={4}>A very long bio.</ExpandableProse>);
+
+    const region = document.getElementById(
+      screen.getByRole('button').getAttribute('aria-controls') ?? ''
+    );
+    expect(region?.className).toContain('line-clamp-4');
+
+    await user.click(screen.getByRole('button'));
+    expect(region?.className).not.toContain('line-clamp-4');
+  });
+
+  it('uses a literal clamp class, since Tailwind cannot see an interpolated one', () => {
+    makeContentOverflow(400, 80);
+    render(<ExpandableProse lines={6}>A very long bio.</ExpandableProse>);
+
+    const region = document.getElementById(
+      screen.getByRole('button').getAttribute('aria-controls') ?? ''
+    );
+    expect(region?.className).toContain('line-clamp-6');
+  });
+});

--- a/web/components/ui/expandable-prose.tsx
+++ b/web/components/ui/expandable-prose.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+/**
+ * Clamps long prose to a few lines, with a control to reveal the rest.
+ *
+ * @remarks
+ * A profile bio has no length limit worth relying on, and a long one pushed
+ * everything below it — affiliations, identifiers, the eprint list — off the
+ * screen. This shows the opening and lets the reader ask for the rest.
+ *
+ * The control appears only when the text is actually clipped. Rendering a
+ * "Show more" beside three lines that were never truncated is worse than not
+ * having one, and whether a given bio overflows depends on the viewport, so it
+ * is measured rather than guessed from a character count: the clamped element
+ * is checked for `scrollHeight > clientHeight`, and re-checked when the
+ * element resizes.
+ *
+ * It wraps arbitrary children rather than taking a string, because the bio is
+ * rich text — links, mentions, LaTeX — and clamping is a layout concern that
+ * should not care what it is clamping.
+ *
+ * @packageDocumentation
+ */
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Props for {@link ExpandableProse}.
+ *
+ * @public
+ */
+export interface ExpandableProseProps {
+  /** The prose to clamp */
+  children: React.ReactNode;
+  /** Lines to show when collapsed */
+  lines?: 3 | 4 | 5 | 6;
+  /** Additional class names for the prose container */
+  className?: string;
+}
+
+/**
+ * Tailwind generates these from the literal class names, so they cannot be
+ * built by interpolation.
+ */
+const CLAMP: Record<number, string> = {
+  3: 'line-clamp-3',
+  4: 'line-clamp-4',
+  5: 'line-clamp-5',
+  6: 'line-clamp-6',
+};
+
+/**
+ * Shows the first few lines of some prose, with a toggle for the rest.
+ *
+ * @param props - Component props
+ * @returns The prose, clamped when it is long enough to need it
+ *
+ * @public
+ */
+export function ExpandableProse({ children, lines = 4, className }: ExpandableProseProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [isClipped, setIsClipped] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const contentId = useId();
+
+  const measure = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    // Only meaningful while clamped: expanded, scrollHeight equals clientHeight
+    // and every bio would look un-clipped.
+    if (expanded) return;
+    setIsClipped(el.scrollHeight > el.clientHeight + 1);
+  }, [expanded]);
+
+  useEffect(() => {
+    measure();
+
+    // A bio that fits on a wide window clips on a narrow one, and the profile
+    // header reflows at `sm`. Without this the control would be decided once,
+    // at whatever width the page happened to load at.
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+    };
+  }, [measure, children]);
+
+  return (
+    <div className="space-y-1">
+      <div ref={ref} id={contentId} className={cn(!expanded && CLAMP[lines], className)}>
+        {children}
+      </div>
+
+      {(isClipped || expanded) && (
+        <button
+          type="button"
+          onClick={() => {
+            setExpanded((value) => !value);
+          }}
+          aria-expanded={expanded}
+          aria-controls={contentId}
+          className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          {expanded ? (
+            <>
+              Show less <ChevronUp className="h-3.5 w-3.5" />
+            </>
+          ) : (
+            <>
+              Show more <ChevronDown className="h-3.5 w-3.5" />
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/lib/profile/__tests__/merge-affiliations.test.ts
+++ b/web/lib/profile/__tests__/merge-affiliations.test.ts
@@ -148,3 +148,69 @@ describe('formatSpan', () => {
     expect(formatSpan({})).toBeUndefined();
   });
 });
+
+describe('ordering', () => {
+  it('puts previous affiliations most recently ended first', () => {
+    // The merge walks Chive first and appends sifa-only entries, which is an
+    // order nobody chose — a list showing years read as though unsorted.
+    const merged = mergeAffiliations(
+      [{ name: 'Listed first in the profile' }],
+      [
+        { institution: 'Ended 2018', endedAt: '2018-01-01', source: 'position' },
+        { institution: 'Ended 2024', endedAt: '2024-01-01', source: 'position' },
+        { institution: 'Ended 2021', endedAt: '2021-01-01', source: 'education' },
+      ]
+    );
+
+    expect(merged.map((m) => m.institution)).toEqual([
+      'Ended 2024',
+      'Ended 2021',
+      'Ended 2018',
+      // Undated, so last.
+      'Listed first in the profile',
+    ]);
+  });
+
+  it('orders current affiliations by when the role began', () => {
+    const merged = mergeAffiliations(undefined, [
+      { institution: 'Started 2016', startedAt: '2016-01-01', source: 'position' },
+      { institution: 'Started 2024', startedAt: '2024-01-01', source: 'position' },
+    ]);
+
+    expect(merged.map((m) => m.institution)).toEqual(['Started 2024', 'Started 2016']);
+  });
+
+  it('leads with the primary affiliation whatever its date', () => {
+    const merged = mergeAffiliations(undefined, [
+      { institution: 'Recent', startedAt: '2024-01-01', source: 'position' },
+      {
+        institution: 'Older but primary',
+        startedAt: '2016-01-01',
+        isPrimary: true,
+        source: 'position',
+      },
+    ]);
+
+    expect(merged[0]?.institution).toBe('Older but primary');
+  });
+
+  it('leaves a profile with no dates exactly as its owner arranged it', () => {
+    // A Chive affiliation carries no dates, so sorting must not reshuffle one.
+    const merged = mergeAffiliations(
+      [{ name: 'First' }, { name: 'Second' }, { name: 'Third' }],
+      undefined
+    );
+
+    expect(merged.map((m) => m.institution)).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('dates an institution the sources both mention by the sifa role', () => {
+    const merged = mergeAffiliations(
+      [{ name: 'Undated in Chive' }, { name: 'Rochester' }],
+      [{ institution: 'Rochester', endedAt: '2024-01-01', source: 'position' }]
+    );
+
+    // Rochester has a date now, so it leads the undated one.
+    expect(merged.map((m) => m.institution)).toEqual(['Rochester', 'Undated in Chive']);
+  });
+});

--- a/web/lib/profile/merge-affiliations.ts
+++ b/web/lib/profile/merge-affiliations.ts
@@ -47,6 +47,10 @@ export interface MergedAffiliation {
   readonly title?: string;
   /** Years the role covers, already formatted */
   readonly span?: string;
+  /** ISO date the role began, kept for ordering */
+  readonly startedAt?: string;
+  /** ISO date the role ended, kept for ordering */
+  readonly endedAt?: string;
   /** Whether this is the primary affiliation */
   readonly isPrimary: boolean;
   /** Which sources mentioned this institution */
@@ -132,6 +136,13 @@ export function mergeAffiliations(
               const span = formatSpan(role);
               return span ? { span } : {};
             })()),
+        // Chive affiliations carry no dates, so an institution both sources
+        // name is dated by the sifa role. Without this it stays undated and
+        // sorts to the bottom of a list ordered by recency.
+        ...(existing.startedAt === undefined && role.startedAt
+          ? { startedAt: role.startedAt }
+          : {}),
+        ...(existing.endedAt === undefined && role.endedAt ? { endedAt: role.endedAt } : {}),
         isPrimary: existing.isPrimary || role.isPrimary === true,
         sources: existing.sources.includes('sifa')
           ? existing.sources
@@ -147,13 +158,55 @@ export function mergeAffiliations(
       units: [],
       ...(role.title ? { title: role.title } : {}),
       ...(span ? { span } : {}),
+      ...(role.startedAt ? { startedAt: role.startedAt } : {}),
+      ...(role.endedAt ? { endedAt: role.endedAt } : {}),
       isPrimary: role.isPrimary === true,
       sources: ['sifa'],
     });
   }
 
-  return order.flatMap((key) => {
+  const merged = order.flatMap((key) => {
     const entry = byKey.get(key);
     return entry ? [entry] : [];
+  });
+
+  return sortByRecency(merged);
+}
+
+/**
+ * Orders affiliations most recent first.
+ *
+ * @param merged - Affiliations in the order the sources listed them
+ * @returns The same affiliations, ordered by date
+ *
+ * @remarks
+ * The merge walks the Chive profile and then appends anything sifa alone knew
+ * about, which is an order nobody chose — so a list showing years read as
+ * though it were unsorted. Previous affiliations order by when the role ended
+ * and current ones by when it began, both most recent first.
+ *
+ * A Chive affiliation carries no dates at all: the record is a tree of
+ * institution and sub-units with nothing temporal on it. Undated entries
+ * therefore sort after dated ones, and among themselves keep the order the
+ * profile lists them in — `Array.prototype.sort` is stable, so a profile with
+ * no dates anywhere is left exactly as its owner arranged it.
+ *
+ * The primary affiliation leads regardless of date, because that is what
+ * "primary" means.
+ */
+function sortByRecency(merged: readonly MergedAffiliation[]): MergedAffiliation[] {
+  return [...merged].sort((a, b) => {
+    if (a.isPrimary !== b.isPrimary) {
+      return a.isPrimary ? -1 : 1;
+    }
+
+    // A role that ended is dated by its ending; one still running by its start.
+    const aKey = a.endedAt ?? a.startedAt ?? '';
+    const bKey = b.endedAt ?? b.startedAt ?? '';
+
+    if (aKey === bKey) return 0;
+    if (!aKey) return 1;
+    if (!bKey) return -1;
+    return bKey.localeCompare(aKey);
   });
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Release 0.14.1. Ordering fixes on the profile, plus the CI and profile work from #191.

**Affiliations were listed in no particular order.** Merging the Chive profile with the sifa.id one walked the Chive record first and appended whatever sifa alone knew about — an order nobody chose, which on a list showing years read as unsorted. Previous affiliations now order by when the role ended and current ones by when it began, most recent first, with the primary affiliation leading whatever its date. A Chive affiliation carries no dates at all, so an institution both sources name takes its dates from the sifa role, undated entries sort last, and a profile with no dates anywhere is left exactly as its owner arranged it.

**A paginated eprint list could repeat, skip or misorder entries.** The queries ordered by date alone, which is a partial order: PostgreSQL gives no guarantee about how tied rows are arranged and may arrange them differently per query, and every page is a separate query. Publication dates are routinely recorded as just a month or a year, so ties are the norm rather than an edge case — 23 of one author's 58 eprints share a timestamp with another. Ordering by URI after the date makes the order total and identical across pages. This became reachable when pagination started working in 0.13.1; before that no second page was ever fetched.

Also carried in this release, from #191: a build cache export failure no longer fails a deployment; long bios clamp behind a "Show more"; profiles link to sifa.id; and the bio field is the rich text editor with `@`/`#` autocomplete.

## Related Issues

Follows v0.14.0.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

- The eprint ordering bug was measured against production, not assumed: `listByAuthor` returns 58 eprints for one author of which 23 share a timestamp with another, and requesting `sortBy=indexedAt` returns a visibly unsorted list of publication dates.
- The tiebreaker was checked against a real PostgreSQL: with it, two pages of tied rows partition cleanly with no overlap and no skip. I could not force the untied version to misbehave on a small table — Postgres happened to be consistent there — so this rests on the ordering guarantee rather than a reproduction.
- 18 tests over the affiliation merge, including that a dateless profile is not reshuffled and that the primary affiliation leads regardless of date.
- Full suites: 4688 backend, 2782 frontend. Lint 0 errors, `format:check` clean.

## Screenshots

N/A

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [ ] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Read path only: an additional ORDER BY term on queries against an index Chive rebuilds from the firehose.

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented