### PR TITLE
Release 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-09-03
+
+### Fixed
+
+- **A citation network of anonymous boxes.** The graph stores only URIs on its nodes, so an edge read back from it carried nothing a reader could recognise, and every node rendered as "Citing paper 1", "Citing paper 2" — a network that is technically correct and tells a reader nothing. `pub.chive.discovery.getCitations` now returns the papers at both ends of the edges it reports, named the way a paper is cited: first author, year, title, and the venue when known. They come back as a lookup rather than as metadata repeated on each edge, since one paper commonly sits at the end of many of them, and they are resolved in a single query rather than one per edge.
+
 ### Fixed
 
 - **A quarter of the corpus had a PDF and no references at all.** Citation extraction runs once, when an eprint is indexed, and degrades gracefully when GROBID cannot be reached — correctly, since one unreachable service must not fail an indexing run. But the degradation left no trace, and nothing retried: an eprint whose extraction failed was indistinguishable from one whose references had been read and found to be none, because both have no rows. On production this was 18 of 66 eprints, including papers with 141 references apiece, and the only symptom was a citation network smaller than it should be.
@@ -1093,7 +1099,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/chive-pub/chive/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/chive-pub/chive/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/chive-pub/chive/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/chive-pub/chive/compare/v0.16.0...v0.17.0

--- a/docs/openapi/chive-api.json
+++ b/docs/openapi/chive-api.json
@@ -5649,13 +5649,30 @@
         "type": "object"
       },
       "pub.chive.discovery.getCitations.eprintRef": {
+        "description": "An eprint named well enough to identify it on sight. The citation graph stores only URIs on its nodes, so an edge read back from it carries nothing a reader could recognise.",
         "properties": {
+          "authors": {
+            "items": {
+              "maxLength": 256,
+              "type": "string"
+            },
+            "type": "array"
+          },
           "title": {
             "type": "string"
           },
           "uri": {
             "format": "at-uri",
             "type": "string"
+          },
+          "venue": {
+            "description": "Journal or proceedings the eprint appeared in, when known.",
+            "maxLength": 512,
+            "type": "string"
+          },
+          "year": {
+            "description": "Publication year, when the eprint records a published version.",
+            "type": "integer"
           }
         },
         "required": [
@@ -25257,6 +25274,12 @@
                     "hasMore": {
                       "description": "Whether more results are available",
                       "type": "boolean"
+                    },
+                    "papers": {
+                      "items": {
+                        "$ref": "#/components/schemas/pub.chive.discovery.getCitations.eprintRef"
+                      },
+                      "type": "array"
                     }
                   },
                   "required": [

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/lexicons/pub/chive/discovery/getCitations.json
+++ b/lexicons/pub/chive/discovery/getCitations.json
@@ -67,6 +67,14 @@
             "hasMore": {
               "type": "boolean",
               "description": "Whether more results are available"
+            },
+            "papers": {
+              "type": "array",
+              "description": "Every eprint appearing at either end of the returned citations, once each. A lookup rather than metadata repeated on each edge: a densely connected paper would otherwise carry the same author list dozens of times in one response.",
+              "items": {
+                "type": "ref",
+                "ref": "#eprintRef"
+              }
             }
           }
         }
@@ -90,8 +98,26 @@
         },
         "title": {
           "type": "string"
+        },
+        "authors": {
+          "type": "array",
+          "description": "Author names in record order. A citation is identified by who wrote it as much as by its title.",
+          "items": {
+            "type": "string",
+            "maxLength": 256
+          }
+        },
+        "year": {
+          "type": "integer",
+          "description": "Publication year, when the eprint records a published version."
+        },
+        "venue": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Journal or proceedings the eprint appeared in, when known."
         }
-      }
+      },
+      "description": "An eprint named well enough to identify it on sight. The citation graph stores only URIs on its nodes, so an edge read back from it carries nothing a reader could recognise."
     },
     "citationCounts": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/src/api/handlers/xrpc/discovery/getCitations.ts
+++ b/src/api/handlers/xrpc/discovery/getCitations.ts
@@ -99,6 +99,26 @@ export const getCitations: XRPCMethod<QueryParams, void, OutputSchema> = {
       }
     }
 
+    // Name both ends of every edge.
+    //
+    // The citation graph stores only URIs on its nodes, so an edge read back
+    // from it carries nothing a reader could recognise -- which is why the
+    // network rendered as boxes labelled "Citing paper 1", "Citing paper 2".
+    //
+    // These go in a lookup rather than on each edge: one paper is commonly at
+    // the end of many of them, and repeating its author list per edge would
+    // send the same names back a dozen times in one response. One query for the
+    // page, not one per edge.
+    const refs = await discovery.getEprintRefs(citations.flatMap((c) => [c.citingUri, c.citedUri]));
+
+    const papers: OutputSchema['papers'] = [...refs.values()].map((ref) => ({
+      uri: ref.uri,
+      title: ref.title,
+      authors: [...ref.authors],
+      ...(ref.year !== undefined ? { year: ref.year } : {}),
+      ...(ref.venue !== undefined ? { venue: ref.venue } : {}),
+    }));
+
     logger.info('Citations returned', {
       uri: params.uri,
       citedByCount: counts.citedByCount,
@@ -119,6 +139,7 @@ export const getCitations: XRPCMethod<QueryParams, void, OutputSchema> = {
           influentialCitedByCount: counts.influentialCitedByCount,
         },
         citations,
+        papers,
         cursor,
         hasMore,
       },

--- a/src/services/discovery/discovery-service.ts
+++ b/src/services/discovery/discovery-service.ts
@@ -82,6 +82,43 @@ import { extractPlainText } from '../../utils/rich-text.js';
 import type { DiscoverySignalWeights } from '../search/ranking-service.js';
 
 /**
+ * An eprint named well enough to identify on sight.
+ *
+ * @public
+ */
+export interface EprintRef {
+  readonly uri: string;
+  readonly title: string;
+  readonly authors: readonly string[];
+  readonly year?: number;
+  readonly venue?: string;
+}
+
+/**
+ * Reads author names out of the stored author list.
+ *
+ * @param value - The `authors` column, as jsonb
+ * @returns Names in record order
+ *
+ * @remarks
+ * Author order is meaningful in a citation -- the first name is how the work is
+ * referred to -- so it is preserved rather than sorted. Entries without a name
+ * are dropped instead of appearing as blanks in a byline.
+ */
+function parseAuthorNames(value: unknown): string[] {
+  const raw = typeof value === 'string' ? (JSON.parse(value) as unknown) : value;
+  if (!Array.isArray(raw)) return [];
+
+  return raw
+    .map((author) =>
+      author !== null && typeof author === 'object'
+        ? (author as { name?: unknown }).name
+        : undefined
+    )
+    .filter((name): name is string => typeof name === 'string' && name.length > 0);
+}
+
+/**
  * Database row for user interactions.
  */
 interface InteractionRow {
@@ -1364,6 +1401,59 @@ export class DiscoveryService implements IDiscoveryService {
    * @remarks
    * Delegates to the underlying citation graph service.
    */
+  /**
+   * Resolves eprints named well enough to identify on sight.
+   *
+   * @param uris - AT-URIs to look up
+   * @returns One entry per indexed eprint; a URI with no eprint is absent
+   *
+   * @remarks
+   * The citation graph stores only URIs on its nodes, so an edge read back from
+   * it carries nothing a reader could recognise -- which is why the network
+   * rendered as boxes labelled "Citing paper 1", "Citing paper 2". A paper is
+   * identified by who wrote it and when as much as by its title, so all three
+   * come back together.
+   *
+   * One query for the whole page rather than a lookup per edge: a well-cited
+   * paper would otherwise cost dozens of round trips to draw a single tab.
+   */
+  async getEprintRefs(uris: readonly string[]): Promise<Map<string, EprintRef>> {
+    if (uris.length === 0) {
+      return new Map();
+    }
+
+    const result = await this.db.query<{
+      uri: string;
+      title: string;
+      authors: unknown;
+      year: number | null;
+      venue: string | null;
+    }>(
+      `SELECT
+         uri,
+         title,
+         authors,
+         NULLIF(LEFT(published_version->>'publishedAt', 4), '')::int AS year,
+         published_version->>'journal' AS venue
+       FROM eprints_index
+       WHERE uri = ANY($1)`,
+      [[...new Set(uris)]]
+    );
+
+    return new Map(
+      result.rows.map((row) => [
+        row.uri,
+        {
+          uri: row.uri,
+          title: row.title,
+          authors: parseAuthorNames(row.authors),
+          ...(row.year !== null ? { year: row.year } : {}),
+          ...(row.venue ? { venue: row.venue } : {}),
+        },
+      ])
+    );
+  }
+
   async getCitationCounts(uri: AtUri): Promise<{
     readonly citedByCount: number;
     readonly referencesCount: number;

--- a/tests/unit/services/discovery/discovery-service.test.ts
+++ b/tests/unit/services/discovery/discovery-service.test.ts
@@ -475,6 +475,76 @@ describe('DiscoveryService', () => {
     vi.clearAllMocks();
   });
 
+  describe('getEprintRefs', () => {
+    // The citation graph stores only URIs on its nodes, so an edge read back
+    // from it carries nothing a reader could recognise -- which is why the
+    // network rendered as boxes labelled "Citing paper 1", "Citing paper 2".
+
+    it('names a paper by title, authors and year', async () => {
+      db.query.mockResolvedValueOnce({
+        rows: [
+          {
+            uri: 'at://did:plc:a/pub.chive.eprint.submission/one',
+            title: 'Neural Models of Factuality',
+            authors: [{ name: 'Aaron Steven White' }, { name: 'Rachel Rudinger' }],
+            year: 2018,
+            venue: 'NAACL',
+          },
+        ],
+      });
+
+      const refs = await service.getEprintRefs(['at://did:plc:a/pub.chive.eprint.submission/one']);
+      const ref = refs.get('at://did:plc:a/pub.chive.eprint.submission/one');
+
+      expect(ref?.title).toBe('Neural Models of Factuality');
+      // Author order is meaningful: the first name is how the work is cited.
+      expect(ref?.authors).toEqual(['Aaron Steven White', 'Rachel Rudinger']);
+      expect(ref?.year).toBe(2018);
+      expect(ref?.venue).toBe('NAACL');
+    });
+
+    it('looks every URI up in one query, deduplicated', async () => {
+      db.query.mockResolvedValueOnce({ rows: [] });
+
+      await service.getEprintRefs(['at://a/c/1', 'at://a/c/2', 'at://a/c/1']);
+
+      // One paper commonly sits at the end of many edges; a lookup per edge
+      // would cost dozens of round trips to draw a single tab.
+      expect(db.query).toHaveBeenCalledTimes(1);
+      const params = db.query.mock.calls[0]?.[1] as unknown[][];
+      expect(params[0]).toEqual(['at://a/c/1', 'at://a/c/2']);
+    });
+
+    it('does not query for an empty set', async () => {
+      const refs = await service.getEprintRefs([]);
+
+      expect(refs.size).toBe(0);
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it('drops author entries with no name rather than rendering blanks', async () => {
+      db.query.mockResolvedValueOnce({
+        rows: [
+          {
+            uri: 'at://did:plc:a/pub.chive.eprint.submission/two',
+            title: 'A Paper',
+            authors: [{ name: 'Real Person' }, {}, { name: '' }],
+            year: null,
+            venue: null,
+          },
+        ],
+      });
+
+      const ref = (
+        await service.getEprintRefs(['at://did:plc:a/pub.chive.eprint.submission/two'])
+      ).get('at://did:plc:a/pub.chive.eprint.submission/two');
+
+      expect(ref?.authors).toEqual(['Real Person']);
+      expect(ref?.year).toBeUndefined();
+      expect(ref?.venue).toBeUndefined();
+    });
+  });
+
   // ==========================================================================
   // setPluginManager
   // ==========================================================================

--- a/web/components/eprints/citation-visualization.label.test.ts
+++ b/web/components/eprints/citation-visualization.label.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for how a citation node names its paper.
+ *
+ * @remarks
+ * The citation graph stores only URIs on its nodes, so before the API returned
+ * anything to label them with, every node read "Citing paper 1", "Citing paper
+ * 2" — a network that is technically correct and tells a reader nothing.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { paperLabel } from '@/components/eprints/citation-visualization';
+
+describe('paperLabel', () => {
+  it('names a paper the way it would be cited', () => {
+    const label = paperLabel(
+      {
+        title: 'Neural Models of Factuality',
+        authors: ['Aaron Steven White', 'Rachel Rudinger'],
+        year: 2018,
+      },
+      'Citing paper 1'
+    );
+
+    // Surname and year, as a citation is spoken; the full name crowds the node.
+    expect(label).toBe('White 2018 — Neural Models of Factuality');
+  });
+
+  it('falls back when the API did not name the paper', () => {
+    expect(paperLabel(undefined, 'Citing paper 3')).toBe('Citing paper 3');
+  });
+
+  it('uses the title alone when there is no author or year', () => {
+    expect(paperLabel({ title: 'An Untitled Sort of Paper' }, 'Reference 2')).toBe(
+      'An Untitled Sort of Paper'
+    );
+  });
+
+  it('truncates a long title rather than letting it overrun the node', () => {
+    const long = 'A'.repeat(80);
+    const label = paperLabel({ title: long, authors: ['Ada Lovelace'], year: 1843 }, 'x');
+
+    expect(label.startsWith('Lovelace 1843 — ')).toBe(true);
+    expect(label.endsWith('...')).toBe(true);
+    expect(label.length).toBeLessThan(70);
+  });
+});

--- a/web/components/eprints/citation-visualization.tsx
+++ b/web/components/eprints/citation-visualization.tsx
@@ -54,6 +54,35 @@ export interface CitationVisualizationProps {
 }
 
 /**
+ * A paper as it should appear on a node.
+ *
+ * @param paper - The paper, when the API named it
+ * @param fallback - What to call it when the API did not
+ * @returns A label a reader can recognise
+ *
+ * @remarks
+ * How a paper is referred to in prose: first author, year, then the title. A
+ * node labelled with the title alone still makes a reader work out whose paper
+ * it is, and one labelled "Citing paper 3" tells them nothing at all -- which
+ * is what these nodes said before the API returned anything to label them
+ * with.
+ */
+export function paperLabel(
+  paper: { title: string; authors?: string[]; year?: number } | undefined,
+  fallback: string
+): string {
+  if (!paper) return fallback;
+
+  const first = paper.authors?.[0];
+  // A surname alone is how a citation is spoken; the full name crowds the node.
+  const surname = first?.trim().split(/\s+/).pop();
+  const byline = [surname, paper.year ? String(paper.year) : undefined].filter(Boolean).join(' ');
+
+  const title = paper.title.length > 44 ? `${paper.title.slice(0, 44)}...` : paper.title;
+  return byline ? `${byline} — ${title}` : title;
+}
+
+/**
  * Citation node data.
  */
 interface CitationNodeData {
@@ -77,6 +106,13 @@ interface CitationData {
     referencesCount: number;
     influentialCitedByCount: number;
   };
+  papers?: Array<{
+    uri: string;
+    title: string;
+    authors?: string[];
+    year?: number;
+    venue?: string;
+  }>;
   citations: Array<{
     citingUri: string;
     citedUri: string;
@@ -146,10 +182,15 @@ const nodeTypes: NodeTypes = {
 function layoutCitationNodes(
   centerEprint: { uri: string; title: string },
   citations: CitationData['citations'],
-  _counts: CitationData['counts']
+  _counts: CitationData['counts'],
+  papers: CitationData['papers'] = []
 ): { nodes: Node<CitationNodeData>[]; edges: Edge[] } {
   const nodes: Node<CitationNodeData>[] = [];
   const edges: Edge[] = [];
+
+  // The API returns each paper once and the edges reference them by URI, so a
+  // paper at the end of many edges is sent once rather than repeated on each.
+  const byUri = new Map(papers.map((paper) => [paper.uri, paper]));
 
   const horizontalSpacing = 300;
   const verticalSpacing = 100;
@@ -185,7 +226,7 @@ function layoutCitationNodes(
       type: 'citation',
       position: { x: -horizontalSpacing, y },
       data: {
-        label: `Citing paper ${index + 1}`,
+        label: paperLabel(byUri.get(citation.citingUri), `Citing paper ${String(index + 1)}`),
         type: 'citing',
         isInfluential: citation.isInfluential,
         uri: citation.citingUri,
@@ -218,7 +259,7 @@ function layoutCitationNodes(
       type: 'citation',
       position: { x: horizontalSpacing, y },
       data: {
-        label: `Reference ${index + 1}`,
+        label: paperLabel(byUri.get(citation.citedUri), `Reference ${String(index + 1)}`),
         type: 'reference',
         isInfluential: citation.isInfluential,
         uri: citation.citedUri,
@@ -301,7 +342,12 @@ export function CitationVisualization({
   const { initialNodes, initialEdges } = useMemo(() => {
     if (!data) return { initialNodes: [], initialEdges: [] };
 
-    const { nodes, edges } = layoutCitationNodes(data.eprint, data.citations, data.counts);
+    const { nodes, edges } = layoutCitationNodes(
+      data.eprint,
+      data.citations,
+      data.counts,
+      data.papers
+    );
 
     return { initialNodes: nodes, initialEdges: edges };
   }, [data]);

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Makes the citation network readable. 0.18.0 gave production its first citation edges — 197 of them across 67 eprint nodes, where there had been none — but `pub.chive.discovery.getCitations` returned only URIs, so every node rendered as "Citing paper 1", "Citing paper 2". A network that is technically correct and tells a reader nothing.

The API now returns the papers at both ends of the edges it reports, named the way a paper is cited: first author, year, title, and venue when known.

Design notes:

- **A `papers` lookup, not metadata per edge.** One paper commonly sits at the end of many edges; repeating its author list on each would send the same names back a dozen times in one response.
- **One query per page, deduplicated** — a lookup per edge would cost dozens of round trips to draw a single tab. A test asserts this.
- **Surname and year** on the node ("White 2018 — Neural Models of Factuality"); a node is narrow and that is how the citation is spoken.
- **`eprintRef` extended** rather than a parallel shape, so the centre node and the edge nodes describe a paper the same way.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

CI green. Backend 4,859 unit tests, frontend 2,808, real `next build` clean.

8 new tests: 4 on the service (naming by author/year/title, single-query dedup, empty-set short-circuit, dropping author entries with no name) and 4 on the labeller (citation form, fallback when the API names nothing, title-only, long-title truncation).

Verified against production data: the paper this was reported on returns `citedByCount: 13` with 13 real matched papers behind it.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

### Breaking Changes

- [x] N/A — no breaking changes