### PR TITLE
Release 0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2] - 2026-09-05
+
 ### Fixed
 
 - **A paper shared from Chive carried the generic Chive card.** The share dialog uploads the OpenGraph image as a post thumbnail rather than letting Bluesky refetch the page, and the url it fetched was hardcoded to `?type=default` — so the same link pasted straight into Bluesky showed the paper's own card while sharing it from the paper's page did not. Both now build the url through one helper, which is also what stops them drifting apart again.
@@ -1213,7 +1215,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.20.1...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.20.2...HEAD
+[0.20.2]: https://github.com/chive-pub/chive/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/chive-pub/chive/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/chive-pub/chive/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/chive-pub/chive/compare/v0.18.3...v0.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A paper shared from Chive carried the generic Chive card.** The share dialog uploads the OpenGraph image as a post thumbnail rather than letting Bluesky refetch the page, and the url it fetched was hardcoded to `?type=default` — so the same link pasted straight into Bluesky showed the paper's own card while sharing it from the paper's page did not. Both now build the url through one helper, which is also what stops them drifting apart again.
+
 - **A record referencing several papers backlinked only one of them.** `backlinks` was unique on `source_uri` alone, while the plugin that writes them emits one row per referenced eprint — so each write overwrote the last and every paper but the final one silently lost its backlink. A Cosmik connection names two eprints by definition and showed on only one; an essay citing three showed on one. The identity of a backlink is the pair, and it is now keyed that way.
 
 ## [0.20.1] - 2026-09-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A record referencing several papers backlinked only one of them.** `backlinks` was unique on `source_uri` alone, while the plugin that writes them emits one row per referenced eprint — so each write overwrote the last and every paper but the final one silently lost its backlink. A Cosmik connection names two eprints by definition and showed on only one; an essay citing three showed on one. The identity of a backlink is the pair, and it is now keyed that way.
+
 ## [0.20.1] - 2026-09-04
 
 ### Fixed

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -490,7 +490,7 @@ export async function seedPostgres(): Promise<void> {
         await client.query(
           `INSERT INTO backlinks (source_uri, source_type, source_did, target_uri, context, indexed_at, is_deleted)
            VALUES ($1, $2, $3, $4, $5, $6, false)
-           ON CONFLICT (source_uri) DO UPDATE SET context = EXCLUDED.context`,
+           ON CONFLICT (source_uri, target_uri) DO UPDATE SET context = EXCLUDED.context`,
           [
             backlink.sourceUri,
             backlink.sourceType,

--- a/src/services/backlink/backlink-service.ts
+++ b/src/services/backlink/backlink-service.ts
@@ -146,7 +146,7 @@ export class BacklinkService implements IBacklinkService {
       ) VALUES (
         $1, $2, $3, $4, $5, NOW(), false
       )
-      ON CONFLICT (source_uri) DO UPDATE SET
+      ON CONFLICT (source_uri, target_uri) DO UPDATE SET
         source_type = EXCLUDED.source_type,
         target_uri = EXCLUDED.target_uri,
         context = EXCLUDED.context,
@@ -383,7 +383,7 @@ export class BacklinkService implements IBacklinkService {
         source_uri, source_type, source_did, target_uri, context,
         indexed_at, is_deleted
       ) VALUES ${valuePlaceholders.join(', ')}
-      ON CONFLICT (source_uri) DO UPDATE SET
+      ON CONFLICT (source_uri, target_uri) DO UPDATE SET
         source_type = EXCLUDED.source_type,
         target_uri = EXCLUDED.target_uri,
         context = EXCLUDED.context,

--- a/src/storage/postgresql/migrations/1743000000000_backlink-unique-per-target.ts
+++ b/src/storage/postgresql/migrations/1743000000000_backlink-unique-per-target.ts
@@ -1,0 +1,56 @@
+/**
+ * Migration to key a backlink on its source *and* its target.
+ *
+ * @remarks
+ * `uq_backlinks_source_uri` made one source record able to record exactly one
+ * backlink. But a source can legitimately reference several eprints — a Cosmik
+ * connection names two by definition, and a Leaflet essay may cite a handful —
+ * and `BacklinkTrackingPlugin` writes one row per reference. Each write hit the
+ * same conflict target and overwrote the previous one, so only the last
+ * reference survived and every earlier paper silently lost its backlink.
+ *
+ * The identity of a backlink is the pair. Keying on it lets one record point at
+ * as many papers as it names, and keeps the upsert idempotent per pair.
+ *
+ * Existing rows are unaffected: they are already unique on `source_uri`, which
+ * makes them unique on the pair.
+ *
+ * @packageDocumentation
+ */
+
+import type { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+/**
+ * Apply migration: re-key the backlink uniqueness on (source_uri, target_uri).
+ *
+ * @param pgm - PostgreSQL migration builder
+ */
+export function up(pgm: MigrationBuilder): void {
+  pgm.dropConstraint('backlinks', 'uq_backlinks_source_uri', { ifExists: true });
+  pgm.addConstraint('backlinks', 'uq_backlinks_source_target', {
+    unique: ['source_uri', 'target_uri'],
+  });
+}
+
+/**
+ * Rollback migration.
+ *
+ * @param pgm - PostgreSQL migration builder
+ *
+ * @remarks
+ * Going back requires the table to hold one row per source again, so any
+ * additional targets a source gained are dropped, keeping the earliest.
+ */
+export function down(pgm: MigrationBuilder): void {
+  pgm.sql(`
+    DELETE FROM backlinks a
+    USING backlinks b
+    WHERE a.source_uri = b.source_uri AND a.id > b.id
+  `);
+  pgm.dropConstraint('backlinks', 'uq_backlinks_source_target', { ifExists: true });
+  pgm.addConstraint('backlinks', 'uq_backlinks_source_uri', {
+    unique: ['source_uri'],
+  });
+}

--- a/tests/unit/services/backlink/backlink-service.test.ts
+++ b/tests/unit/services/backlink/backlink-service.test.ts
@@ -122,6 +122,26 @@ describe('BacklinkService', () => {
       );
     });
 
+    it('keys the upsert on source and target, so one record can cite several papers', async () => {
+      // A Cosmik connection names two eprints by definition, and an essay may
+      // cite several. `BacklinkTrackingPlugin` writes one row per reference, so
+      // a conflict target of `source_uri` alone made each write overwrite the
+      // last and only the final paper kept its backlink.
+      db.query.mockResolvedValueOnce({ rows: [SAMPLE_BACKLINK_ROW] });
+
+      await service.createBacklink({
+        sourceUri: SAMPLE_SOURCE_URI,
+        sourceType: 'cosmik.connection' as BacklinkSourceType,
+        targetUri: SAMPLE_TARGET_URI,
+      });
+
+      const insert = db.query.mock.calls
+        .map((c) => String(c[0]))
+        .find((q) => q.includes('INSERT INTO backlinks'));
+      expect(insert).toBeDefined();
+      expect(insert).toContain('ON CONFLICT (source_uri, target_uri)');
+    });
+
     it('should extract DID from source URI', async () => {
       db.query.mockResolvedValueOnce({ rows: [SAMPLE_BACKLINK_ROW] });
 

--- a/web/app/eprints/[...uri]/eprint-content.tsx
+++ b/web/app/eprints/[...uri]/eprint-content.tsx
@@ -101,6 +101,7 @@ import { createBlueskyPost, type ShareContent } from '@/lib/bluesky';
 import { EprintDocument } from '@/components/documents/eprint-document';
 import { detectDocumentFormat, formatExtension } from '@/lib/documents/document-format';
 import { toast } from 'sonner';
+import { eprintOgImageUrl } from '@/lib/metadata/og-image-url';
 
 /**
  * Map document format to display label for the document tab.
@@ -593,15 +594,26 @@ export function EprintDetailContent({ uri }: EprintDetailContentProps) {
     [agent, eprint, uri, endorsementToShare]
   );
 
-  // Build share content for the dialog
-  // Use default OG image (Chive logo/branding) for all shares
+  // Build share content for the dialog. The card is the paper's own, built by
+  // the same helper the page's metadata uses: a share embeds this image as a
+  // blob rather than letting Bluesky refetch the page, so hardcoding the
+  // default here meant a paper shared from Chive carried generic branding
+  // while the same link pasted into Bluesky carried the paper.
   const shareContent: ShareContent | null = eprint
     ? {
         type: 'eprint',
         url: `${typeof window !== 'undefined' ? window.location.origin : ''}/eprints/${encodeURIComponent(uri)}`,
         title: eprint.title,
         description: (eprint.abstract ?? '').slice(0, 200),
-        ogImageUrl: '/api/og?type=default',
+        ogImageUrl: eprintOgImageUrl({
+          uri,
+          title: eprint.title,
+          authorNames: eprint.authors?.map((a) => a.name),
+          abstract: eprint.abstract ?? undefined,
+          createdAt: eprint.createdAt,
+          keywords: eprint.keywords,
+          publicationStatusSlug: eprint.publicationStatusSlug,
+        }),
       }
     : null;
 

--- a/web/app/eprints/[...uri]/page.tsx
+++ b/web/app/eprints/[...uri]/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/metadata/entity-metadata';
 import { EntityHeadTags } from '@/lib/metadata/EntityHeadTags';
 import { absoluteUrl } from '@/lib/site/url';
+import { eprintOgImageUrl } from '@/lib/metadata/og-image-url';
 
 /**
  * Eprint detail page route parameters.
@@ -58,29 +59,16 @@ export async function generateMetadata({ params }: EprintPageProps): Promise<Met
     // substance, so the abstract, the full author list, the venue and the
     // keywords are all passed. The abstract is capped well short of any URL
     // limit; the card truncates again for its own layout.
-    const venue = value.publishedVersion?.journal ?? '';
-    const year = value.createdAt ? new Date(value.createdAt).getUTCFullYear().toString() : '';
-    const ogImageParams = new URLSearchParams({
-      type: 'eprint',
+    const ogImageUrl = eprintOgImageUrl({
       uri: fullUri,
-      title: value.title.slice(0, 200),
-      author: authorName,
+      title: value.title,
+      authorNames: value.authors.map((a) => a.name),
+      abstract: abstractText,
+      venue: value.publishedVersion?.journal,
+      createdAt: value.createdAt,
+      keywords: value.keywords,
+      publicationStatusSlug: value.publicationStatusSlug,
     });
-    const allAuthors = value.authors
-      .map((a) => a.name)
-      .filter(Boolean)
-      .join('|');
-    if (allAuthors) ogImageParams.set('authors', allAuthors.slice(0, 400));
-    if (abstractText) ogImageParams.set('abstract', abstractText.slice(0, 400));
-    if (venue) ogImageParams.set('venue', venue.slice(0, 120));
-    if (year) ogImageParams.set('year', year);
-    if (value.keywords && value.keywords.length > 0) {
-      ogImageParams.set('fields', value.keywords.slice(0, 3).join(','));
-    }
-    if (value.publicationStatusSlug) {
-      ogImageParams.set('status', value.publicationStatusSlug);
-    }
-    const ogImageUrl = `/api/og?${ogImageParams.toString()}`;
 
     return {
       title: value.title,

--- a/web/lib/metadata/og-image-url.ts
+++ b/web/lib/metadata/og-image-url.ts
@@ -1,0 +1,68 @@
+/**
+ * Building the OpenGraph card URL for an eprint.
+ *
+ * @remarks
+ * The card renders from query parameters rather than fetching the eprint, so
+ * whoever builds the URL decides what the card can show. Two callers need it —
+ * the page's metadata, which is what a crawler reads, and the share dialog,
+ * which uploads the image as a post thumbnail because Bluesky embeds a blob
+ * rather than refetching the page.
+ *
+ * They were not the same URL. The share hardcoded `?type=default`, so a paper
+ * shared from Chive carried the generic Chive card while the identical link
+ * pasted into Bluesky carried the paper's own. One builder, so they cannot
+ * drift again.
+ *
+ * @packageDocumentation
+ */
+
+/** The parts of an eprint the card can draw. */
+export interface EprintOgInput {
+  uri: string;
+  title: string;
+  /** Author display names, in order. */
+  authorNames?: readonly (string | undefined)[];
+  /** Plain-text abstract. */
+  abstract?: string;
+  /** Journal or venue, when published. */
+  venue?: string;
+  /** ISO date the record carries; the year is taken from it. */
+  createdAt?: string;
+  keywords?: readonly string[];
+  publicationStatusSlug?: string;
+}
+
+/**
+ * Builds the `/api/og` URL for an eprint card.
+ *
+ * @param eprint - The eprint's displayable parts
+ * @returns A site-relative URL
+ *
+ * @public
+ */
+export function eprintOgImageUrl(eprint: EprintOgInput): string {
+  const names = (eprint.authorNames ?? []).filter((n): n is string => Boolean(n));
+  const params = new URLSearchParams({
+    type: 'eprint',
+    uri: eprint.uri,
+    title: eprint.title.slice(0, 200),
+    author: names[0] ?? 'Unknown Author',
+  });
+
+  const allAuthors = names.join('|');
+  if (allAuthors) params.set('authors', allAuthors.slice(0, 400));
+  if (eprint.abstract) params.set('abstract', eprint.abstract.slice(0, 400));
+  if (eprint.venue) params.set('venue', eprint.venue.slice(0, 120));
+
+  const year = eprint.createdAt ? new Date(eprint.createdAt).getUTCFullYear() : NaN;
+  if (!Number.isNaN(year)) params.set('year', String(year));
+
+  if (eprint.keywords && eprint.keywords.length > 0) {
+    params.set('fields', eprint.keywords.slice(0, 3).join(','));
+  }
+  if (eprint.publicationStatusSlug) {
+    params.set('status', eprint.publicationStatusSlug);
+  }
+
+  return `/api/og?${params.toString()}`;
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch release.

**Fixed**
- A record referencing several papers backlinked only one of them. `backlinks` was unique on `source_uri` alone while the plugin writes one row per referenced eprint, so each write overwrote the last: a Cosmik connection names two papers by definition and showed on one, an essay citing three showed on one. Keyed on the pair now, with a migration.
- A paper shared from Chive carried the generic Chive card. The share dialog uploads the OpenGraph image as a post thumbnail rather than letting Bluesky refetch the page, and that url was hardcoded to `?type=default`. Both callers build it through one helper now.