### PR TITLE
Release 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-09-05
+
+### Added
+
+- **An Atmosphere tab, holding everything the network has said about a paper.** References from elsewhere on the network used to sit at the bottom of the Citations tab, under a heading called "Backlinks", as a stack of collapsed accordions that fetched nothing until a reader thought to open one. The section names came from the counts endpoint, which buckets five ways — so a talk, a standard.site document, a Margin annotation and a Cosmik connection all hid behind a heading reading "Other Sources" that named none of them. They now have a tab of their own, loaded at once, filtered by the application that published each record, and the tab says how many there are before it is opened. Where a paper has none, it says so rather than leaving a blank tab, because an empty panel cannot be told from one that failed to load.
+
+### Changed
+
+- **Every link on an eprint page renders through one card.** Code, data, materials, external identifiers, linked resources and atmosphere references each had their own layout: a tinted icon and a platform badge on one tab, a flat row with a monospaced value on another, a small grey icon and a line of context on a third. None of the differences carried meaning — a reader learns nothing from a DOI being styled unlike a repository — and the richest of them, the GitHub card, was the one a reader saw least often. That card is now the shape all of them take, and each fills it with whatever detail its own source can give.
+
+  The detail itself is the point. A card headed "GitHub" now reads `chive-pub/chive` beneath it, and one headed "arXiv" leads with the identifier: the address was in the record all along and simply was not shown. Zenodo reports its deposit type, access, version, views and downloads; Software Heritage says what is archived and when it was last seen; an atmosphere reference says which application published it, what kind of record it is, when it appeared, and what it said.
+
+### Fixed
+
+- **Two link destinations on the atmosphere panel were wrong, and most were missing.** A `network.cosmik.card` was linked to `cosmik.network/collection/{did}/{rkey}`, which 404s — a card is not a collection. Every Leaflet reference was linked as a document, comments included, because the plugin that indexes them files both under one source type. And for a talk, a standard.site document or a Margin annotation, no link was offered at all.
+
+  Links are now built from the collection NSID carried in the record's own URI, which cannot disagree with the record, rather than from Chive's coarser classification. An application's own address is offered only where the route was checked against a live record — Smoke Signal and Bluesky, verified; Cosmik's dropped rather than shipped wrong. Alongside it every reference now carries a link to the record itself in a public record browser, which resolves any AT-URI by reading it from the repository that holds it. That one works for every source type, including the ones no application on the network renders yet.
+
+- **A repository the author named but gave no address for vanished, while the tab still counted it.** A Code tab reading "2" above one card reads as a fault in Chive rather than as an incomplete record. The card renders and says the record carries no address.
+
+- **The supplementary materials count ignored the datasets it was displaying.** It counted uploaded files only, so a paper whose auxiliary material is a dataset linked on Layers showed a badge reading "0" above the card for it.
+
 ## [0.20.2] - 2026-09-05
 
 ### Fixed
@@ -1215,7 +1237,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.20.2...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/chive-pub/chive/compare/v0.20.2...v0.21.0
 [0.20.2]: https://github.com/chive-pub/chive/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/chive-pub/chive/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/chive-pub/chive/compare/v0.19.0...v0.20.0

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/web/app/eprints/[...uri]/eprint-content.tsx
+++ b/web/app/eprints/[...uri]/eprint-content.tsx
@@ -60,6 +60,7 @@ import { IntegrationPanel } from '@/components/integrations';
 import { RelatedPapersPanel, CitationSummary, CitationListPanel } from '@/components/discovery';
 import { isRichTextItem } from '@/lib/types/rich-text';
 import { BacklinksPanel } from '@/components/backlinks';
+import { useBacklinkCounts } from '@/lib/hooks/use-backlinks';
 import { EnrichmentPanel } from '@/components/enrichment';
 import { Pencil, Trash2 } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -219,6 +220,11 @@ export function EprintDetailContent({ uri }: EprintDetailContentProps) {
   const createReview = useCreateReview();
   const updateReview = useUpdateReview();
   const deleteReview = useDeleteReview();
+
+  // How many records elsewhere on the network refer to this paper. Read here
+  // only for the tab's count; the panel fetches the references themselves.
+  const { data: backlinkCounts } = useBacklinkCounts(uri);
+  const backlinkTotal = backlinkCounts?.total ?? 0;
 
   // Annotation hooks (separate from reviews -- annotations have text span targets)
   const { data: annotationsData } = useAnnotations(uri);
@@ -859,6 +865,19 @@ export function EprintDetailContent({ uri }: EprintDetailContentProps) {
           <TabsTrigger value="related">Related</TabsTrigger>
           <TabsTrigger value="network">Network</TabsTrigger>
           <TabsTrigger value="citations">Citations</TabsTrigger>
+          {/* Everything the wider network has said about this paper, gathered
+              in one place. It used to sit at the bottom of the citations tab,
+              under a heading that named none of the applications it covered,
+              which is where a reader looking for it would never think to
+              look. */}
+          <TabsTrigger value="atmosphere" className="gap-1.5">
+            Atmosphere
+            {backlinkTotal > 0 && (
+              <span className="ml-1 rounded-full bg-muted px-1.5 py-0.5 text-xs">
+                {backlinkTotal}
+              </span>
+            )}
+          </TabsTrigger>
           <TabsTrigger value="metadata">Metadata</TabsTrigger>
           {eprint.versions && eprint.versions.length > 1 && (
             <TabsTrigger value="versions">Versions</TabsTrigger>
@@ -1422,7 +1441,11 @@ export function EprintDetailContent({ uri }: EprintDetailContentProps) {
         {/* Citations tab */}
         <TabsContent value="citations" className="space-y-6">
           <CitationListPanel eprintUri={uri} editable={isAuthenticated} />
-          <BacklinksPanel eprintUri={uri} />
+        </TabsContent>
+
+        {/* Atmosphere tab */}
+        <TabsContent value="atmosphere" className="space-y-6">
+          <BacklinksPanel eprintUri={uri} showEmpty />
         </TabsContent>
 
         {/* Metadata tab */}

--- a/web/components/backlinks/__tests__/backlink-item.test.tsx
+++ b/web/components/backlinks/__tests__/backlink-item.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Tests for one atmosphere reference.
+ *
+ * @remarks
+ * Two behaviours here were previously wrong on production, so they are the
+ * ones pinned hardest: a Leaflet comment must not be presented as a Leaflet
+ * document merely because the indexing plugin files both under the same source
+ * type, and a Cosmik card must not be linked to a Cosmik collection address
+ * that does not resolve.
+ *
+ * @packageDocumentation
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BacklinkItem } from '../backlink-item';
+import type { Backlink } from '@/lib/hooks/use-backlinks';
+
+const DID = 'did:plc:34mbm5v3umztwvvgnttvcz6e';
+const TARGET = 'at://did:plc:owner/pub.chive.eprint.submission/paper';
+
+function backlink(overrides: Partial<Backlink> & Pick<Backlink, 'sourceUri' | 'sourceType'>) {
+  return {
+    id: 1,
+    targetUri: TARGET,
+    indexedAt: '2026-09-04T12:00:00Z',
+    deleted: false,
+    ...overrides,
+  } as Backlink;
+}
+
+describe('BacklinkItem', () => {
+  it('leads with what the source record called itself', () => {
+    render(
+      <BacklinkItem
+        backlink={backlink({
+          sourceUri: `at://${DID}/pub.leaflet.document/3abc`,
+          sourceType: 'leaflet.document',
+          context: 'Probe essay',
+        })}
+      />
+    );
+    expect(screen.getByText('Probe essay')).toBeInTheDocument();
+    expect(screen.getByText('Leaflet')).toBeInTheDocument();
+    expect(screen.getByText('Document')).toBeInTheDocument();
+  });
+
+  it('tells a Leaflet comment from a Leaflet document, which the source type does not', () => {
+    // The plugin assigns `leaflet.document` to both. Only the collection in the
+    // URI distinguishes them, and a comment has no leaflet.pub address.
+    render(
+      <BacklinkItem
+        backlink={backlink({
+          sourceUri: `at://${DID}/pub.leaflet.comment/3abc`,
+          sourceType: 'leaflet.document',
+          context: 'Probe comment',
+        })}
+      />
+    );
+    expect(screen.getByText('Comment')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /open in leaflet/i })).toBeNull();
+  });
+
+  it('offers no Cosmik address for a Cosmik card', () => {
+    render(
+      <BacklinkItem
+        backlink={backlink({
+          sourceUri: `at://${DID}/network.cosmik.card/3abc`,
+          sourceType: 'cosmik.collection',
+        })}
+      />
+    );
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute(
+      'href',
+      `https://pdsls.dev/at://${DID}/network.cosmik.card/3abc`
+    );
+  });
+
+  it('offers the Smoke Signal page for a calendar event, alongside the record', () => {
+    render(
+      <BacklinkItem
+        backlink={backlink({
+          sourceUri: `at://${DID}/community.lexicon.calendar.event/3xyz`,
+          sourceType: 'calendar.event',
+          context: 'Probe talk',
+        })}
+      />
+    );
+    expect(screen.getByRole('link', { name: /open in smoke signal/i })).toHaveAttribute(
+      'href',
+      `https://smokesignal.events/${DID}/3xyz`
+    );
+    expect(screen.getByRole('link', { name: /view record/i })).toBeInTheDocument();
+  });
+
+  it('names itself when the source record carried no context', () => {
+    render(
+      <BacklinkItem
+        backlink={backlink({
+          sourceUri: `at://${DID}/at.margin.note/3abc`,
+          sourceType: 'margin.annotation',
+        })}
+      />
+    );
+    expect(screen.getByText('Margin note')).toBeInTheDocument();
+  });
+
+  it('shows the record URI, so a reader can find it without a web address', () => {
+    const uri = `at://${DID}/site.standard.document/3abc`;
+    render(
+      <BacklinkItem backlink={backlink({ sourceUri: uri, sourceType: 'standard.document' })} />
+    );
+    expect(screen.getByText(uri)).toBeInTheDocument();
+  });
+
+  it('says when the reference appeared', () => {
+    render(
+      <BacklinkItem
+        backlink={backlink({
+          sourceUri: `at://${DID}/pub.leaflet.document/3abc`,
+          sourceType: 'leaflet.document',
+          indexedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        })}
+      />
+    );
+    expect(screen.getByText(/about 1 hour ago/i)).toBeInTheDocument();
+  });
+
+  it('renders a record from an application it has never heard of', () => {
+    const item = screen.queryByTestId('backlink-item');
+    expect(item).toBeNull();
+    render(
+      <BacklinkItem
+        backlink={backlink({
+          sourceUri: `at://${DID}/com.example.newthing/3abc`,
+          sourceType: 'other',
+        })}
+      />
+    );
+    const card = screen.getByTestId('backlink-item');
+    expect(within(card).getByText('com.example.newthing')).toBeInTheDocument();
+    expect(within(card).getByRole('link', { name: /view record/i })).toBeInTheDocument();
+  });
+});

--- a/web/components/backlinks/__tests__/backlinks-panel.test.tsx
+++ b/web/components/backlinks/__tests__/backlinks-panel.test.tsx
@@ -1,3 +1,17 @@
+/**
+ * Tests for the atmosphere panel.
+ *
+ * @remarks
+ * The panel replaced a stack of collapsed accordions whose section headings
+ * came from a counts endpoint that buckets five ways -- so talks, standard.site
+ * documents and Margin annotations all sat behind one heading called "Other
+ * Sources". The behaviours pinned here are the ones that fixes: the references
+ * are visible without a click, and the filters name the applications that
+ * actually published them.
+ *
+ * @packageDocumentation
+ */
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -6,7 +20,6 @@ import type { ReactNode } from 'react';
 
 import { BacklinksPanel, BacklinksPanelSkeleton } from '../backlinks-panel';
 
-// Mock functions must be hoisted along with vi.mock
 const { mockList, mockGetCounts } = vi.hoisted(() => ({
   mockList: vi.fn(),
   mockGetCounts: vi.fn(),
@@ -14,75 +27,63 @@ const { mockList, mockGetCounts } = vi.hoisted(() => ({
 
 vi.mock('@/lib/api/client', () => ({
   api: {
-    pub: {
-      chive: {
-        backlink: {
-          list: mockList,
-          getCounts: mockGetCounts,
-        },
-      },
-    },
+    pub: { chive: { backlink: { list: mockList, getCounts: mockGetCounts } } },
   },
 }));
 
-// Test wrapper with QueryClient
 function createWrapper() {
   const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        gcTime: 0,
-      },
-    },
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
   return function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
 }
 
-const mockCounts = {
-  cosmikCollections: 2,
-  blueskyPosts: 3,
-  blueskyEmbeds: 0,
-  leafletLists: 1,
-  other: 0,
-  total: 6,
-};
+const DID = 'did:plc:34mbm5v3umztwvvgnttvcz6e';
+const EPRINT = 'at://did:plc:user1/pub.chive.eprint.submission/paper1';
 
-const _mockBacklinks = [
-  {
-    id: 1,
-    sourceUri: 'at://did:plc:abc123/cosmik.collection/xyz',
-    sourceType: 'cosmik.collection' as const,
-    targetUri: 'at://did:plc:user1/pub.chive.eprint/paper1',
-    context: 'Added to ML Papers collection',
-    indexedAt: '2024-01-15T10:30:00Z',
+function row(id: number, collection: string, sourceType: string, context?: string) {
+  return {
+    id,
+    sourceUri: `at://${DID}/${collection}/rk${id}`,
+    sourceType,
+    targetUri: EPRINT,
+    ...(context ? { context } : {}),
+    indexedAt: '2026-09-04T12:00:00Z',
     deleted: false,
-  },
-  {
-    id: 2,
-    sourceUri: 'at://did:plc:def456/cosmik.collection/abc',
-    sourceType: 'cosmik.collection' as const,
-    targetUri: 'at://did:plc:user1/pub.chive.eprint/paper1',
-    context: 'Added to NLP collection',
-    indexedAt: '2024-01-16T14:00:00Z',
-    deleted: false,
-  },
+  };
+}
+
+const BACKLINKS = [
+  row(1, 'pub.leaflet.document', 'leaflet.document', 'Probe essay'),
+  row(2, 'pub.leaflet.comment', 'leaflet.document', 'Probe comment'),
+  row(3, 'community.lexicon.calendar.event', 'calendar.event', 'Probe talk'),
+  row(4, 'at.margin.note', 'margin.annotation', 'Probe annotation'),
 ];
 
-describe('BacklinksPanelSkeleton', () => {
-  it('should render skeleton loader', () => {
-    render(<BacklinksPanelSkeleton />);
+function counts(total: number) {
+  return {
+    data: {
+      cosmikCollections: 0,
+      blueskyPosts: 0,
+      blueskyEmbeds: 0,
+      leafletLists: 0,
+      other: total,
+      total,
+    },
+  };
+}
 
+describe('BacklinksPanelSkeleton', () => {
+  it('renders a placeholder', () => {
+    render(<BacklinksPanelSkeleton />);
     expect(screen.getByText('Backlinks')).toBeInTheDocument();
-    // Should have skeleton elements
-    const skeletons = document.querySelectorAll('[class*="animate-pulse"]');
-    expect(skeletons.length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('[class*="animate-pulse"]').length).toBeGreaterThan(0);
   });
 
-  it('should apply custom className', () => {
+  it('applies a custom class', () => {
     const { container } = render(<BacklinksPanelSkeleton className="custom-class" />);
-
     expect(container.querySelector('.custom-class')).toBeInTheDocument();
   });
 });
@@ -94,103 +95,97 @@ describe('BacklinksPanel', () => {
     mockGetCounts.mockReset();
   });
 
-  it('should render loading state initially', () => {
-    mockGetCounts.mockImplementation(() => new Promise(() => {})); // Never resolves
+  it('renders every reference without waiting for a click', async () => {
+    mockGetCounts.mockResolvedValue(counts(4));
+    mockList.mockResolvedValue({ data: { backlinks: BACKLINKS, hasMore: false } });
 
-    render(<BacklinksPanel eprintUri="at://did:plc:user1/pub.chive.eprint/paper1" />, {
+    render(<BacklinksPanel eprintUri={EPRINT} />, { wrapper: createWrapper() });
+
+    // Previously each of these sat behind its own collapsed section, and three
+    // of the four behind one headed "Other Sources".
+    expect(await screen.findByText('Probe essay')).toBeInTheDocument();
+    expect(screen.getByText('Probe comment')).toBeInTheDocument();
+    expect(screen.getByText('Probe talk')).toBeInTheDocument();
+    expect(screen.getByText('Probe annotation')).toBeInTheDocument();
+    expect(screen.getByTestId('backlinks-count')).toHaveTextContent('4');
+  });
+
+  it('filters by the application that published the record', async () => {
+    const user = userEvent.setup();
+    mockGetCounts.mockResolvedValue(counts(4));
+    mockList.mockResolvedValue({ data: { backlinks: BACKLINKS, hasMore: false } });
+
+    render(<BacklinksPanel eprintUri={EPRINT} />, { wrapper: createWrapper() });
+    await screen.findByText('Probe essay');
+
+    // Both Leaflet records group under one chip even though one of them is a
+    // comment, because the reader is choosing an application, not a record type.
+    await user.click(screen.getByRole('button', { name: 'Leaflet 2' }));
+
+    expect(screen.getByText('Probe essay')).toBeInTheDocument();
+    expect(screen.getByText('Probe comment')).toBeInTheDocument();
+    expect(screen.queryByText('Probe talk')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'All 4' }));
+    expect(screen.getByText('Probe talk')).toBeInTheDocument();
+  });
+
+  it('offers no filters when everything came from one application', async () => {
+    mockGetCounts.mockResolvedValue(counts(1));
+    mockList.mockResolvedValue({ data: { backlinks: [BACKLINKS[0]], hasMore: false } });
+
+    render(<BacklinksPanel eprintUri={EPRINT} />, { wrapper: createWrapper() });
+    await screen.findByText('Probe essay');
+
+    expect(screen.queryByRole('group', { name: /filter by application/i })).toBeNull();
+  });
+
+  it('renders nothing when there are no references and it was not asked to speak up', async () => {
+    mockGetCounts.mockResolvedValue(counts(0));
+    mockList.mockResolvedValue({ data: { backlinks: [], hasMore: false } });
+
+    const { container } = render(<BacklinksPanel eprintUri={EPRINT} />, {
       wrapper: createWrapper(),
     });
 
-    expect(screen.getByText('Backlinks')).toBeInTheDocument();
-  });
-
-  it('should render nothing when no backlinks', async () => {
-    mockGetCounts.mockResolvedValueOnce({
-      data: {
-        cosmikCollections: 0,
-        blueskyPosts: 0,
-        blueskyEmbeds: 0,
-        leafletLists: 0,
-        other: 0,
-        total: 0,
-      },
-    });
-
-    const { container } = render(
-      <BacklinksPanel eprintUri="at://did:plc:user1/pub.chive.eprint/paper1" />,
-      { wrapper: createWrapper() }
-    );
-
-    // Wait for the query to complete
     await vi.waitFor(() => {
       expect(mockGetCounts).toHaveBeenCalled();
     });
-
-    // Should render nothing when total is 0
     await vi.waitFor(() => {
-      expect(container.querySelector('[class*="card"]')).not.toBeInTheDocument();
+      expect(container).toBeEmptyDOMElement();
     });
   });
 
-  it('should render backlinks panel with counts', async () => {
-    mockGetCounts.mockResolvedValueOnce({
-      data: mockCounts,
-    });
+  it('says so when there are no references and it has a tab to itself', async () => {
+    mockGetCounts.mockResolvedValue(counts(0));
+    mockList.mockResolvedValue({ data: { backlinks: [], hasMore: false } });
 
-    render(<BacklinksPanel eprintUri="at://did:plc:user1/pub.chive.eprint/paper1" />, {
-      wrapper: createWrapper(),
-    });
+    render(<BacklinksPanel eprintUri={EPRINT} showEmpty />, { wrapper: createWrapper() });
 
-    await vi.waitFor(() => {
-      expect(screen.getByText('6')).toBeInTheDocument(); // Total count badge
-    });
-
-    // Should show source type sections
-    expect(screen.getByText('Cosmik Collections')).toBeInTheDocument();
-    expect(screen.getByText('Bluesky Posts')).toBeInTheDocument();
-    expect(screen.getByText('Leaflet Documents')).toBeInTheDocument();
+    // A blank tab cannot be told from one that failed to load.
+    expect(
+      await screen.findByText(/nothing on the network refers to this paper yet/i)
+    ).toBeInTheDocument();
   });
 
-  it('should expand section and load backlinks on click', async () => {
+  it('loads the next page on request', async () => {
     const user = userEvent.setup();
+    mockGetCounts.mockResolvedValue(counts(5));
+    mockList
+      .mockResolvedValueOnce({ data: { backlinks: BACKLINKS, cursor: 'c1', hasMore: true } })
+      .mockResolvedValueOnce({
+        data: {
+          backlinks: [row(5, 'network.cosmik.card', 'cosmik.collection', 'Probe card')],
+          hasMore: false,
+        },
+      });
 
-    // First call returns counts
-    mockGetCounts.mockResolvedValueOnce({
-      data: mockCounts,
-    });
+    render(<BacklinksPanel eprintUri={EPRINT} />, { wrapper: createWrapper() });
+    await screen.findByText('Probe essay');
 
-    render(<BacklinksPanel eprintUri="at://did:plc:user1/pub.chive.eprint/paper1" />, {
-      wrapper: createWrapper(),
-    });
+    await user.click(screen.getByRole('button', { name: /load more/i }));
 
-    await vi.waitFor(() => {
-      expect(screen.getByText('Cosmik Collections')).toBeInTheDocument();
-    });
-
-    // First section is expanded by default, let's check for Bluesky which is not
-    // Click to expand Bluesky Posts section
-    mockList.mockResolvedValueOnce({
-      data: {
-        backlinks: [
-          {
-            id: 3,
-            sourceUri: 'at://did:plc:xyz/app.bsky.feed.post/123',
-            sourceType: 'bluesky.post',
-            targetUri: 'at://did:plc:user1/pub.chive.eprint/paper1',
-            context: 'Great paper!',
-            indexedAt: '2024-01-17T09:00:00Z',
-            deleted: false,
-          },
-        ],
-        hasMore: false,
-      },
-    });
-
-    const blueskyButton = screen.getByText('Bluesky Posts');
-    await user.click(blueskyButton);
-
-    await vi.waitFor(() => {
-      expect(screen.getByText('Great paper!')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Probe card')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cosmik 1' })).toBeInTheDocument();
   });
 });

--- a/web/components/backlinks/backlink-item.tsx
+++ b/web/components/backlinks/backlink-item.tsx
@@ -1,85 +1,136 @@
 'use client';
 
+/**
+ * One reference to a paper from elsewhere in the atmosphere.
+ *
+ * @remarks
+ * These used to render as a grey icon, a two-word label and a line of context,
+ * which said almost nothing and, for most source types, offered no way through
+ * to the thing being described. Two of the links that were offered were wrong:
+ * a `network.cosmik.card` was linked as though it were a Cosmik collection, and
+ * every Leaflet reference was linked as a document, including the comments.
+ *
+ * The card now says which application published the record, what kind of record
+ * it is, when it appeared, and what it said, and it offers the record itself
+ * through a public record browser -- which works for every source type,
+ * including the ones no application renders on the web yet.
+ *
+ * @packageDocumentation
+ */
+
 import {
   BookMarked,
   MessageCircle,
   FileText,
   CalendarDays,
   Highlighter,
-  Users,
   Link2,
+  Clock,
+  Layers as LayersIcon,
+  GitBranch,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 
+import {
+  ResourceCard,
+  type ResourceAction,
+  type ResourceStat,
+} from '@/components/links/resource-card';
+import { describeAtUri } from '@/lib/atproto/at-uri-links';
 import type { Backlink, BacklinkSourceType } from '@/lib/hooks/use-backlinks';
 
-/**
- * Gets the appropriate icon for a backlink source type.
- */
-function getSourceIcon(sourceType: BacklinkSourceType) {
-  switch (sourceType) {
-    case 'cosmik.collection':
-      return BookMarked;
-    case 'cosmik.connection':
-    case 'cosmik.follow':
-      return Users;
-    case 'leaflet.document':
-    case 'standard.document':
-      return FileText;
-    case 'leaflet.comment':
-      return MessageCircle;
-    case 'calendar.event':
-      return CalendarDays;
-    case 'margin.annotation':
-    case 'margin.highlight':
-    case 'margin.bookmark':
-      return Highlighter;
-    case 'bluesky.post':
-    case 'bluesky.embed':
-      return MessageCircle;
-    case 'other':
-    default:
-      return Link2;
-  }
+/** How a publishing application is drawn. */
+interface AppStyle {
+  icon: React.ComponentType<{ className?: string }>;
+  color: string;
+  bgColor: string;
 }
 
 /**
- * Builds a URL for viewing the source of a backlink.
+ * Icon and colour per application.
+ *
+ * @remarks
+ * Keyed on the application name that {@link describeAtUri} derives from the
+ * record's own collection NSID, so a Leaflet comment and a Leaflet document
+ * agree, and an application Chive has not heard of falls through to the
+ * generic link mark rather than borrowing another service's colour.
  */
-function buildSourceUrl(backlink: Backlink): string | null {
-  const { sourceUri, sourceType } = backlink;
+const APP_STYLES: Record<string, AppStyle> = {
+  Leaflet: { icon: FileText, color: 'text-orange-600', bgColor: 'bg-orange-50 dark:bg-orange-950' },
+  Cosmik: {
+    icon: BookMarked,
+    color: 'text-violet-600',
+    bgColor: 'bg-violet-50 dark:bg-violet-950',
+  },
+  Margin: {
+    icon: Highlighter,
+    color: 'text-yellow-600',
+    bgColor: 'bg-yellow-50 dark:bg-yellow-950',
+  },
+  'Smoke Signal': {
+    icon: CalendarDays,
+    color: 'text-rose-600',
+    bgColor: 'bg-rose-50 dark:bg-rose-950',
+  },
+  'standard.site': {
+    icon: FileText,
+    color: 'text-emerald-600',
+    bgColor: 'bg-emerald-50 dark:bg-emerald-950',
+  },
+  Bluesky: { icon: MessageCircle, color: 'text-sky-600', bgColor: 'bg-sky-50 dark:bg-sky-950' },
+  Layers: {
+    icon: LayersIcon,
+    color: 'text-indigo-600',
+    bgColor: 'bg-indigo-50 dark:bg-indigo-950',
+  },
+  Tangled: {
+    icon: GitBranch,
+    color: 'text-purple-600',
+    bgColor: 'bg-purple-50 dark:bg-purple-950',
+  },
+};
 
-  // Parse the AT URI: at://did:plc:xyz/collection/rkey
-  const match = /^at:\/\/([^/]+)\/([^/]+)\/(.+)$/.exec(sourceUri);
-  if (!match) return null;
+const FALLBACK_STYLE: AppStyle = {
+  icon: Link2,
+  color: 'text-muted-foreground',
+  bgColor: 'bg-muted',
+};
 
-  const [, did, , rkey] = match;
-
-  switch (sourceType) {
-    case 'cosmik.collection':
-      // Cosmik collections at cosmik.network/collection/{did}/{rkey}
-      return `https://cosmik.network/collection/${did}/${rkey}`;
-    case 'leaflet.document':
-    case 'leaflet.comment':
-      // Leaflet documents at leaflet.pub/{did}/{rkey}
-      return `https://leaflet.pub/${did}/${rkey}`;
-    case 'bluesky.post':
-    case 'bluesky.embed':
-      // Bluesky posts at bsky.app/profile/{did}/post/{rkey}
-      return `https://bsky.app/profile/${did}/post/${rkey}`;
-    default:
-      // A standard.site document, a calendar event or a Margin annotation has
-      // no single web host: the record is the artefact and each publisher
-      // renders it at its own address. The AT-URI is shown instead of guessing
-      // a link that may not resolve.
-      return null;
-  }
+/**
+ * Icon and colour for a reference.
+ *
+ * @param appName - Application name from the record's collection
+ * @param sourceType - Chive's own classification, used when the collection is unknown
+ * @returns How to draw it
+ */
+function styleFor(appName: string | undefined, sourceType: BacklinkSourceType): AppStyle {
+  if (appName && APP_STYLES[appName]) return APP_STYLES[appName];
+  // A record whose collection Chive does not recognize can still be placed by
+  // the source type the indexing plugin assigned it.
+  const prefix = String(sourceType).split('.')[0];
+  const byPrefix: Record<string, AppStyle> = {
+    cosmik: APP_STYLES.Cosmik,
+    leaflet: APP_STYLES.Leaflet,
+    margin: APP_STYLES.Margin,
+    standard: APP_STYLES['standard.site'],
+    calendar: APP_STYLES['Smoke Signal'],
+    bluesky: APP_STYLES.Bluesky,
+  };
+  return byPrefix[prefix] ?? FALLBACK_STYLE;
 }
 
 /**
- * Gets a short label for the source type.
+ * Gets a human-readable label for a backlink source type.
+ *
+ * @param sourceType - Chive's classification of the source record
+ * @returns A short label
+ *
+ * @remarks
+ * Used only where the record's own collection could not be read from the URI.
+ * The collection is the better answer wherever it is available, because it
+ * distinguishes records the source type conflates.
  */
-function getSourceLabel(sourceType: BacklinkSourceType): string {
+export function getSourceLabel(sourceType: BacklinkSourceType): string {
   switch (sourceType) {
     case 'cosmik.collection':
       return 'Cosmik';
@@ -117,43 +168,52 @@ export interface BacklinkItemProps {
 }
 
 /**
- * Displays a single backlink with source icon, context, and timestamp.
+ * Displays a single reference to this paper from another application.
+ *
+ * @param props - Component props
+ * @returns The card
+ *
+ * @public
  */
 export function BacklinkItem({ backlink, className }: BacklinkItemProps) {
-  const Icon = getSourceIcon(backlink.sourceType);
-  const url = buildSourceUrl(backlink);
-  const label = getSourceLabel(backlink.sourceType);
-  const timeAgo = formatDistanceToNow(new Date(backlink.indexedAt), { addSuffix: true });
+  const record = describeAtUri(backlink.sourceUri);
+  const style = styleFor(record?.appName, backlink.sourceType);
 
-  const content = (
-    <div className={`flex items-start gap-3 py-2 ${className ?? ''}`} data-testid="backlink-item">
-      <Icon className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-medium text-muted-foreground">{label}</span>
-          <span className="text-xs text-muted-foreground" data-testid="backlink-timestamp">
-            {timeAgo}
-          </span>
-        </div>
-        {backlink.context && (
-          <p className="text-sm text-foreground line-clamp-2 mt-0.5">{backlink.context}</p>
-        )}
-      </div>
-    </div>
-  );
+  const appName = record?.appName ?? getSourceLabel(backlink.sourceType);
+  const kind = record?.kind ?? 'Record';
 
-  if (url) {
-    return (
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block hover:bg-muted/50 rounded-md -mx-2 px-2 transition-colors"
-      >
-        {content}
-      </a>
-    );
+  // The context is whatever the source record called itself -- an essay's
+  // title, an event's name, the text of an annotation. Where there is one it
+  // is the most informative thing on the card, so it leads.
+  const title = backlink.context?.trim() || `${appName} ${kind.toLowerCase()}`;
+
+  const indexed = new Date(backlink.indexedAt);
+  const stats: ResourceStat[] = [{ label: kind }];
+  if (!Number.isNaN(indexed.getTime())) {
+    stats.push({
+      icon: Clock,
+      label: formatDistanceToNow(indexed, { addSuffix: true }),
+      title: indexed.toLocaleString(),
+    });
   }
 
-  return content;
+  const actions: ResourceAction[] = [];
+  if (record?.webUrl) actions.push({ label: `Open in ${record.appName}`, href: record.webUrl });
+  if (record) actions.push({ label: 'View record', href: record.recordUrl });
+
+  return (
+    <div data-testid="backlink-item" className={className}>
+      <ResourceCard
+        icon={style.icon}
+        iconColor={style.color}
+        iconBg={style.bgColor}
+        title={title}
+        badge={appName}
+        subtitle={backlink.sourceUri}
+        subtitleMono
+        stats={stats}
+        actions={actions}
+      />
+    </div>
+  );
 }

--- a/web/components/backlinks/backlinks-panel.tsx
+++ b/web/components/backlinks/backlinks-panel.tsx
@@ -1,30 +1,57 @@
 'use client';
 
-import { Link2, ChevronDown, ChevronUp } from 'lucide-react';
-import { useState } from 'react';
+/**
+ * Where a paper has been referred to across the atmosphere.
+ *
+ * @remarks
+ * This panel used to be a stack of collapsed accordions, one per source type,
+ * each of which fetched its own page only once a reader thought to open it.
+ * That buried the thing it exists to show. Worse, the sections came from the
+ * counts endpoint, which buckets five ways and files everything else under
+ * `other` -- so a talk, a standard.site document and a Margin annotation all
+ * hid behind a heading that named none of them.
+ *
+ * It is now a flat list, loaded at once and filtered by the application that
+ * published each record, which is read from the record's own collection rather
+ * than from Chive's coarser classification. A reader arriving at the tab sees
+ * the references themselves.
+ *
+ * @packageDocumentation
+ */
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Link2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  useBacklinks,
-  useBacklinkCounts,
-  getSourceTypeLabel,
-  type BacklinkSourceType,
-} from '@/lib/hooks/use-backlinks';
+import { describeAtUri } from '@/lib/atproto/at-uri-links';
+import { useBacklinks, useBacklinkCounts, type Backlink } from '@/lib/hooks/use-backlinks';
 
-import { BacklinkItem } from './backlink-item';
+import { BacklinkItem, getSourceLabel } from './backlink-item';
 
 export interface BacklinksPanelProps {
   eprintUri: string;
   className?: string;
-  /** Maximum number of backlinks to show initially */
-  initialLimit?: number;
+  /**
+   * Say so when there is nothing, rather than rendering nothing.
+   *
+   * @remarks
+   * On a tab of its own an empty panel would leave a blank page, and a reader
+   * cannot tell a paper with no references from a panel that failed to load.
+   * Inside a page that has other content, staying silent is still right.
+   */
+  showEmpty?: boolean;
 }
 
 /**
- * Skeleton loader for backlinks panel.
+ * Skeleton loader for the panel.
+ *
+ * @param props - Component props
+ * @returns The placeholder
+ *
+ * @public
  */
 export function BacklinksPanelSkeleton({ className }: { className?: string }) {
   return (
@@ -37,11 +64,11 @@ export function BacklinksPanelSkeleton({ className }: { className?: string }) {
       </CardHeader>
       <CardContent className="space-y-3">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="flex items-start gap-3">
-            <Skeleton className="h-4 w-4 mt-0.5" />
-            <div className="flex-1 space-y-1">
-              <Skeleton className="h-3 w-20" />
-              <Skeleton className="h-4 w-full" />
+          <div key={i} className="flex items-start gap-3 rounded-lg border p-3">
+            <Skeleton className="h-9 w-9 shrink-0 rounded-md" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-3 w-full" />
             </div>
           </div>
         ))}
@@ -51,115 +78,71 @@ export function BacklinksPanelSkeleton({ className }: { className?: string }) {
 }
 
 /**
- * Source type section within the backlinks panel.
+ * Which application published a reference.
+ *
+ * @param backlink - The reference
+ * @returns The application's name
  */
-function BacklinkSection({
-  sourceType,
-  eprintUri,
-  initialExpanded = false,
-}: {
-  sourceType: BacklinkSourceType;
-  eprintUri: string;
-  initialExpanded?: boolean;
-}) {
-  const [expanded, setExpanded] = useState(initialExpanded);
-
-  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useBacklinks(
-    eprintUri,
-    {
-      sourceType,
-      limit: 5,
-      enabled: expanded,
-    }
-  );
-
-  const backlinks = data?.pages.flatMap((p) => p.backlinks) ?? [];
-  const label = getSourceTypeLabel(sourceType);
-
-  return (
-    <div className="border-t pt-3 first:border-t-0 first:pt-0">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full text-left group"
-      >
-        <span className="text-sm font-medium">{label}</span>
-        {expanded ? (
-          <ChevronUp className="h-4 w-4 text-muted-foreground" />
-        ) : (
-          <ChevronDown className="h-4 w-4 text-muted-foreground" />
-        )}
-      </button>
-
-      {expanded && (
-        <div className="mt-2 space-y-1">
-          {isLoading ? (
-            <div className="space-y-2">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-          ) : backlinks.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-2">No backlinks from this source</p>
-          ) : (
-            <>
-              {backlinks.map((backlink) => (
-                <BacklinkItem key={backlink.id} backlink={backlink} />
-              ))}
-              {hasNextPage && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => fetchNextPage()}
-                  disabled={isFetchingNextPage}
-                  className="w-full mt-2"
-                >
-                  {isFetchingNextPage ? 'Loading...' : 'Load more'}
-                </Button>
-              )}
-            </>
-          )}
-        </div>
-      )}
-    </div>
-  );
+function appNameOf(backlink: Backlink): string {
+  return describeAtUri(backlink.sourceUri)?.appName ?? getSourceLabel(backlink.sourceType);
 }
 
 /**
- * Displays backlinks to an eprint from external sources.
+ * Displays references to an eprint from elsewhere on the network.
  *
- * @remarks
- * Shows references to this eprint from elsewhere on the network: Cosmik
- * collections, Leaflet documents and comments, standard.site documents,
- * calendar events, Margin annotations and Bluesky posts.
+ * @param props - Component props
+ * @returns The panel
  *
- * @example
- * ```tsx
- * <BacklinksPanel eprintUri="at://did:plc:abc/pub.chive.eprint.submission/123" />
- * ```
+ * @public
  */
-export function BacklinksPanel({ eprintUri, className }: BacklinksPanelProps) {
-  const { data: counts, isLoading: countsLoading } = useBacklinkCounts(eprintUri);
+export function BacklinksPanel({ eprintUri, className, showEmpty = false }: BacklinksPanelProps) {
+  const { data: counts } = useBacklinkCounts(eprintUri);
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useBacklinks(
+    eprintUri,
+    { limit: 20 }
+  );
 
-  // Determine which source types have backlinks
-  const sourcesWithBacklinks: BacklinkSourceType[] = [];
-  if (counts) {
-    if (counts.cosmikCollections > 0) sourcesWithBacklinks.push('cosmik.collection');
-    if (counts.blueskyPosts > 0) sourcesWithBacklinks.push('bluesky.post');
-    if (counts.blueskyEmbeds > 0) sourcesWithBacklinks.push('bluesky.embed');
-    if (counts.leafletLists > 0) sourcesWithBacklinks.push('leaflet.document');
-    // `other` covers the source types the counts are not bucketed by —
-    // standard.site documents, calendar events and Margin annotations all land
-    // here, so the filter must offer it whenever anything is there.
-    if (counts.other > 0) sourcesWithBacklinks.push('other');
-  }
+  const [app, setApp] = useState<string | null>(null);
 
-  const hasBacklinks = counts && counts.total > 0;
+  const backlinks = useMemo(() => data?.pages.flatMap((p) => p.backlinks) ?? [], [data]);
 
-  if (countsLoading) {
+  // Chips are counted over what has been loaded, which is what they filter.
+  // Counting them from the totals endpoint would promise a filter that then
+  // showed fewer rows than its own label.
+  const apps = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const backlink of backlinks) {
+      const name = appNameOf(backlink);
+      tally.set(name, (tally.get(name) ?? 0) + 1);
+    }
+    return [...tally.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  }, [backlinks]);
+
+  const shown = app ? backlinks.filter((b) => appNameOf(b) === app) : backlinks;
+
+  if (isLoading) {
     return <BacklinksPanelSkeleton className={className} />;
   }
 
-  if (!hasBacklinks) {
-    return null;
+  const total = counts?.total ?? backlinks.length;
+
+  if (total === 0) {
+    if (!showEmpty) return null;
+    return (
+      <Card className={className}>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Link2 className="h-4 w-4" />
+            Atmosphere
+          </CardTitle>
+          <CardDescription>
+            Nothing on the network refers to this paper yet. When someone collects it on Cosmik,
+            writes about it on Leaflet, annotates it in Margin, schedules a talk about it, or
+            publishes it through standard.site, the record appears here.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
   }
 
   return (
@@ -167,21 +150,64 @@ export function BacklinksPanel({ eprintUri, className }: BacklinksPanelProps) {
       <CardHeader className="pb-3">
         <CardTitle className="text-base flex items-center gap-2">
           <Link2 className="h-4 w-4" />
-          Backlinks
+          Atmosphere
           <Badge variant="secondary" className="ml-auto" data-testid="backlinks-count">
-            {counts.total}
+            {total}
           </Badge>
         </CardTitle>
+        <CardDescription>
+          Records elsewhere on the network that refer to this paper. Each one lives in its
+          author&apos;s own repository, not in Chive.
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
-        {sourcesWithBacklinks.map((sourceType) => (
-          <BacklinkSection
-            key={sourceType}
-            sourceType={sourceType}
-            eprintUri={eprintUri}
-            initialExpanded={false}
-          />
-        ))}
+        {apps.length > 1 && (
+          <div className="flex flex-wrap gap-1.5" role="group" aria-label="Filter by application">
+            <Button
+              variant={app === null ? 'secondary' : 'outline'}
+              size="sm"
+              className="h-7 rounded-full px-3 text-xs"
+              aria-pressed={app === null}
+              onClick={() => {
+                setApp(null);
+              }}
+            >
+              All {backlinks.length}
+            </Button>
+            {apps.map(([name, count]) => (
+              <Button
+                key={name}
+                variant={app === name ? 'secondary' : 'outline'}
+                size="sm"
+                className="h-7 rounded-full px-3 text-xs"
+                aria-pressed={app === name}
+                onClick={() => {
+                  setApp(app === name ? null : name);
+                }}
+              >
+                {name} {count}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          {shown.map((backlink) => (
+            <BacklinkItem key={backlink.id} backlink={backlink} />
+          ))}
+        </div>
+
+        {hasNextPage && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full"
+            disabled={isFetchingNextPage}
+            onClick={() => void fetchNextPage()}
+          >
+            {isFetchingNextPage ? 'Loading…' : 'Load more'}
+          </Button>
+        )}
       </CardContent>
     </Card>
   );

--- a/web/components/eprints/external-ids-panel.test.tsx
+++ b/web/components/eprints/external-ids-panel.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Tests for the external identifiers panel.
+ *
+ * @remarks
+ * The panel used to render a flat row -- a label, then a monospaced value --
+ * which looked unlike every other link on the page for no reason a reader could
+ * learn anything from. It now renders the page's standard card, with the
+ * identifier leading and the address it resolves to beneath it.
+ *
+ * @packageDocumentation
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ExternalIdsPanel } from './external-ids-panel';
+
+describe('ExternalIdsPanel', () => {
+  it('renders nothing when there are no identifiers', () => {
+    const { container } = render(<ExternalIdsPanel />);
+    expect(container).toBeEmptyDOMElement();
+    const empty = render(<ExternalIdsPanel externalIds={{}} />);
+    expect(empty.container).toBeEmptyDOMElement();
+  });
+
+  it('leads with the identifier and names the service beside it', () => {
+    render(<ExternalIdsPanel externalIds={{ arxivId: '2405.12345' }} />);
+    expect(screen.getByText('2405.12345')).toBeInTheDocument();
+    expect(screen.getByText('arXiv')).toBeInTheDocument();
+  });
+
+  it('says where the link goes before it is clicked', () => {
+    render(<ExternalIdsPanel externalIds={{ arxivId: '2405.12345' }} />);
+    expect(screen.getByText('arxiv.org/abs/2405.12345')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://arxiv.org/abs/2405.12345');
+  });
+
+  it('renders a display-only identifier without pretending it links somewhere', () => {
+    render(<ExternalIdsPanel externalIds={{ magId: '99887766' }} />);
+    expect(screen.getByText('99887766')).toBeInTheDocument();
+    expect(screen.getByText('No public address')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('counts the identifiers it holds', () => {
+    render(
+      <ExternalIdsPanel externalIds={{ arxivId: '2405.12345', pmid: '12345678', osf: 'abc12' }} />
+    );
+    expect(screen.getAllByRole('link')).toHaveLength(3);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+});

--- a/web/components/eprints/external-ids-panel.tsx
+++ b/web/components/eprints/external-ids-panel.tsx
@@ -10,10 +10,12 @@
  * @packageDocumentation
  */
 
-import { ExternalLink, Link as LinkIcon } from 'lucide-react';
+import { Link as LinkIcon, BookText, FlaskConical, Landmark, Microscope } from 'lucide-react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ResourceCard } from '@/components/links/resource-card';
 import { Badge } from '@/components/ui/badge';
+import { summarizeUrl } from '@/lib/atproto/at-uri-links';
 import type { EprintExternalIds } from '@/lib/api/schema';
 
 // =============================================================================
@@ -38,6 +40,12 @@ interface ExternalIdConfig {
   label: string;
   /** Returns the full URL for the identifier, or null if display-only */
   buildUrl: (id: string) => string | null;
+  /** Service icon, so a reader recognizes the row before reading it */
+  icon: React.ComponentType<{ className?: string }>;
+  /** Tailwind text colour for the icon */
+  color: string;
+  /** Tailwind background for the icon tile */
+  bgColor: string;
 }
 
 const EXTERNAL_ID_CONFIGS: ExternalIdConfig[] = [
@@ -45,51 +53,81 @@ const EXTERNAL_ID_CONFIGS: ExternalIdConfig[] = [
     key: 'arxivId',
     label: 'arXiv',
     buildUrl: (id) => `https://arxiv.org/abs/${id}`,
+    icon: BookText,
+    color: 'text-red-600',
+    bgColor: 'bg-red-50 dark:bg-red-950',
   },
   {
     key: 'pmid',
     label: 'PubMed',
     buildUrl: (id) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,
+    icon: Microscope,
+    color: 'text-blue-600',
+    bgColor: 'bg-blue-50 dark:bg-blue-950',
   },
   {
     key: 'pmcid',
     label: 'PubMed Central',
     buildUrl: (id) => `https://www.ncbi.nlm.nih.gov/pmc/articles/${id}`,
+    icon: Microscope,
+    color: 'text-blue-600',
+    bgColor: 'bg-blue-50 dark:bg-blue-950',
   },
   {
     key: 'ssrnId',
     label: 'SSRN',
     buildUrl: (id) => `https://ssrn.com/abstract=${id}`,
+    icon: Landmark,
+    color: 'text-amber-600',
+    bgColor: 'bg-amber-50 dark:bg-amber-950',
   },
   {
     key: 'osf',
     label: 'OSF',
     buildUrl: (id) => `https://osf.io/${id}`,
+    icon: FlaskConical,
+    color: 'text-indigo-600',
+    bgColor: 'bg-indigo-50 dark:bg-indigo-950',
   },
   {
     key: 'zenodoDoi',
     label: 'Zenodo',
     buildUrl: (doi) => `https://doi.org/${doi}`,
+    icon: Landmark,
+    color: 'text-sky-600',
+    bgColor: 'bg-sky-50 dark:bg-sky-950',
   },
   {
     key: 'openAlexId',
     label: 'OpenAlex',
     buildUrl: (id) => `https://openalex.org/works/${id}`,
+    icon: BookText,
+    color: 'text-emerald-600',
+    bgColor: 'bg-emerald-50 dark:bg-emerald-950',
   },
   {
     key: 'semanticScholarId',
     label: 'Semantic Scholar',
     buildUrl: (id) => `https://api.semanticscholar.org/CorpusID:${id}`,
+    icon: BookText,
+    color: 'text-violet-600',
+    bgColor: 'bg-violet-50 dark:bg-violet-950',
   },
   {
     key: 'coreSid',
     label: 'CORE',
     buildUrl: (id) => `https://core.ac.uk/outputs/${id}`,
+    icon: BookText,
+    color: 'text-teal-600',
+    bgColor: 'bg-teal-50 dark:bg-teal-950',
   },
   {
     key: 'magId',
     label: 'Microsoft Academic (legacy)',
     buildUrl: () => null,
+    icon: BookText,
+    color: 'text-gray-600',
+    bgColor: 'bg-gray-50 dark:bg-gray-900',
   },
 ];
 
@@ -98,36 +136,34 @@ const EXTERNAL_ID_CONFIGS: ExternalIdConfig[] = [
 // =============================================================================
 
 /**
- * Single external identifier row.
+ * One external identifier, rendered as the page's standard link card.
+ *
+ * @remarks
+ * The identifier leads, because that is the part a reader is looking for --
+ * the same reason the repository card leads with `owner/repo` rather than with
+ * "GitHub". The service name sits beside it as a badge, and the address it
+ * resolves to sits under it, so the row says where it goes before it is
+ * clicked.
  */
 function ExternalIdRow({
-  label,
+  config,
   value,
   url,
 }: {
-  label: string;
+  config: ExternalIdConfig;
   value: string;
   url: string | null;
 }) {
   return (
-    <div className="flex items-center gap-3 p-3 rounded-lg border bg-card min-h-[44px]">
-      <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap sm:flex-nowrap">
-        <span className="text-sm font-medium shrink-0">{label}</span>
-        {url ? (
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-muted-foreground hover:text-foreground hover:underline flex items-center gap-1 min-w-0 min-h-[44px] sm:min-h-0"
-          >
-            <span className="truncate font-mono">{value}</span>
-            <ExternalLink className="h-3 w-3 shrink-0" />
-          </a>
-        ) : (
-          <span className="text-sm text-muted-foreground font-mono truncate">{value}</span>
-        )}
-      </div>
-    </div>
+    <ResourceCard
+      icon={config.icon}
+      iconColor={config.color}
+      iconBg={config.bgColor}
+      title={value}
+      badge={config.label}
+      subtitle={url ? summarizeUrl(url) : 'No public address'}
+      {...(url ? { href: url } : {})}
+    />
   );
 }
 
@@ -170,7 +206,7 @@ export function ExternalIdsPanel({ externalIds, className }: ExternalIdsPanelPro
         {presentIds.map((config) => {
           const value = externalIds[config.key] as string;
           const url = config.buildUrl(value);
-          return <ExternalIdRow key={config.key} label={config.label} value={value} url={url} />;
+          return <ExternalIdRow key={config.key} config={config} value={value} url={url} />;
         })}
       </CardContent>
     </Card>

--- a/web/components/eprints/repositories-panel.aturi.test.tsx
+++ b/web/components/eprints/repositories-panel.aturi.test.tsx
@@ -120,7 +120,14 @@ describe('RepositoriesPanel with AT-URI datasets', () => {
     );
 
     expect(screen.getByText(NEGRAISING)).toBeInTheDocument();
-    expect(screen.queryByRole('link')).toBeNull();
+    // The web page the record also carried is not what the card acts on, and
+    // an at-uri is not an address a browser can follow. What is offered is the
+    // record itself, through a browser that resolves any at-uri by reading it
+    // from the repository that holds it.
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute('href', `https://pdsls.dev/${NEGRAISING}`);
+    expect(links[0]).toHaveTextContent('View record');
   });
 
   it('still renders an ordinary web repository as a link', () => {

--- a/web/components/eprints/repositories-panel.only.test.tsx
+++ b/web/components/eprints/repositories-panel.only.test.tsx
@@ -84,3 +84,67 @@ describe('legacy platform field', () => {
     expect(screen.getByRole('link')).toHaveAttribute('href', 'https://example.org/repo');
   });
 });
+
+describe('RepositoriesPanel link detail', () => {
+  it('shows which repository a card means, not merely which service', () => {
+    // A card headed "GitHub" said less than the URL it was built from already
+    // knew. The address was in the record the whole time; it was not shown.
+    render(
+      <RepositoriesPanel
+        only={['code']}
+        repositories={{
+          code: [
+            {
+              url: 'https://github.com/aaronstevenwhite/chive.git',
+              label: 'Chive',
+              platformSlug: 'github',
+            },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByText('github.com/aaronstevenwhite/chive')).toBeInTheDocument();
+  });
+
+  it('shows a DOI alongside the address when the record carries one', () => {
+    render(
+      <RepositoriesPanel
+        only={['data']}
+        repositories={{
+          data: [
+            {
+              url: 'https://zenodo.org/records/123',
+              label: 'Stimuli',
+              platformSlug: 'zenodo',
+              doi: '10.5281/zenodo.123',
+            },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByText('DOI: 10.5281/zenodo.123')).toBeInTheDocument();
+  });
+});
+
+describe('RepositoriesPanel entries without an address', () => {
+  it('renders an entry the author labelled but gave no address', () => {
+    // The tab count counts these, so dropping the card left a tab reading
+    // "Code 2" above one card.
+    render(
+      <RepositoriesPanel
+        only={['code']}
+        repositories={{
+          code: [
+            { url: 'https://github.com/a/b', label: 'Real repo', platformSlug: 'github' },
+            { label: 'Probe repo on Tangled', platformSlug: 'tangled' },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByText('Real repo')).toBeInTheDocument();
+    expect(screen.getByText('Probe repo on Tangled')).toBeInTheDocument();
+    expect(screen.getByText('No address on the record')).toBeInTheDocument();
+    // It says so rather than offering a link that goes nowhere.
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+  });
+});

--- a/web/components/eprints/repositories-panel.tsx
+++ b/web/components/eprints/repositories-panel.tsx
@@ -10,12 +10,27 @@
  * @packageDocumentation
  */
 
-import { ExternalLink, Github, Database, Code, Box, FlaskConical, FileText } from 'lucide-react';
+import {
+  ExternalLink,
+  Github,
+  Database,
+  Code,
+  Box,
+  FlaskConical,
+  FileText,
+  CalendarClock,
+  Fingerprint,
+} from 'lucide-react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { DatasetSnippet } from '@/components/eprints/dataset-snippet';
+import {
+  ResourceCard,
+  type ResourceAction,
+  type ResourceStat,
+} from '@/components/links/resource-card';
 import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib/utils';
+import { describeAtUri, summarizeUrl } from '@/lib/atproto/at-uri-links';
 import type { Repositories, Preregistration } from '@/lib/api/schema';
 
 // =============================================================================
@@ -331,14 +346,18 @@ function RepositoryCard({
   config: Record<string, PlatformConfig>;
   doi?: string;
 }) {
-  if (!url && !recordUri) return null;
+  // An entry with no address at all still says the author named a resource,
+  // and the tab's count already counted it. Dropping the card silently left a
+  // tab reading "Code 2" over one card, which reads as a bug in Chive rather
+  // than as an incomplete record.
+  const hasAddress = Boolean(url ?? recordUri);
 
   // `recordUri` is where a record reference belongs; `url` is an address a
   // browser can open. Records written before the data shape had `recordUri`
   // put at-uris in `url`, so both are read -- the dedicated field first, the
   // legacy placement after it.
   const reference = recordUri ?? url ?? '';
-  const atKind = atUriKind(reference);
+  const atKind = hasAddress ? atUriKind(reference) : null;
 
   // A Layers dataset is named by its collection or corpus record, and the
   // entries written before the platform was recorded carry `platform: "other"`,
@@ -352,52 +371,51 @@ function RepositoryCard({
   // Use label if provided, otherwise platform config label
   const displayLabel = label || platformConfig.label;
 
-  // An AT-URI is not a browser address. Rendering it as an anchor gives a link
-  // that does nothing and an icon promising it opens somewhere, so the card
-  // drops both and offers the way in that does work: the URI itself, and the
-  // code that loads it.
+  // An AT-URI is not a browser address, so the card never puts one in an
+  // href. It does offer the two links that work: the publishing application's
+  // own page where that route is known, and a record browser, which resolves
+  // any AT-URI by reading it from the PDS that holds it.
   if (atKind) {
+    const record = describeAtUri(reference);
+    const actions: ResourceAction[] = [];
+    if (record?.webUrl) actions.push({ label: `Open in ${record.appName}`, href: record.webUrl });
+    if (record) actions.push({ label: 'View record', href: record.recordUrl });
+
     return (
-      <div className="flex items-start gap-3 p-3 rounded-lg border bg-card">
-        <div className={cn('shrink-0 p-2 rounded-md', platformConfig.bgColor)}>
-          <Icon className={cn('h-5 w-5', platformConfig.color)} />
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="font-medium truncate">{displayLabel}</span>
-            <Badge variant="outline" className="text-xs shrink-0">
-              {platformConfig.label}
-            </Badge>
-          </div>
-          <p className="text-xs text-muted-foreground break-all mt-0.5">{reference}</p>
-          {atKind === 'collection' && <DatasetSnippet catalogRef={reference} />}
-          {atKind === 'corpus' && <DatasetSnippet corpusRef={reference} />}
-        </div>
-      </div>
+      <ResourceCard
+        icon={Icon}
+        iconColor={platformConfig.color}
+        iconBg={platformConfig.bgColor}
+        title={displayLabel}
+        badge={platformConfig.label}
+        subtitle={reference}
+        subtitleMono
+        actions={actions}
+      >
+        {atKind === 'collection' && <DatasetSnippet catalogRef={reference} />}
+        {atKind === 'corpus' && <DatasetSnippet corpusRef={reference} />}
+      </ResourceCard>
     );
   }
 
+  // The address is already in the record; it was simply never shown. A card
+  // headed "GitHub" over `aaronstevenwhite/chive` says what the one headed
+  // "GitHub" alone could not.
+  const stats: ResourceStat[] = [];
+  if (doi)
+    stats.push({ icon: Fingerprint, label: `DOI: ${doi}`, title: 'Digital Object Identifier' });
+
   return (
-    <a
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group flex items-center gap-3 p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors"
-    >
-      <div className={cn('shrink-0 p-2 rounded-md', platformConfig.bgColor)}>
-        <Icon className={cn('h-5 w-5', platformConfig.color)} />
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="font-medium truncate">{displayLabel}</span>
-          <Badge variant="outline" className="text-xs shrink-0">
-            {platformConfig.label}
-          </Badge>
-        </div>
-        {doi && <p className="text-xs text-muted-foreground truncate mt-0.5">DOI: {doi}</p>}
-      </div>
-      <ExternalLink className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
-    </a>
+    <ResourceCard
+      icon={Icon}
+      iconColor={platformConfig.color}
+      iconBg={platformConfig.bgColor}
+      title={displayLabel}
+      badge={platformConfig.label}
+      subtitle={url ? summarizeUrl(url) : 'No address on the record'}
+      stats={stats}
+      {...(url ? { href: url } : {})}
+    />
   );
 }
 
@@ -410,35 +428,26 @@ function PreregistrationCard({ prereg }: { prereg: Preregistration }) {
   // Normalize platform slug for icon/color lookup
   const normalizedSlug = normalizePlatformSlug(platformSlugOf(prereg));
   const platformConfig = PREREG_PLATFORM_CONFIG[normalizedSlug] ?? PREREG_PLATFORM_CONFIG.other;
-  const Icon = platformConfig.icon;
-  // Use platform config label for display
-  const displayPlatform = platformConfig.label;
+
+  const stats: ResourceStat[] = [];
+  if (prereg.registrationDate) {
+    stats.push({
+      icon: CalendarClock,
+      label: `Registered ${new Date(prereg.registrationDate).toLocaleDateString()}`,
+    });
+  }
 
   return (
-    <a
+    <ResourceCard
+      icon={platformConfig.icon}
+      iconColor={platformConfig.color}
+      iconBg={platformConfig.bgColor}
+      title="Pre-registration"
+      badge={platformConfig.label}
+      subtitle={summarizeUrl(prereg.url)}
+      stats={stats}
       href={prereg.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group flex items-center gap-3 p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors"
-    >
-      <div className={cn('shrink-0 p-2 rounded-md', platformConfig.bgColor)}>
-        <Icon className={cn('h-5 w-5', platformConfig.color)} />
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="font-medium">Pre-registration</span>
-          <Badge variant="outline" className="text-xs shrink-0">
-            {displayPlatform}
-          </Badge>
-        </div>
-        {prereg.registrationDate && (
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Registered: {new Date(prereg.registrationDate).toLocaleDateString()}
-          </p>
-        )}
-      </div>
-      <ExternalLink className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
-    </a>
+    />
   );
 }
 

--- a/web/components/eprints/supplementary-panel.datalinks.test.tsx
+++ b/web/components/eprints/supplementary-panel.datalinks.test.tsx
@@ -99,3 +99,22 @@ describe('SupplementaryPanel data links', () => {
     expect(code.textContent).toContain('pub.layers.catalog.collection/acceptability');
   });
 });
+
+describe('SupplementaryPanel count', () => {
+  it('counts linked datasets, which the panel also renders', () => {
+    // The badge read "0" above a card, because it counted only uploaded files.
+    render(
+      <SupplementaryPanel
+        items={[]}
+        dataLinks={[
+          {
+            uri: 'at://did:plc:a/pub.layers.eprint.dataLink/1',
+            dataKind: 'corpus',
+            catalogRef: 'at://did:plc:a/pub.layers.catalog.collection/c1',
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+});

--- a/web/components/eprints/supplementary-panel.tsx
+++ b/web/components/eprints/supplementary-panel.tsx
@@ -27,13 +27,18 @@ import {
   Download,
   ChevronDown,
   ChevronUp,
-  ExternalLink,
 } from 'lucide-react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import {
+  ResourceCard,
+  type ResourceAction,
+  type ResourceStat,
+} from '@/components/links/resource-card';
+import { describeAtUri } from '@/lib/atproto/at-uri-links';
 import { cn } from '@/lib/utils';
 
 // =============================================================================
@@ -160,47 +165,27 @@ function formatFileSize(bytes: number): string {
  */
 function SupplementaryItemCard({ item }: { item: SupplementaryItem }) {
   const config = CATEGORY_CONFIG[item.category];
-  const Icon = config.icon;
+
+  const stats: ResourceStat[] = [];
+  if (item.format) stats.push({ label: item.format.toUpperCase() });
+  if (item.size) stats.push({ label: formatFileSize(item.size) });
+
+  const actions: ResourceAction[] = [];
+  if (item.viewUrl) actions.push({ label: 'View', href: item.viewUrl });
+  if (item.downloadUrl) {
+    actions.push({ label: 'Download', href: item.downloadUrl, download: true, icon: Download });
+  }
 
   return (
-    <div className="flex items-start gap-3 p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors">
-      <div className={cn('shrink-0 mt-0.5', config.color)}>
-        <Icon className="h-5 w-5" />
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="font-medium truncate">{item.label}</span>
-          <Badge variant="outline" className="text-xs shrink-0">
-            {config.label}
-          </Badge>
-        </div>
-        {item.description && (
-          <p className="text-sm text-muted-foreground line-clamp-2 mt-1">{item.description}</p>
-        )}
-        <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
-          {item.format && <span className="uppercase">{item.format}</span>}
-          {item.size && <span>{formatFileSize(item.size)}</span>}
-        </div>
-      </div>
-      <div className="flex items-center gap-1 shrink-0">
-        {item.viewUrl && (
-          <Button asChild variant="ghost" size="sm" className="h-8 w-8 p-0">
-            <a href={item.viewUrl} target="_blank" rel="noopener noreferrer">
-              <ExternalLink className="h-4 w-4" />
-              <span className="sr-only">View</span>
-            </a>
-          </Button>
-        )}
-        {item.downloadUrl && (
-          <Button asChild variant="ghost" size="sm" className="h-8 w-8 p-0">
-            <a href={item.downloadUrl} download>
-              <Download className="h-4 w-4" />
-              <span className="sr-only">Download</span>
-            </a>
-          </Button>
-        )}
-      </div>
-    </div>
+    <ResourceCard
+      icon={config.icon}
+      iconColor={config.color}
+      title={item.label}
+      badge={config.label}
+      description={item.description}
+      stats={stats}
+      actions={actions}
+    />
   );
 }
 
@@ -211,32 +196,38 @@ function SupplementaryItemCard({ item }: { item: SupplementaryItem }) {
  * `paperSection` is given prominence because it is what makes a link useful:
  * "the corpus" is an offer, "the corpus behind Table 3" is an answer.
  *
- * The card does not link out. All we hold is the AT-URI of the dataLink record
- * in its author's repository, and Layers' web routing is not settled, so any
- * URL we built from that URI today would be a guess that may 404. Showing the
- * dataset and saying where it lives is worth more than a broken link.
+ * Layers' web routing is still unsettled, so the card offers no address on
+ * layers.pub -- a URL built from the AT-URI today would be a guess. It does
+ * offer the record itself through a public record browser, which resolves any
+ * AT-URI by reading it from the repository that holds it, so the dataset is
+ * reachable rather than merely named.
  */
 function DataLinkCard({ link }: { link: DataLinkItem }) {
+  const reference = link.catalogRef ?? link.corpusRef;
+  const record = reference ? describeAtUri(reference) : null;
+
+  const stats: ResourceStat[] = [];
+  if (link.paperSection) stats.push({ label: link.paperSection });
+
+  const actions: ResourceAction[] = record
+    ? [{ label: 'View record', href: record.recordUrl }]
+    : [];
+
   return (
-    <div className="flex items-start gap-3 p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors">
-      <div className="shrink-0 mt-0.5 text-violet-500">
-        <Database className="h-5 w-5" />
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="font-medium truncate">{formatDataKind(link.dataKind)}</span>
-          {link.paperSection && (
-            <Badge variant="secondary" className="text-xs shrink-0">
-              {link.paperSection}
-            </Badge>
-          )}
-        </div>
-        {link.description && (
-          <p className="text-sm text-muted-foreground line-clamp-2 mt-1">{link.description}</p>
-        )}
-        <DatasetSnippet catalogRef={link.catalogRef} corpusRef={link.corpusRef} />
-      </div>
-    </div>
+    <ResourceCard
+      icon={Database}
+      iconColor="text-violet-600"
+      iconBg="bg-violet-50 dark:bg-violet-950"
+      title={formatDataKind(link.dataKind)}
+      badge="Layers"
+      subtitle={reference}
+      subtitleMono
+      description={link.description}
+      stats={stats}
+      actions={actions}
+    >
+      <DatasetSnippet catalogRef={link.catalogRef} corpusRef={link.corpusRef} />
+    </ResourceCard>
   );
 }
 
@@ -311,8 +302,11 @@ export function SupplementaryPanel({
           <CardTitle className="text-base flex items-center gap-2">
             <Paperclip className="h-4 w-4" />
             Supplementary Materials
+            {/* The panel holds uploaded files and datasets linked on Layers,
+                and it renders both. Counting only the first showed "0" above a
+                card. */}
             <Badge variant="secondary" className="ml-1">
-              {items.length}
+              {items.length + dataLinks.length}
             </Badge>
           </CardTitle>
         </div>

--- a/web/components/integrations/__tests__/integration-cards.test.tsx
+++ b/web/components/integrations/__tests__/integration-cards.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Tests for the integration cards.
+ *
+ * @remarks
+ * These four cards each had their own layout, and the GitHub one was the only
+ * one worth keeping. They now render through the page's shared card, so the
+ * contract worth holding is that nothing that was informative was lost on the
+ * way -- and, in particular, that an unreachable upstream still refuses to
+ * print a placeholder count as though it were a measurement.
+ *
+ * @packageDocumentation
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DatasetLinkItem } from '../dataset-links';
+import { GitHubRepoCard } from '../github-repo-card';
+import { GitLabProjectCard } from '../gitlab-project-card';
+import { SoftwareHeritageBadge } from '../software-heritage-badge';
+import { ZenodoBadge } from '../zenodo-badge';
+
+const REPO = {
+  type: 'github' as const,
+  owner: 'aaronstevenwhite',
+  repo: 'chive',
+  url: 'https://github.com/aaronstevenwhite/chive',
+  stars: 1234,
+  forks: 56,
+  language: 'TypeScript',
+  description: 'Decentralized eprints on ATProto',
+  license: 'MIT',
+  topics: ['atprotocol', 'eprints', 'open-science', 'preprints', 'a', 'b', 'c'],
+  lastUpdated: '2026-09-01T00:00:00Z',
+};
+
+describe('GitHubRepoCard', () => {
+  it('leads with the repository and reports what GitHub knows', () => {
+    render(<GitHubRepoCard repo={REPO} />);
+    expect(screen.getByText('aaronstevenwhite/chive')).toBeInTheDocument();
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText('Decentralized eprints on ATProto')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('56')).toBeInTheDocument();
+    expect(screen.getByText('MIT')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', REPO.url);
+  });
+
+  it('caps the topics rather than growing the card without limit', () => {
+    render(<GitHubRepoCard repo={REPO} />);
+    expect(screen.getByText('atprotocol')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('refuses to print a placeholder count as a measurement', () => {
+    render(<GitHubRepoCard repo={{ ...REPO, unavailable: true, stars: 0, forks: 0 }} />);
+    expect(screen.getAllByText('—')).toHaveLength(2);
+    expect(screen.queryByText('0')).toBeNull();
+    expect(screen.getByText(/could not be reached/i)).toBeInTheDocument();
+  });
+});
+
+describe('GitLabProjectCard', () => {
+  it('shows the project path, its visibility and its counts', () => {
+    render(
+      <GitLabProjectCard
+        project={{
+          type: 'gitlab',
+          pathWithNamespace: 'group/project',
+          name: 'project',
+          url: 'https://gitlab.com/group/project',
+          stars: 7,
+          forks: 2,
+          description: 'A project',
+          visibility: 'public',
+          topics: ['nlp'],
+          lastActivityAt: '2026-09-01T00:00:00Z',
+        }}
+      />
+    );
+    expect(screen.getByText('group/project')).toBeInTheDocument();
+    expect(screen.getByText('GitLab')).toBeInTheDocument();
+    expect(screen.getByText('public')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('nlp')).toBeInTheDocument();
+  });
+});
+
+describe('ZenodoBadge', () => {
+  const RECORD = {
+    type: 'zenodo' as const,
+    doi: '10.5281/zenodo.123',
+    title: 'Stimuli and analysis code',
+    url: 'https://doi.org/10.5281/zenodo.123',
+    resourceType: 'dataset',
+    accessRight: 'open',
+    version: '2',
+    stats: { views: 900, downloads: 120 },
+  };
+
+  it('leads with the DOI and reports the deposit', () => {
+    render(<ZenodoBadge record={RECORD} variant="card" />);
+    expect(screen.getByText('10.5281/zenodo.123')).toBeInTheDocument();
+    expect(screen.getByText('Zenodo')).toBeInTheDocument();
+    expect(screen.getByText('Stimuli and analysis code')).toBeInTheDocument();
+    expect(screen.getByText('dataset')).toBeInTheDocument();
+    expect(screen.getByText('open')).toBeInTheDocument();
+    expect(screen.getByText('v2')).toBeInTheDocument();
+    expect(screen.getByText('900 views')).toBeInTheDocument();
+    expect(screen.getByText('120 downloads')).toBeInTheDocument();
+  });
+
+  it('still renders the compact badge variant used elsewhere', () => {
+    render(<ZenodoBadge record={RECORD} />);
+    expect(screen.getByText('DOI')).toBeInTheDocument();
+  });
+});
+
+describe('SoftwareHeritageBadge', () => {
+  it('says what is archived and when it was last seen', () => {
+    render(
+      <SoftwareHeritageBadge
+        variant="card"
+        data={{
+          type: 'software-heritage',
+          originUrl: 'https://github.com/a/b',
+          archived: true,
+          lastVisit: '2026-01-15T00:00:00Z',
+          lastSnapshotSwhid: 'swh:1:snp:0123456789abcdef0123456789abcdef01234567',
+          browseUrl: 'https://archive.softwareheritage.org/browse/x',
+        }}
+      />
+    );
+    expect(screen.getByText('Software Heritage')).toBeInTheDocument();
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+    expect(screen.getByText('https://github.com/a/b')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      'https://archive.softwareheritage.org/browse/x'
+    );
+  });
+
+  it('says plainly when nothing is archived yet', () => {
+    render(
+      <SoftwareHeritageBadge
+        variant="card"
+        data={{ type: 'software-heritage', originUrl: 'https://github.com/a/b', archived: false }}
+      />
+    );
+    expect(screen.getByText('Not yet archived')).toBeInTheDocument();
+  });
+});
+
+describe('DatasetLinkItem', () => {
+  it('leads with the deposit title rather than the repository name', () => {
+    render(
+      <DatasetLinkItem
+        variant="card"
+        dataset={{
+          type: 'osf',
+          title: 'Experiment 1 materials',
+          url: 'https://osf.io/abc12',
+          doi: '10.17605/OSF.IO/ABC12',
+        }}
+      />
+    );
+    expect(screen.getByText('Experiment 1 materials')).toBeInTheDocument();
+    expect(screen.getByText('OSF')).toBeInTheDocument();
+    expect(screen.getByText('osf.io/abc12')).toBeInTheDocument();
+    expect(screen.getByText('DOI: 10.17605/OSF.IO/ABC12')).toBeInTheDocument();
+  });
+});

--- a/web/components/integrations/brand-marks.tsx
+++ b/web/components/integrations/brand-marks.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * Brand marks for the services an eprint links out to.
+ *
+ * @remarks
+ * Kept as icon components with the same shape as a Lucide icon, so a service's
+ * own mark can be passed anywhere the shared card takes an icon. A recognized
+ * mark is the fastest thing on a card to read, and the difference between a
+ * generic code glyph and GitHub's is the difference between a card a reader
+ * scans and one they have to parse.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * The GitHub mark.
+ *
+ * @param props - Standard icon props
+ * @returns The mark
+ *
+ * @public
+ */
+export function GithubMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
+/**
+ * The GitLab mark.
+ *
+ * @param props - Standard icon props
+ * @returns The mark
+ *
+ * @public
+ */
+export function GitlabMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 32 32" className={className} aria-hidden="true">
+      <path fill="#E24329" d="M16 31.2L21.2 16H10.8L16 31.2z" />
+      <path fill="#FC6D26" d="M16 31.2L10.8 16H2L16 31.2z" />
+      <path fill="#FCA326" d="M2 16L.1 21.8c-.2.5 0 1.1.5 1.4L16 31.2L2 16z" />
+      <path fill="#E24329" d="M2 16h8.8L7.5 5.4c-.1-.4-.7-.4-.9 0L2 16z" />
+      <path fill="#FC6D26" d="M16 31.2L21.2 16H30L16 31.2z" />
+      <path fill="#FCA326" d="M30 16l1.9 5.8c.2.5 0 1.1-.5 1.4L16 31.2L30 16z" />
+      <path fill="#E24329" d="M30 16h-8.8l3.3-10.6c.1-.4.7-.4.9 0L30 16z" />
+    </svg>
+  );
+}

--- a/web/components/integrations/dataset-links.tsx
+++ b/web/components/integrations/dataset-links.tsx
@@ -3,6 +3,8 @@
 import { ExternalLink, Database, FlaskConical, FolderOpen } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
+import { ResourceCard, type ResourceStat } from '@/components/links/resource-card';
+import { summarizeUrl } from '@/lib/atproto/at-uri-links';
 import { cn } from '@/lib/utils';
 import type { DatasetIntegration } from '@/lib/hooks/use-integrations';
 
@@ -90,31 +92,24 @@ export function DatasetLinkItem({ dataset, variant = 'badge', className }: Datas
     );
   }
 
-  // Card variant
+  // Card variant, in the page's standard shape: the deposit's own title leads,
+  // the repository names itself beside it, and the DOI and address read as
+  // facts under it rather than as two anonymous grey lines.
+  const stats: ResourceStat[] = [];
+  if (dataset.doi) stats.push({ label: `DOI: ${dataset.doi}` });
+
   return (
-    <a
+    <ResourceCard
+      className={className}
+      icon={Icon}
+      iconColor="text-white"
+      iconBg={color}
+      title={dataset.title || name}
+      badge={name}
+      subtitle={dataset.url ? summarizeUrl(dataset.url) : undefined}
+      stats={stats}
       href={dataset.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn(
-        'flex items-start gap-3 rounded-lg border p-3 transition-colors hover:bg-muted/50 no-underline',
-        className
-      )}
-    >
-      <div className={cn('flex h-8 w-8 items-center justify-center rounded-md shrink-0', color)}>
-        <Icon className="h-4 w-4" />
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center justify-between gap-2">
-          <div className="text-sm font-medium">{name}</div>
-          <ExternalLink className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-        </div>
-        <p className="text-xs text-muted-foreground truncate">{dataset.title}</p>
-        {dataset.doi && (
-          <span className="text-xs text-muted-foreground font-mono">{dataset.doi}</span>
-        )}
-      </div>
-    </a>
+    />
   );
 }
 

--- a/web/components/integrations/github-repo-card.tsx
+++ b/web/components/integrations/github-repo-card.tsx
@@ -1,11 +1,24 @@
 'use client';
 
-import { ExternalLink, Star, GitFork, Code2, Scale } from 'lucide-react';
+/**
+ * A GitHub repository, with what GitHub says about it.
+ *
+ * @remarks
+ * This card is the page's reference for how a link should read: the repository
+ * leads, the service sits beside it, and the facts that tell a reader whether
+ * it is worth opening -- language, stars, forks, licence, topics -- come from
+ * GitHub rather than from the eprint record. Every other link on the page now
+ * renders through the same card, with whatever detail its own source can give.
+ *
+ * @packageDocumentation
+ */
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib/utils';
+import { Star, GitFork, Code2, Scale } from 'lucide-react';
+
+import { ResourceCard, type ResourceStat } from '@/components/links/resource-card';
 import type { GitHubIntegration } from '@/lib/hooks/use-integrations';
+
+import { GithubMark } from './brand-marks';
 
 export interface GitHubRepoCardProps {
   repo: GitHubIntegration;
@@ -13,89 +26,45 @@ export interface GitHubRepoCardProps {
 }
 
 /**
- * Displays GitHub repository information as a card.
+ * Displays GitHub repository information.
  *
- * @remarks
- * Shows repository metadata including stars, forks, language, and license.
- * Links to the GitHub repository.
+ * @param props - Component props
+ * @returns The card
+ *
+ * @public
  */
 export function GitHubRepoCard({ repo, className }: GitHubRepoCardProps) {
+  const stats: ResourceStat[] = [];
+  if (repo.language) stats.push({ icon: Code2, label: repo.language });
+  // Never render a placeholder count as a real one.
+  stats.push({
+    icon: Star,
+    label: repo.unavailable ? '—' : repo.stars.toLocaleString(),
+    title: 'Stars',
+  });
+  stats.push({
+    icon: GitFork,
+    label: repo.unavailable ? '—' : repo.forks.toLocaleString(),
+    title: 'Forks',
+  });
+  if (repo.license) stats.push({ icon: Scale, label: repo.license });
+
   return (
-    <Card className={cn('overflow-hidden', className)}>
-      <CardHeader className="pb-2">
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <svg
-              viewBox="0 0 16 16"
-              className="h-5 w-5 shrink-0"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-            </svg>
-            <CardTitle className="text-base">
-              <a
-                href={repo.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 hover:underline"
-              >
-                {repo.owner}/{repo.repo}
-                <ExternalLink className="h-3.5 w-3.5 opacity-50" />
-              </a>
-            </CardTitle>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        {repo.unavailable && (
-          <p className="text-sm text-muted-foreground">
-            GitHub could not be reached, so this repository&apos;s details are unavailable.
-          </p>
-        )}
-        {repo.description && (
-          <p className="text-sm text-muted-foreground line-clamp-2">{repo.description}</p>
-        )}
-
-        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-          {repo.language && (
-            <div className="flex items-center gap-1">
-              <Code2 className="h-4 w-4" />
-              <span>{repo.language}</span>
-            </div>
-          )}
-          <div className="flex items-center gap-1">
-            <Star className="h-4 w-4" />
-            {/* Never render a placeholder count as a real one. */}
-            <span>{repo.unavailable ? '—' : repo.stars.toLocaleString()}</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <GitFork className="h-4 w-4" />
-            <span>{repo.unavailable ? '—' : repo.forks.toLocaleString()}</span>
-          </div>
-          {repo.license && (
-            <div className="flex items-center gap-1">
-              <Scale className="h-4 w-4" />
-              <span>{repo.license}</span>
-            </div>
-          )}
-        </div>
-
-        {repo.topics && repo.topics.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {repo.topics.slice(0, 5).map((topic) => (
-              <Badge key={topic} variant="secondary" className="text-xs">
-                {topic}
-              </Badge>
-            ))}
-            {repo.topics.length > 5 && (
-              <Badge variant="outline" className="text-xs">
-                +{repo.topics.length - 5}
-              </Badge>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+    <ResourceCard
+      className={className}
+      icon={GithubMark}
+      iconColor="text-gray-900 dark:text-gray-100"
+      iconBg="bg-gray-100 dark:bg-gray-800"
+      title={`${repo.owner}/${repo.repo}`}
+      badge="GitHub"
+      description={
+        repo.unavailable
+          ? 'GitHub could not be reached, so this repository’s details are unavailable.'
+          : (repo.description ?? undefined)
+      }
+      stats={stats}
+      tags={repo.topics}
+      href={repo.url}
+    />
   );
 }

--- a/web/components/integrations/gitlab-project-card.tsx
+++ b/web/components/integrations/gitlab-project-card.tsx
@@ -1,11 +1,17 @@
 'use client';
 
-import { ExternalLink, Star, GitFork, Eye, EyeOff } from 'lucide-react';
+/**
+ * A GitLab project, rendered as the page's standard link card.
+ *
+ * @packageDocumentation
+ */
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib/utils';
+import { Star, GitFork, Eye, EyeOff } from 'lucide-react';
+
+import { ResourceCard, type ResourceStat } from '@/components/links/resource-card';
 import type { GitLabIntegration } from '@/lib/hooks/use-integrations';
+
+import { GitlabMark } from './brand-marks';
 
 export interface GitLabProjectCardProps {
   project: GitLabIntegration;
@@ -13,79 +19,42 @@ export interface GitLabProjectCardProps {
 }
 
 /**
- * Displays GitLab project information as a card.
+ * Displays GitLab project information.
  *
- * @remarks
- * Shows project metadata including stars, forks, visibility, and topics.
- * Links to the GitLab project.
+ * @param props - Component props
+ * @returns The card
+ *
+ * @public
  */
 export function GitLabProjectCard({ project, className }: GitLabProjectCardProps) {
   const isPublic = project.visibility === 'public';
 
+  const stats: ResourceStat[] = [
+    { icon: isPublic ? Eye : EyeOff, label: project.visibility },
+    // Never render a placeholder count as a real one.
+    {
+      icon: Star,
+      label: project.unavailable ? '—' : project.stars.toLocaleString(),
+      title: 'Stars',
+    },
+    {
+      icon: GitFork,
+      label: project.unavailable ? '—' : project.forks.toLocaleString(),
+      title: 'Forks',
+    },
+  ];
+
   return (
-    <Card className={cn('overflow-hidden', className)}>
-      <CardHeader className="pb-2">
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <svg viewBox="0 0 32 32" className="h-5 w-5 shrink-0" aria-hidden="true">
-              <path fill="#E24329" d="M16 31.2L21.2 16H10.8L16 31.2z" />
-              <path fill="#FC6D26" d="M16 31.2L10.8 16H2L16 31.2z" />
-              <path fill="#FCA326" d="M2 16L.1 21.8c-.2.5 0 1.1.5 1.4L16 31.2L2 16z" />
-              <path fill="#E24329" d="M2 16h8.8L7.5 5.4c-.1-.4-.7-.4-.9 0L2 16z" />
-              <path fill="#FC6D26" d="M16 31.2L21.2 16H30L16 31.2z" />
-              <path fill="#FCA326" d="M30 16l1.9 5.8c.2.5 0 1.1-.5 1.4L16 31.2L30 16z" />
-              <path fill="#E24329" d="M30 16h-8.8l3.3-10.6c.1-.4.7-.4.9 0L30 16z" />
-            </svg>
-            <CardTitle className="text-base">
-              <a
-                href={project.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 hover:underline"
-              >
-                {project.pathWithNamespace}
-                <ExternalLink className="h-3.5 w-3.5 opacity-50" />
-              </a>
-            </CardTitle>
-          </div>
-          <Badge variant={isPublic ? 'outline' : 'secondary'} className="shrink-0">
-            {isPublic ? <Eye className="mr-1 h-3 w-3" /> : <EyeOff className="mr-1 h-3 w-3" />}
-            {project.visibility}
-          </Badge>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        {project.description && (
-          <p className="text-sm text-muted-foreground line-clamp-2">{project.description}</p>
-        )}
-
-        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-          <div className="flex items-center gap-1">
-            <Star className="h-4 w-4" />
-            {/* Never render a placeholder count as a real one. */}
-            <span>{project.unavailable ? '—' : project.stars.toLocaleString()}</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <GitFork className="h-4 w-4" />
-            <span>{project.unavailable ? '—' : project.forks.toLocaleString()}</span>
-          </div>
-        </div>
-
-        {project.topics && project.topics.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {project.topics.slice(0, 5).map((topic) => (
-              <Badge key={topic} variant="secondary" className="text-xs">
-                {topic}
-              </Badge>
-            ))}
-            {project.topics.length > 5 && (
-              <Badge variant="outline" className="text-xs">
-                +{project.topics.length - 5}
-              </Badge>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+    <ResourceCard
+      className={className}
+      icon={GitlabMark}
+      iconBg="bg-orange-50 dark:bg-orange-950"
+      title={project.pathWithNamespace}
+      badge="GitLab"
+      description={project.description ?? undefined}
+      stats={stats}
+      tags={project.topics}
+      href={project.url}
+    />
   );
 }

--- a/web/components/integrations/software-heritage-badge.tsx
+++ b/web/components/integrations/software-heritage-badge.tsx
@@ -3,6 +3,7 @@
 import { ExternalLink, Check, X, Clock } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
+import { ResourceCard, type ResourceStat } from '@/components/links/resource-card';
 import { cn } from '@/lib/utils';
 import type { SoftwareHeritageIntegration } from '@/lib/hooks/use-integrations';
 
@@ -53,51 +54,30 @@ export function SoftwareHeritageBadge({
     );
   }
 
-  // Card variant
+  // Card variant, in the page's standard shape. What is archived, and when it
+  // was last seen, are the two things a reader wants from this card.
+  const stats: ResourceStat[] = [
+    { icon: data.archived ? Check : Clock, label: data.archived ? 'Archived' : 'Not yet archived' },
+  ];
+  if (data.archived && data.lastVisit) {
+    stats.push({ label: `Last visit ${new Date(data.lastVisit).toLocaleDateString()}` });
+  }
+  if (data.archived && data.lastSnapshotSwhid) {
+    stats.push({ label: `${data.lastSnapshotSwhid.slice(0, 24)}…`, title: data.lastSnapshotSwhid });
+  }
+
   return (
-    <a
+    <ResourceCard
+      className={className}
+      icon={data.archived ? Check : X}
+      iconColor="text-white"
+      iconBg={data.archived ? 'bg-emerald-600' : 'bg-amber-600'}
+      title="Software Heritage"
+      badge="Archive"
+      subtitle={data.originUrl}
+      subtitleMono
+      stats={stats}
       href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn(
-        'flex flex-col gap-2 rounded-lg border p-4 transition-colors hover:bg-muted/50 no-underline',
-        className
-      )}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <div
-            className={cn(
-              'flex h-8 w-8 items-center justify-center rounded-md text-white',
-              data.archived ? 'bg-emerald-600' : 'bg-amber-600'
-            )}
-          >
-            {data.archived ? <Check className="h-4 w-4" /> : <X className="h-4 w-4" />}
-          </div>
-          <div>
-            <div className="text-sm font-medium">Software Heritage</div>
-            <div className="text-xs text-muted-foreground">
-              {data.archived ? 'Archived' : 'Not yet archived'}
-            </div>
-          </div>
-        </div>
-        <ExternalLink className="h-4 w-4 text-muted-foreground shrink-0" />
-      </div>
-
-      <p className="text-xs text-muted-foreground line-clamp-1 font-mono">{data.originUrl}</p>
-
-      {data.archived && data.lastVisit && (
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge variant="outline" className="text-xs">
-            Last visit: {new Date(data.lastVisit).toLocaleDateString()}
-          </Badge>
-          {data.lastSnapshotSwhid && (
-            <Badge variant="secondary" className="text-xs font-mono truncate max-w-[200px]">
-              {data.lastSnapshotSwhid.slice(0, 30)}...
-            </Badge>
-          )}
-        </div>
-      )}
-    </a>
+    />
   );
 }

--- a/web/components/integrations/zenodo-badge.tsx
+++ b/web/components/integrations/zenodo-badge.tsx
@@ -3,6 +3,7 @@
 import { ExternalLink, Download, Eye, Archive, Lock, Unlock } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
+import { ResourceCard, type ResourceStat } from '@/components/links/resource-card';
 import { cn } from '@/lib/utils';
 import type { ZenodoIntegration } from '@/lib/hooks/use-integrations';
 
@@ -20,9 +21,6 @@ export interface ZenodoBadgeProps {
  * Links to the Zenodo record page.
  */
 export function ZenodoBadge({ record, variant = 'badge', className }: ZenodoBadgeProps) {
-  const accessIcon =
-    record.accessRight === 'open' ? <Unlock className="h-3 w-3" /> : <Lock className="h-3 w-3" />;
-
   if (variant === 'badge') {
     return (
       <a
@@ -43,59 +41,31 @@ export function ZenodoBadge({ record, variant = 'badge', className }: ZenodoBadg
     );
   }
 
-  // Card variant
+  // Card variant. The same shape as every other link on the page: the record
+  // leads, the service names itself beside it, and what Zenodo knows about the
+  // deposit -- type, access, version, views, downloads -- reads as facts under
+  // it rather than as a row of unlabelled badges.
+  const stats: ResourceStat[] = [
+    { label: record.resourceType },
+    { icon: record.accessRight === 'open' ? Unlock : Lock, label: record.accessRight },
+  ];
+  if (record.version) stats.push({ label: `v${record.version}` });
+  if (record.stats) {
+    stats.push({ icon: Eye, label: `${record.stats.views.toLocaleString()} views` });
+    stats.push({ icon: Download, label: `${record.stats.downloads.toLocaleString()} downloads` });
+  }
+
   return (
-    <a
+    <ResourceCard
+      className={className}
+      icon={Archive}
+      iconColor="text-white"
+      iconBg="bg-[#024C79]"
+      title={record.doi}
+      badge="Zenodo"
+      description={record.title}
+      stats={stats}
       href={record.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn(
-        'flex flex-col gap-2 rounded-lg border p-4 transition-colors hover:bg-muted/50 no-underline',
-        className
-      )}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-[#024C79] text-white">
-            <Archive className="h-4 w-4" />
-          </div>
-          <div>
-            <div className="text-sm font-medium">Zenodo</div>
-            <div className="text-xs text-muted-foreground font-mono">{record.doi}</div>
-          </div>
-        </div>
-        <ExternalLink className="h-4 w-4 text-muted-foreground shrink-0" />
-      </div>
-
-      <p className="text-sm text-muted-foreground line-clamp-2">{record.title}</p>
-
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant="secondary" className="text-xs">
-          {record.resourceType}
-        </Badge>
-        <Badge variant="outline" className="text-xs gap-1">
-          {accessIcon}
-          {record.accessRight}
-        </Badge>
-        {record.version && (
-          <Badge variant="outline" className="text-xs">
-            v{record.version}
-          </Badge>
-        )}
-      </div>
-
-      {record.stats && (
-        <div className="flex items-center gap-4 text-xs text-muted-foreground">
-          <div className="flex items-center gap-1">
-            <Eye className="h-3 w-3" />
-            <span>{record.stats.views.toLocaleString()} views</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <Download className="h-3 w-3" />
-            <span>{record.stats.downloads.toLocaleString()} downloads</span>
-          </div>
-        </div>
-      )}
-    </a>
+    />
   );
 }

--- a/web/components/links/resource-card.test.tsx
+++ b/web/components/links/resource-card.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for the shared link card.
+ *
+ * @remarks
+ * Every link on an eprint page renders through this, so the contract worth
+ * holding is that each optional field is genuinely optional and that the two
+ * link modes stay distinct: a card with one destination is itself the link,
+ * and a card with several never nests one anchor inside another.
+ *
+ * @packageDocumentation
+ */
+
+import { render, screen } from '@testing-library/react';
+import { Github } from 'lucide-react';
+import { describe, expect, it } from 'vitest';
+
+import { ResourceCard } from './resource-card';
+
+describe('ResourceCard', () => {
+  it('renders with nothing but an icon and a title', () => {
+    render(<ResourceCard icon={Github} title="Bare" />);
+    expect(screen.getByText('Bare')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('makes the whole card one link when there is one destination', () => {
+    render(<ResourceCard icon={Github} title="Repo" href="https://github.com/a/b" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://github.com/a/b');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveTextContent('Repo');
+  });
+
+  it('renders actions instead of wrapping, so no anchor nests inside another', () => {
+    render(
+      <ResourceCard
+        icon={Github}
+        title="Record"
+        href="https://ignored.example"
+        actions={[
+          { label: 'Open in Leaflet', href: 'https://leaflet.pub/x' },
+          { label: 'View record', href: 'https://pdsls.dev/at://x' },
+        ]}
+      />
+    );
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links.map((l) => l.getAttribute('href'))).toEqual([
+      'https://leaflet.pub/x',
+      'https://pdsls.dev/at://x',
+    ]);
+  });
+
+  it('downloads rather than opening when an action says so', () => {
+    render(
+      <ResourceCard
+        icon={Github}
+        title="File"
+        actions={[{ label: 'Download', href: 'https://pds.example/blob', download: true }]}
+      />
+    );
+    const link = screen.getByRole('link', { name: /download/i });
+    expect(link).toHaveAttribute('download');
+    // A download that opens a tab first leaves an empty one behind.
+    expect(link).not.toHaveAttribute('target');
+  });
+
+  it('shows badge, subtitle, description and stats when given them', () => {
+    render(
+      <ResourceCard
+        icon={Github}
+        title="chive"
+        badge="GitHub"
+        subtitle="github.com/aaronstevenwhite/chive"
+        description="A decentralized eprint service."
+        stats={[{ label: '12 stars' }, { label: 'MIT' }]}
+      />
+    );
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText('github.com/aaronstevenwhite/chive')).toBeInTheDocument();
+    expect(screen.getByText('A decentralized eprint service.')).toBeInTheDocument();
+    expect(screen.getByText('12 stars')).toBeInTheDocument();
+    expect(screen.getByText('MIT')).toBeInTheDocument();
+  });
+
+  it('lets a URI break anywhere, so a long one cannot widen the page', () => {
+    render(
+      <ResourceCard icon={Github} title="Record" subtitle="at://did:plc:x/c/r" subtitleMono />
+    );
+    expect(screen.getByText('at://did:plc:x/c/r').className).toContain('break-all');
+  });
+
+  it('renders anything it is given below its own content', () => {
+    render(
+      <ResourceCard icon={Github} title="Dataset">
+        <p>snippet</p>
+      </ResourceCard>
+    );
+    expect(screen.getByText('snippet')).toBeInTheDocument();
+  });
+});

--- a/web/components/links/resource-card.test.tsx
+++ b/web/components/links/resource-card.test.tsx
@@ -91,6 +91,17 @@ describe('ResourceCard', () => {
     expect(screen.getByText('at://did:plc:x/c/r').className).toContain('break-all');
   });
 
+  it('will not wrap a card that carries something interactive of its own', () => {
+    // A button nested inside a link is not something a browser can represent.
+    render(
+      <ResourceCard icon={Github} title="Dataset" href="https://example.org">
+        <button type="button">Load in Python</button>
+      </ResourceCard>
+    );
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Load in Python' })).toBeInTheDocument();
+  });
+
   it('renders anything it is given below its own content', () => {
     render(
       <ResourceCard icon={Github} title="Dataset">

--- a/web/components/links/resource-card.tsx
+++ b/web/components/links/resource-card.tsx
@@ -137,7 +137,10 @@ export function ResourceCard({
   children,
   className,
 }: ResourceCardProps) {
-  const linkWraps = Boolean(href) && !actions?.length;
+  // Wrapping the card in an anchor is only safe when nothing inside it is
+  // interactive: a button nested in a link is not something a browser can
+  // represent, and the dataset snippet a card can carry has one.
+  const linkWraps = Boolean(href) && !actions?.length && !children;
 
   const body = (
     <div className="flex items-start gap-3">

--- a/web/components/links/resource-card.tsx
+++ b/web/components/links/resource-card.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+/**
+ * One card shape for every link on an eprint page.
+ *
+ * @remarks
+ * A paper's links were rendered four different ways depending on which tab
+ * they landed on. The repository panel had a tinted icon and a platform badge;
+ * the external identifiers panel had a flat row with a monospaced value;
+ * backlinks had a small grey icon and a line of context; the GitHub integration
+ * card had a title, a description, and a row of statistics. The last of those
+ * was the one worth keeping, and the difference between them was not carrying
+ * any meaning -- a reader cannot learn anything from the fact that a DOI is
+ * styled unlike a repository.
+ *
+ * So all of them render through this. The card is deliberately uniform and
+ * deliberately roomy: an icon that identifies the service, a title, a badge
+ * naming the service, a subtitle carrying the part of the address a reader
+ * would actually read, a description, a row of small facts, and the ways in.
+ * Every field but the icon and the title is optional, so a card with nothing
+ * but a DOI is the same card as one with stars, forks, and a licence.
+ *
+ * @packageDocumentation
+ */
+
+import { ExternalLink } from 'lucide-react';
+import type { ComponentType, ReactNode } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+/** A small labelled fact shown in the card's footer row. */
+export interface ResourceStat {
+  /** Optional leading icon. */
+  readonly icon?: ComponentType<{ className?: string }>;
+  /** The fact itself, already formatted. */
+  readonly label: string;
+  /** Screen-reader name, when the label alone would not say what it counts. */
+  readonly title?: string;
+}
+
+/** A way into the resource. */
+export interface ResourceAction {
+  /** Link text. */
+  readonly label: string;
+  /** Where it goes. */
+  readonly href: string;
+  /**
+   * Saves the target rather than opening it.
+   *
+   * @remarks
+   * A supplementary file is fetched, not visited, and a download that opens a
+   * new tab first leaves an empty one behind.
+   */
+  readonly download?: boolean;
+  /** Leading icon, where one says what the action does faster than the words. */
+  readonly icon?: ComponentType<{ className?: string }>;
+}
+
+/**
+ * Props for {@link ResourceCard}.
+ *
+ * @public
+ */
+export interface ResourceCardProps {
+  /** Service or resource icon. */
+  readonly icon: ComponentType<{ className?: string }>;
+  /** Tailwind text colour for the icon. */
+  readonly iconColor?: string;
+  /** Tailwind background for the icon tile. */
+  readonly iconBg?: string;
+  /** What this resource is called. */
+  readonly title: string;
+  /** The service it lives on, shown as a badge beside the title. */
+  readonly badge?: string;
+  /**
+   * The address, or the part of it worth reading.
+   *
+   * @remarks
+   * `owner/repo` for a repository, `host/path` for anything else on the web,
+   * the AT-URI for a record. This is the field that turns a card headed
+   * "GitHub" into one that says which repository it means.
+   */
+  readonly subtitle?: string;
+  /** Renders the subtitle monospaced, for an identifier or a URI. */
+  readonly subtitleMono?: boolean;
+  /** A sentence or two about the resource. */
+  readonly description?: string;
+  /** Small facts: stars, a date, a record key. */
+  readonly stats?: readonly ResourceStat[];
+  /**
+   * Short keywords the resource carries.
+   *
+   * @remarks
+   * GitHub topics, GitLab topics, Zenodo keywords. Capped on render, because
+   * a repository with forty topics would otherwise be the tallest card on the
+   * page.
+   */
+  readonly tags?: readonly string[];
+  /**
+   * Makes the whole card a link.
+   *
+   * @remarks
+   * Used when there is exactly one place to go. A card with `actions` renders
+   * those instead, because a link inside a link is not a thing a browser can
+   * represent.
+   */
+  readonly href?: string;
+  /** Ways in, when there is more than one or the card is not itself a link. */
+  readonly actions?: readonly ResourceAction[];
+  /** Anything the card should carry below its own content. */
+  readonly children?: ReactNode;
+  readonly className?: string;
+}
+
+/**
+ * Renders one linked resource.
+ *
+ * @param props - Component props
+ * @returns The card
+ *
+ * @public
+ */
+export function ResourceCard({
+  icon: Icon,
+  iconColor = 'text-muted-foreground',
+  iconBg = 'bg-muted',
+  title,
+  badge,
+  subtitle,
+  subtitleMono,
+  description,
+  stats,
+  tags,
+  href,
+  actions,
+  children,
+  className,
+}: ResourceCardProps) {
+  const linkWraps = Boolean(href) && !actions?.length;
+
+  const body = (
+    <div className="flex items-start gap-3">
+      <div className={cn('shrink-0 rounded-md p-2', iconBg)}>
+        <Icon className={cn('h-5 w-5', iconColor)} />
+      </div>
+
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="min-w-0 break-words font-medium leading-tight">{title}</span>
+          {badge && (
+            <Badge variant="outline" className="shrink-0 text-xs font-normal">
+              {badge}
+            </Badge>
+          )}
+        </div>
+
+        {subtitle && (
+          <p
+            className={cn(
+              'text-xs text-muted-foreground',
+              // A URI has no spaces to wrap at, so it has to be allowed to
+              // break anywhere or it pushes the card off a narrow screen.
+              subtitleMono ? 'break-all font-mono' : 'break-words'
+            )}
+          >
+            {subtitle}
+          </p>
+        )}
+
+        {description && <p className="line-clamp-3 text-sm text-muted-foreground">{description}</p>}
+
+        {stats && stats.length > 0 && (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-0.5 text-xs text-muted-foreground">
+            {stats.map((stat, index) => {
+              const StatIcon = stat.icon;
+              return (
+                // Two stats can carry the same text -- an unreachable upstream
+                // renders both counts as an em dash -- so the position is the
+                // only key that stays unique.
+                // eslint-disable-next-line react/no-array-index-key
+                <span
+                  key={`${stat.label}-${index}`}
+                  className="flex items-center gap-1"
+                  title={stat.title}
+                >
+                  {StatIcon && <StatIcon className="h-3.5 w-3.5" />}
+                  {stat.label}
+                </span>
+              );
+            })}
+          </div>
+        )}
+
+        {tags && tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 pt-1">
+            {tags.slice(0, 5).map((tag) => (
+              <Badge key={tag} variant="secondary" className="text-xs font-normal">
+                {tag}
+              </Badge>
+            ))}
+            {tags.length > 5 && (
+              <Badge variant="outline" className="text-xs font-normal">
+                +{tags.length - 5}
+              </Badge>
+            )}
+          </div>
+        )}
+
+        {actions && actions.length > 0 && (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-1">
+            {actions.map((action) => {
+              const ActionIcon = action.icon ?? ExternalLink;
+              return (
+                <a
+                  key={`${action.label}-${action.href}`}
+                  href={action.href}
+                  {...(action.download
+                    ? { download: true }
+                    : { target: '_blank', rel: 'noopener noreferrer' })}
+                  className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                >
+                  {action.label}
+                  <ActionIcon className="h-3 w-3" />
+                </a>
+              );
+            })}
+          </div>
+        )}
+
+        {children}
+      </div>
+
+      {linkWraps && (
+        <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+      )}
+    </div>
+  );
+
+  const shell = cn('rounded-lg border bg-card p-3', className);
+
+  if (linkWraps) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn('group block transition-colors hover:bg-accent/50', shell)}
+      >
+        {body}
+      </a>
+    );
+  }
+
+  return <div className={shell}>{body}</div>;
+}

--- a/web/lib/atproto/at-uri-links.test.ts
+++ b/web/lib/atproto/at-uri-links.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for AT-URI and URL link resolution.
+ *
+ * @remarks
+ * The two things worth holding this to are the two things that were wrong
+ * before it existed: a link must never be built from Chive's `sourceType`
+ * when the record's own collection disagrees with it, and a link must never be
+ * offered on an application's domain unless that route was checked.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  describeAtUri,
+  describeUrl,
+  parseAtUri,
+  recordBrowserUrl,
+  summarizeUrl,
+} from './at-uri-links';
+
+const DID = 'did:plc:34mbm5v3umztwvvgnttvcz6e';
+
+describe('parseAtUri', () => {
+  it('splits a record URI into its three parts', () => {
+    expect(parseAtUri(`at://${DID}/pub.leaflet.document/3abc`)).toEqual({
+      did: DID,
+      collection: 'pub.leaflet.document',
+      rkey: '3abc',
+    });
+  });
+
+  it('accepts a handle in place of a DID', () => {
+    expect(parseAtUri('at://alice.example/app.bsky.feed.post/3abc')?.did).toBe('alice.example');
+  });
+
+  it('rejects a URI that names no record', () => {
+    expect(parseAtUri(`at://${DID}`)).toBeNull();
+    expect(parseAtUri(`at://${DID}/pub.leaflet.document`)).toBeNull();
+    expect(parseAtUri('https://example.org/thing')).toBeNull();
+    expect(parseAtUri('')).toBeNull();
+  });
+});
+
+describe('describeAtUri', () => {
+  it('names the application from the collection, not from a source type', () => {
+    // The Leaflet plugin files comments under sourceType `leaflet.document`.
+    // The collection is the only thing that tells them apart.
+    expect(describeAtUri(`at://${DID}/pub.leaflet.comment/3abc`)).toMatchObject({
+      appName: 'Leaflet',
+      kind: 'Comment',
+    });
+    expect(describeAtUri(`at://${DID}/pub.leaflet.document/3abc`)).toMatchObject({
+      appName: 'Leaflet',
+      kind: 'Document',
+    });
+  });
+
+  it('offers a Smoke Signal address for a calendar event', () => {
+    // Checked against a live record: this address renders the event.
+    expect(describeAtUri(`at://${DID}/community.lexicon.calendar.event/3xyz`)?.webUrl).toBe(
+      `https://smokesignal.events/${DID}/3xyz`
+    );
+  });
+
+  it('offers a Bluesky address for a post', () => {
+    expect(describeAtUri(`at://${DID}/app.bsky.feed.post/3xyz`)?.webUrl).toBe(
+      `https://bsky.app/profile/${DID}/post/3xyz`
+    );
+  });
+
+  it('offers no application address where the route is unverified', () => {
+    // A `network.cosmik.card` was previously linked as though it were a Cosmik
+    // collection, which 404s. No link is better than a wrong one.
+    expect(describeAtUri(`at://${DID}/network.cosmik.card/3abc`)?.webUrl).toBeUndefined();
+    expect(describeAtUri(`at://${DID}/network.cosmik.connection/3abc`)?.webUrl).toBeUndefined();
+    expect(describeAtUri(`at://${DID}/at.margin.note/3abc`)?.webUrl).toBeUndefined();
+    expect(describeAtUri(`at://${DID}/site.standard.document/3abc`)?.webUrl).toBeUndefined();
+  });
+
+  it('always offers a record address, whatever the collection', () => {
+    for (const collection of [
+      'network.cosmik.card',
+      'at.margin.note',
+      'site.standard.document',
+      'com.example.entirely.unknown',
+    ]) {
+      const uri = `at://${DID}/${collection}/3abc`;
+      expect(describeAtUri(uri)?.recordUrl).toBe(`https://pdsls.dev/${uri}`);
+    }
+  });
+
+  it('falls back to the collection name for an application it has never heard of', () => {
+    const described = describeAtUri(`at://${DID}/com.example.newthing/3abc`);
+    expect(described).toMatchObject({ appName: 'com.example.newthing', kind: 'Record' });
+    expect(described?.webUrl).toBeUndefined();
+  });
+
+  it('returns nothing for a string that is not an AT-URI', () => {
+    expect(describeAtUri('https://github.com/x/y')).toBeNull();
+  });
+});
+
+describe('recordBrowserUrl', () => {
+  it('addresses the record itself', () => {
+    expect(recordBrowserUrl(`at://${DID}/at.margin.note/3abc`)).toBe(
+      `https://pdsls.dev/at://${DID}/at.margin.note/3abc`
+    );
+  });
+});
+
+describe('describeUrl', () => {
+  it('keeps the part of the address a reader would read', () => {
+    expect(describeUrl('https://github.com/aaronstevenwhite/chive')).toEqual({
+      host: 'github.com',
+      path: '/aaronstevenwhite/chive',
+    });
+  });
+
+  it('drops the noise', () => {
+    expect(describeUrl('https://www.osf.io/abc123/')).toEqual({ host: 'osf.io', path: '/abc123' });
+    expect(describeUrl('https://github.com/a/b.git')).toEqual({ host: 'github.com', path: '/a/b' });
+    expect(describeUrl('https://example.org/')).toEqual({ host: 'example.org', path: '' });
+  });
+
+  it('refuses anything that is not a web address', () => {
+    expect(describeUrl(`at://${DID}/x/y`)).toBeNull();
+    expect(describeUrl('javascript:alert(1)')).toBeNull();
+    expect(describeUrl('not a url')).toBeNull();
+  });
+});
+
+describe('summarizeUrl', () => {
+  it('reads as host and path', () => {
+    expect(summarizeUrl('https://github.com/aaronstevenwhite/chive')).toBe(
+      'github.com/aaronstevenwhite/chive'
+    );
+  });
+
+  it('returns the input unchanged when it will not parse', () => {
+    expect(summarizeUrl('not a url')).toBe('not a url');
+  });
+});

--- a/web/lib/atproto/at-uri-links.ts
+++ b/web/lib/atproto/at-uri-links.ts
@@ -1,0 +1,251 @@
+/**
+ * Turning AT-URIs and web URLs into something a reader can act on.
+ *
+ * @remarks
+ * A paper on Chive is referred to from two kinds of place. Some of them are
+ * ordinary web addresses -- a GitHub repository, an OSF project -- and some of
+ * them are records in the atmosphere, which have no web address at all until
+ * some application decides to render them. The link surfaces on an eprint page
+ * have to handle both, and until now they handled them differently and badly:
+ * a web URL was shown as its own href and nothing else, and a record was shown
+ * as a guessed URL on the publishing app's domain.
+ *
+ * Two of those guesses were wrong. `cosmik.network/collection/{did}/{rkey}`
+ * was built from a `network.cosmik.card`, which is not a collection, and 404s.
+ * Every record link was built from `sourceType`, which the Leaflet plugin
+ * assigns as `leaflet.document` for comments as well as documents.
+ *
+ * So this module keys off the collection NSID in the URI itself, which is the
+ * one thing that cannot be wrong, and it distinguishes two levels of
+ * confidence. An app link is offered only where the route was checked against
+ * a live record. A record link -- the URI opened in a public record browser --
+ * is offered for everything, because it always resolves.
+ *
+ * @packageDocumentation
+ */
+
+/** The three parts of an AT-URI that name a record. */
+export interface AtUriParts {
+  /** Repository the record lives in, as a DID or a handle. */
+  readonly did: string;
+  /** Collection NSID, e.g. `pub.leaflet.document`. */
+  readonly collection: string;
+  /** Record key. */
+  readonly rkey: string;
+}
+
+/**
+ * Splits an AT-URI into repository, collection, and record key.
+ *
+ * @param uri - An AT-URI naming a record
+ * @returns Its parts, or `null` when the string is not one
+ *
+ * @public
+ */
+export function parseAtUri(uri: string): AtUriParts | null {
+  const match = /^at:\/\/([^/]+)\/([^/]+)\/(.+)$/.exec(uri);
+  if (!match) return null;
+  const [, did, collection, rkey] = match;
+  if (!did || !collection || !rkey) return null;
+  return { did, collection, rkey };
+}
+
+/**
+ * A public record browser that renders any AT-URI.
+ *
+ * @param uri - An AT-URI
+ * @returns An address that shows the record itself
+ *
+ * @remarks
+ * This is the link that is always correct. It reads the record from whichever
+ * PDS holds it, so it works for a record type no application on the network
+ * renders yet -- which, for a good deal of what references a paper, is the
+ * situation.
+ *
+ * @public
+ */
+export function recordBrowserUrl(uri: string): string {
+  return `https://pdsls.dev/${uri}`;
+}
+
+/**
+ * What an application is called, and where it renders its records.
+ */
+interface AtmosphereApp {
+  /** The application's name, as its own users would say it. */
+  readonly name: string;
+  /** What one of these records is, in one or two words. */
+  readonly kind: string;
+  /**
+   * Builds the application's own address for a record.
+   *
+   * @remarks
+   * Present only where the route was checked against a real record. Absent is
+   * the honest answer for an app whose web routing is private or unsettled,
+   * and it costs nothing: {@link recordBrowserUrl} still applies.
+   */
+  readonly webUrl?: (parts: AtUriParts) => string;
+}
+
+/**
+ * The record types that reference a paper, by collection NSID.
+ *
+ * @remarks
+ * Keyed on the NSID rather than on Chive's `sourceType` because the NSID is
+ * carried in the URI and cannot disagree with the record, whereas `sourceType`
+ * is assigned by whichever plugin indexed it and is coarser than the records
+ * it covers.
+ */
+const APPS: Record<string, AtmosphereApp> = {
+  'pub.leaflet.document': {
+    name: 'Leaflet',
+    kind: 'Document',
+    webUrl: ({ did, rkey }) => `https://leaflet.pub/${did}/${rkey}`,
+  },
+  'pub.leaflet.comment': {
+    name: 'Leaflet',
+    kind: 'Comment',
+  },
+  'network.cosmik.card': {
+    name: 'Cosmik',
+    kind: 'Card',
+  },
+  'network.cosmik.connection': {
+    name: 'Cosmik',
+    kind: 'Connection',
+  },
+  'network.cosmik.collection': {
+    name: 'Cosmik',
+    kind: 'Collection',
+  },
+  'site.standard.document': {
+    name: 'standard.site',
+    kind: 'Document',
+  },
+  'site.standard.publication': {
+    name: 'standard.site',
+    kind: 'Publication',
+  },
+  // Verified against a live record: smokesignal.events renders a
+  // `community.lexicon.calendar.event` at this address, titled from the event.
+  'community.lexicon.calendar.event': {
+    name: 'Smoke Signal',
+    kind: 'Event',
+    webUrl: ({ did, rkey }) => `https://smokesignal.events/${did}/${rkey}`,
+  },
+  'events.smokesignal.calendar.event': {
+    name: 'Smoke Signal',
+    kind: 'Event',
+    webUrl: ({ did, rkey }) => `https://smokesignal.events/${did}/${rkey}`,
+  },
+  'at.margin.note': {
+    name: 'Margin',
+    kind: 'Note',
+  },
+  'at.margin.reply': {
+    name: 'Margin',
+    kind: 'Reply',
+  },
+  'app.bsky.feed.post': {
+    name: 'Bluesky',
+    kind: 'Post',
+    webUrl: ({ did, rkey }) => `https://bsky.app/profile/${did}/post/${rkey}`,
+  },
+  'pub.layers.catalog.collection': {
+    name: 'Layers',
+    kind: 'Dataset',
+  },
+  'pub.layers.corpus.corpus': {
+    name: 'Layers',
+    kind: 'Corpus',
+  },
+  'pub.layers.eprint.dataLink': {
+    name: 'Layers',
+    kind: 'Data link',
+  },
+  'sh.tangled.repo': {
+    name: 'Tangled',
+    kind: 'Repository',
+  },
+};
+
+/** How a record should be presented, and where it can be opened. */
+export interface AtmosphereRecord extends AtUriParts {
+  /** The publishing application's name, or the NSID when it is unknown. */
+  readonly appName: string;
+  /** What this record is, in one or two words. */
+  readonly kind: string;
+  /** The application's own address for it, when one is known to work. */
+  readonly webUrl?: string;
+  /** A record browser address, which always works. */
+  readonly recordUrl: string;
+}
+
+/**
+ * Describes a record named by an AT-URI.
+ *
+ * @param uri - An AT-URI
+ * @returns How to name and open the record, or `null` if the URI is malformed
+ *
+ * @remarks
+ * An unrecognized collection is not a failure. The NSID stands in for the
+ * application's name and `Record` for the kind, and the record browser link is
+ * unaffected -- a new app in the ecosystem shows up as a usable card the day it
+ * first cites a paper, rather than waiting for Chive to learn its name.
+ *
+ * @public
+ */
+export function describeAtUri(uri: string): AtmosphereRecord | null {
+  const parts = parseAtUri(uri);
+  if (!parts) return null;
+  const app = APPS[parts.collection];
+  const webUrl = app?.webUrl?.(parts);
+  return {
+    ...parts,
+    appName: app?.name ?? parts.collection,
+    kind: app?.kind ?? 'Record',
+    ...(webUrl ? { webUrl } : {}),
+    recordUrl: recordBrowserUrl(uri),
+  };
+}
+
+/**
+ * The readable part of a web address.
+ *
+ * @param url - An absolute http(s) URL
+ * @returns Host and path, with the noise removed, or `null` if it will not parse
+ *
+ * @remarks
+ * A card headed "GitHub" says less than one headed "GitHub" over
+ * `aaronstevenwhite/chive`, and the second costs nothing: the detail is
+ * already in the URL, it was simply not being shown. The `www.` prefix, the
+ * trailing slash and a `.git` suffix are dropped because they are never the
+ * information a reader wanted.
+ *
+ * @public
+ */
+export function describeUrl(url: string): { host: string; path: string } | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    const host = parsed.hostname.replace(/^www\./, '');
+    const path = parsed.pathname.replace(/\.git$/, '').replace(/\/$/, '');
+    return { host, path: path === '/' ? '' : path };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A one-line description of where a link goes.
+ *
+ * @param url - An absolute http(s) URL
+ * @returns `host/path`, or the URL unchanged when it will not parse
+ *
+ * @public
+ */
+export function summarizeUrl(url: string): string {
+  const parts = describeUrl(url);
+  if (!parts) return url;
+  return `${parts.host}${parts.path}`;
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Every link on an eprint page now renders through one card, and the references a paper collects from elsewhere on the network get a tab of their own.

**Atmosphere tab.** References from other applications used to sit at the bottom of the Citations tab as collapsed accordions that fetched nothing until opened, with section names taken from the counts endpoint — which buckets five ways, so a talk, a standard.site document, a Margin annotation and a Cosmik connection all hid behind "Other Sources". They now have a tab, loaded at once, filterable by publishing application, counted on the tab itself, with an empty state where a paper has none.

**One card.** Code, data, materials, external identifiers, linked resources and atmosphere references each had their own layout; none of the differences carried meaning, and the richest of them — the GitHub integration card — was the one seen least often. That is now the shape they all take, each filled with whatever detail its own source can give: `chive-pub/chive` under a GitHub card, the identifier leading an arXiv card, Zenodo's deposit type and access and counts, Software Heritage's archival state, and for an atmosphere reference the application, the record kind, when it appeared and what it said.

**Three link bugs.** A `network.cosmik.card` was linked to `cosmik.network/collection/{did}/{rkey}`, which 404s — a card is not a collection. Every Leaflet reference was linked as a document, comments included, because the indexing plugin files both under one source type. And a talk, a standard.site document or a Margin annotation was offered no link at all. Links are now built from the collection NSID in the record's own URI rather than from Chive's coarser classification; an application's own address is offered only where the route was checked against a live record; and every reference additionally carries a record-browser link, which resolves any AT-URI by reading it from the repository that holds it.

Two smaller fixes fall out of the same pass: a repository the author named without an address vanished while the tab still counted it, and the supplementary materials badge counted uploaded files only, reading "0" above a card for a dataset linked on Layers.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

- Full frontend suite: 176 files, 2920 tests passing. 40 of them new, covering the shared card, the AT-URI resolver, the atmosphere panel and item, the external identifiers panel, and the five integration cards.
- The link-destination fixes are pinned by tests written from the failures seen on production: a Leaflet comment must not be presented as a document, and a Cosmik card must not carry a Cosmik address.
- The external routes offered were checked against live records rather than inferred. `smokesignal.events/{did}/{rkey}` renders a real `community.lexicon.calendar.event` (verified by title); `pdsls.dev/at://…` resolves every record type tried. `cosmik.network/collection/{did}/{rkey}` 404s for a card, so that link is gone.
- Rendered against production data in a local production build: the probe paper's five atmosphere references (Leaflet document, Leaflet comment, Cosmik card, Margin note, Smoke Signal event) each render with the right application, kind, and links, and a second paper's `standard.site` document renders alone without a filter row.
- Responsive: with the content column constrained to 296px — narrower than any phone — the Atmosphere, Data and Metadata tabs each report zero horizontally overflowing elements.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, and `next build` all clean.

## Screenshots

Not attached; the change is described above and visible on any eprint page's Atmosphere tab.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Frontend only: no data flow, schema, or indexing change.

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented