### PR TITLE
Release 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-09-06
+
+### Fixed
+
+- **Citation arrows were drawn on top of the papers.** Lit edges carried an explicit `zIndex`, which lifts an edge out of the layer React Flow draws beneath the nodes, so every highlighted arrow crossed the pills it ran between and cut through their labels. They keep their place above the faded background edges by ordering within that layer instead, which is where the distinction belonged.
+
 ## [0.22.0] - 2026-09-05
 
 ### Added
@@ -1257,7 +1263,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/chive-pub/chive/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/chive-pub/chive/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/chive-pub/chive/compare/v0.20.2...v0.21.0
 [0.20.2]: https://github.com/chive-pub/chive/compare/v0.20.1...v0.20.2

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/web/lib/citations/flow-graph.test.ts
+++ b/web/lib/citations/flow-graph.test.ts
@@ -66,11 +66,21 @@ describe('buildFlowEdges', () => {
     expect(background?.markerEnd).toBeDefined();
   });
 
-  it('paints lit edges above the background ones', () => {
+  it('paints lit edges above the background ones, by ordering', () => {
     const edges = buildFlowEdges(EDGES, assignEdgeRoles(EDGES, { focusUri: 'focus' }));
-    const lit = edges.find((edge) => edge.id === 'focus->ref');
-    const dim = edges.find((edge) => edge.id === 'far->other');
-    expect(lit?.zIndex).toBeGreaterThan(dim?.zIndex ?? 0);
+    const ids = edges.map((edge) => edge.id);
+    // Later in the array is painted higher within the edge layer.
+    expect(ids.indexOf('focus->ref')).toBeGreaterThan(ids.indexOf('far->other'));
+    expect(ids.indexOf('citer->focus')).toBeGreaterThan(ids.indexOf('far->other'));
+  });
+
+  it('leaves every edge in the layer React Flow draws beneath the nodes', () => {
+    // An explicit zIndex lifts an edge out of that layer, which put every lit
+    // arrow on top of the papers it runs between.
+    const edges = buildFlowEdges(EDGES, assignEdgeRoles(EDGES, { focusUri: 'focus' }));
+    for (const edge of edges) {
+      expect(edge.zIndex).toBeUndefined();
+    }
   });
 
   it('runs the edge from the citing paper to the cited one', () => {

--- a/web/lib/citations/flow-graph.ts
+++ b/web/lib/citations/flow-graph.ts
@@ -132,34 +132,41 @@ export function buildFlowEdges(
   citations: readonly NetworkEdge[],
   roles: ReadonlyMap<string, NodeRole>
 ): Edge[] {
-  return citations.map((citation) => {
+  const built = citations.map((citation) => {
     const key = edgeKey(citation);
     const role = roles.get(key) ?? UNRELATED;
     const style = roleStyle(role);
     const lit = role.tier !== 'none';
 
     return {
-      id: key,
-      source: citation.citingUri,
-      target: citation.citedUri,
-      type: 'straight',
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        width: lit ? 18 : 14,
-        height: lit ? 18 : 14,
-        color: style.stroke,
-      },
-      style: {
-        stroke: style.stroke,
-        strokeWidth: lit ? 1.8 : 1,
-        opacity: lit ? 0.9 : 0.25,
-        ...(lit ? {} : { strokeDasharray: '4 4' }),
-      },
-      // Lit edges paint over the background, so a neighbourhood reads as one
-      // shape rather than as lines crossing a mesh.
-      zIndex: lit ? 1 : 0,
+      lit,
+      edge: {
+        id: key,
+        source: citation.citingUri,
+        target: citation.citedUri,
+        type: 'straight',
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: lit ? 18 : 14,
+          height: lit ? 18 : 14,
+          color: style.stroke,
+        },
+        style: {
+          stroke: style.stroke,
+          strokeWidth: lit ? 1.8 : 1,
+          opacity: lit ? 0.9 : 0.25,
+          ...(lit ? {} : { strokeDasharray: '4 4' }),
+        },
+      } satisfies Edge,
     };
   });
+
+  // Lit edges paint over the background ones, so a neighbourhood reads as one
+  // shape rather than as lines crossing a mesh -- but by ordering rather than
+  // by `zIndex`. An explicit zIndex lifts an edge out of the edge layer, which
+  // React Flow draws beneath the nodes, and put every lit arrow on top of the
+  // papers it runs between. Within the layer, later is painted higher.
+  return [...built.filter((e) => !e.lit), ...built.filter((e) => e.lit)].map((e) => e.edge);
 }
 
 /**

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Citation arrows were drawn on top of the papers they run between, cutting through node labels.

The cause was mine, from 0.22.0: lit edges carried an explicit `zIndex` so they would paint above the faded background edges. But an explicit `zIndex` lifts an edge out of the layer React Flow draws beneath the nodes, so it went above the pills as well.

Lit edges keep their place above the background ones by **ordering within the edge layer** instead — later in the array is painted higher — which is where that distinction belonged. Nothing else changes: same colours, widths, opacity, dashing and arrowheads.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

- The stacking contract is now pinned two ways: lit edges must appear later in the array than background ones, and no edge may set a `zIndex` at all. The second test fails against the previous code.
- Rendered against live production data in a production build, on the same paper and the same selected node as the report: edges visibly pass behind the pills, and arrowheads still terminate at the node boundary.
- Full frontend suite green (2994). `pnpm typecheck`, `pnpm format:check` and the OpenAPI check clean.

## Screenshots

Compared before and after on the reported view; the change is the stacking only.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Presentation only; no data flow touched.

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented