### PR TITLE
Release 0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-09-06
+
+### Fixed
+
+- **Citation arrows ran through the papers and overshot them.** Every edge was routed between React Flow handles, and a handle is fixed to one side of its node -- with the target handle at the top, an edge whose cited paper sat _above_ its citing one had to travel up through that paper's body to reach its top edge, crossing the pill and leaving the arrowhead inside it. Edges now compute their own endpoints from the two node outlines, so each meets whichever point faces the other. Nothing overshoots, because the endpoint is the boundary, and nothing enters a node, because the segment stops there. The `zIndex` in 0.22.1 had treated a symptom of this rather than its cause.
+
+- **The line showed through the arrowhead.** The fade on an edge was element `opacity`, which applies to the path and the marker alike, so where the line ran under the arrowhead the two composited and the line read as a darker streak through it. The fade is carried in the stroke colour now, and the arrowhead takes exactly that colour.
+
+### Changed
+
+- **A paper more than one citation away is drawn as a dot, with no label.** At fifty papers the names were the clutter, and at five hundred they would be unreadable; the ones worth reading are those beside the paper in hand or beside whatever the reader has clicked. The rest are the shape of the field, which a dot conveys better than a name nobody is reading. Hovering still gives any paper its full bibliography entry, and a dot grows into a labelled pill the moment it attaches to the focus or the selection.
+
 ## [0.22.1] - 2026-09-06
 
 ### Fixed
@@ -1263,7 +1275,8 @@ Initial release of Chive, a decentralized eprint service built on AT Protocol.
 - Unit test suite with 134 test files covering handlers, services, storage adapters, plugins, and utilities
 - Test infrastructure with Docker test stack, seed data scripts, and cleanup utilities
 
-[Unreleased]: https://github.com/chive-pub/chive/compare/v0.22.1...HEAD
+[Unreleased]: https://github.com/chive-pub/chive/compare/v0.22.2...HEAD
+[0.22.2]: https://github.com/chive-pub/chive/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/chive-pub/chive/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/chive-pub/chive/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/chive-pub/chive/compare/v0.20.2...v0.21.0

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/docs",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "private": true,
   "author": {
     "name": "Aaron Steven White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/monorepo",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "private": true,
   "type": "module",
   "description": "A decentralized eprint service built on AT Protocol",

--- a/web/components/eprints/citation-network/__tests__/network-pieces.test.tsx
+++ b/web/components/eprints/citation-network/__tests__/network-pieces.test.tsx
@@ -37,6 +37,24 @@ describe('NetworkNode', () => {
     expect(screen.getByText('White 2014')).toBeInTheDocument();
   });
 
+  it('draws a paper beyond one citation as a dot, with no text at all', () => {
+    // A few hundred labels is a wall of words. The names worth reading are the
+    // ones beside the paper in hand; the rest are the shape of the field.
+    renderNode({ relation: 'none', tier: 'none' });
+    const node = screen.getByTestId('network-node');
+    expect(node).toHaveAttribute('data-labelled', 'false');
+    expect(node.textContent).toBe('');
+    // Still nameable without reading the canvas.
+    expect(node).toHaveAttribute('aria-label', 'White 2014');
+  });
+
+  it('labels a paper the moment it attaches to the focus or the selection', () => {
+    renderNode({ relation: 'citer', tier: 'secondary' });
+    const node = screen.getByTestId('network-node');
+    expect(node).toHaveAttribute('data-labelled', 'true');
+    expect(screen.getByText('White 2014')).toBeInTheDocument();
+  });
+
   it('records its role, so the colour and the meaning cannot drift apart', () => {
     renderNode({ relation: 'citer', tier: 'secondary' });
     const node = screen.getByTestId('network-node');

--- a/web/components/eprints/citation-network/citation-network.tsx
+++ b/web/components/eprints/citation-network/citation-network.tsx
@@ -33,6 +33,7 @@ import {
   useReactFlow,
   ReactFlowProvider,
   type Edge,
+  type EdgeTypes,
   type Node,
   type NodeTypes,
 } from '@xyflow/react';
@@ -63,6 +64,7 @@ import { formatAuthors, papersByUri } from '@/lib/citations/paper-label';
 import { cn } from '@/lib/utils';
 
 import { NetworkLegend } from './network-legend';
+import { FloatingEdge } from './floating-edge';
 import { NetworkNode } from './network-node';
 import { PaperHoverCard } from './paper-hover-card';
 import { useCitationNetwork } from './use-citation-network';
@@ -77,6 +79,7 @@ export interface CitationNetworkProps {
 }
 
 const nodeTypes: NodeTypes = { paper: NetworkNode };
+const edgeTypes: EdgeTypes = { floating: FloatingEdge };
 
 /**
  * The graph itself.
@@ -263,6 +266,7 @@ function CitationNetworkCanvas({ eprintUri, height = '70vh', className }: Citati
         onNodeMouseLeave={onNodeMouseLeave}
         onInit={onInit}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         // Zooming out to the whole network is the point, so let it go far.
         minZoom={0.05}
         maxZoom={2.5}

--- a/web/components/eprints/citation-network/floating-edge.tsx
+++ b/web/components/eprints/citation-network/floating-edge.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+/**
+ * A citation drawn between the outlines of the two papers.
+ *
+ * @remarks
+ * React Flow's built-in edges run between handles, and a handle is fixed to one
+ * side of its node. With a target handle at the top, every edge arrived at the
+ * top of the cited paper -- so an edge whose target sat above its source ran up
+ * through the target's body, crossing the pill and leaving the arrowhead inside
+ * it. A citation network has no top or bottom; an edge should meet each paper
+ * wherever its outline faces the other one.
+ *
+ * @packageDocumentation
+ */
+
+import { getStraightPath, useInternalNode, type EdgeProps } from '@xyflow/react';
+
+import { floatingEnds, type NodeBox } from '@/lib/citations/edge-geometry';
+
+/**
+ * Reads a node's drawn box out of React Flow's internal state.
+ *
+ * @param node - The internal node, when React Flow has one
+ * @returns Its position and measured size, or null before it is measured
+ *
+ * @remarks
+ * `measured` is what the node actually occupies, which is what the geometry
+ * needs: a background paper is drawn as a small circle and a highlighted one as
+ * a labelled pill, and an edge has to meet each at its own outline.
+ */
+function boxOf(node: ReturnType<typeof useInternalNode>): NodeBox | null {
+  if (!node) return null;
+  const width = node.measured?.width ?? node.width;
+  const height = node.measured?.height ?? node.height;
+  if (width === undefined || height === undefined) return null;
+  return {
+    x: node.internals.positionAbsolute.x,
+    y: node.internals.positionAbsolute.y,
+    width,
+    height,
+  };
+}
+
+/**
+ * Renders one citation.
+ *
+ * @param props - React Flow edge props
+ * @returns The path, or nothing until both ends have been measured
+ *
+ * @public
+ */
+export function FloatingEdge({ id, source, target, markerEnd, style }: EdgeProps) {
+  const sourceBox = boxOf(useInternalNode(source));
+  const targetBox = boxOf(useInternalNode(target));
+
+  if (!sourceBox || !targetBox) return null;
+
+  const ends = floatingEnds(sourceBox, targetBox);
+  const [path] = getStraightPath(ends);
+
+  return (
+    <path
+      id={id}
+      d={path}
+      className="react-flow__edge-path"
+      markerEnd={markerEnd}
+      style={style}
+      fill="none"
+    />
+  );
+}

--- a/web/components/eprints/citation-network/network-node.tsx
+++ b/web/components/eprints/citation-network/network-node.tsx
@@ -15,7 +15,7 @@
 
 import { Handle, Position } from '@xyflow/react';
 
-import { NODE_HEIGHT, NODE_WIDTH, type FlowNodeData } from '@/lib/citations/flow-graph';
+import { DOT_SIZE, NODE_HEIGHT, NODE_WIDTH, type FlowNodeData } from '@/lib/citations/flow-graph';
 import { roleStyle } from '@/lib/citations/network-model';
 
 export type { FlowNodeData as NetworkNodeData };
@@ -31,12 +31,57 @@ export type { FlowNodeData as NetworkNodeData };
 export function NetworkNode({ data, selected }: { data: FlowNodeData; selected?: boolean }) {
   const style = roleStyle(data.role);
   const isAnchor = data.role.relation === 'anchor' && data.role.tier !== 'none';
+  const labelled = data.role.tier !== 'none';
+
+  // React Flow needs a source and a target for an edge to attach to. They are
+  // drawn at zero size and their position is immaterial: the edges compute
+  // their own endpoints from the node outlines, because a citation network has
+  // no direction of flow for a handle to sit on the near side of.
+  const handles = (
+    <>
+      <Handle type="target" position={Position.Top} style={{ opacity: 0, width: 1, height: 1 }} />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        style={{ opacity: 0, width: 1, height: 1 }}
+      />
+    </>
+  );
+
+  // A paper more than one citation away from whatever is being read against is
+  // drawn as a dot. At a few hundred papers the labels are the clutter, and the
+  // ones worth reading are the ones beside the paper in hand; the rest are the
+  // shape of the field, which a dot conveys and a name obscures. Hovering still
+  // names it.
+  if (!labelled) {
+    return (
+      <div
+        data-testid="network-node"
+        data-relation={data.role.relation}
+        data-tier={data.role.tier}
+        data-labelled="false"
+        className="cursor-pointer rounded-full border transition-transform hover:scale-150"
+        style={{
+          background: style.fill,
+          borderColor: style.stroke,
+          opacity: style.opacity,
+          width: DOT_SIZE,
+          height: DOT_SIZE,
+        }}
+        title={data.label}
+        aria-label={data.label}
+      >
+        {handles}
+      </div>
+    );
+  }
 
   return (
     <div
       data-testid="network-node"
       data-relation={data.role.relation}
       data-tier={data.role.tier}
+      data-labelled="true"
       className="cursor-pointer overflow-hidden rounded-full border px-3 text-center text-xs font-medium leading-[26px] transition-transform hover:scale-105"
       style={{
         background: style.fill,
@@ -50,17 +95,8 @@ export function NetworkNode({ data, selected }: { data: FlowNodeData; selected?:
       }}
       title={data.label}
     >
-      {/* React Flow needs a source and a target for an edge to attach to. They
-          are drawn at zero size: a citation network has no natural direction on
-          the page, so an edge should leave a node from wherever the other end
-          happens to be rather than from a fixed side. */}
-      <Handle type="target" position={Position.Top} style={{ opacity: 0, width: 1, height: 1 }} />
+      {handles}
       <span className="block truncate">{data.label}</span>
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        style={{ opacity: 0, width: 1, height: 1 }}
-      />
     </div>
   );
 }

--- a/web/lib/citations/edge-geometry.test.ts
+++ b/web/lib/citations/edge-geometry.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for where a citation edge meets its papers.
+ *
+ * @remarks
+ * The fault these exist for: handles fixed at the top and bottom of a node made
+ * every edge run to the target's top edge, so an edge whose target sat above
+ * its source travelled up through the target's body -- crossing the pill and
+ * putting the arrowhead inside it. The two properties that rule that out are
+ * that each endpoint lies on its own node's outline, and that the segment
+ * between them enters neither node.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { boundaryPoint, centreOf, floatingEnds, type NodeBox } from './edge-geometry';
+
+/** A node of the size the network draws. */
+function box(x: number, y: number, width = 184, height = 26): NodeBox {
+  return { x, y, width, height };
+}
+
+/** Whether a point is strictly inside a node's box. */
+function inside(b: NodeBox, x: number, y: number): boolean {
+  return x > b.x && x < b.x + b.width && y > b.y && y < b.y + b.height;
+}
+
+describe('centreOf', () => {
+  it('is the midpoint of the drawn node', () => {
+    expect(centreOf(box(0, 0, 100, 20))).toEqual({ x: 50, y: 10 });
+  });
+});
+
+describe('boundaryPoint', () => {
+  it('leaves by the right side when the other node is to the right', () => {
+    const b = box(0, 0, 100, 20);
+    const p = boundaryPoint(b, { x: 500, y: 10 });
+    expect(p).toEqual({ x: 100, y: 10 });
+  });
+
+  it('leaves by the left side when the other node is to the left', () => {
+    const b = box(0, 0, 100, 20);
+    expect(boundaryPoint(b, { x: -500, y: 10 })).toEqual({ x: 0, y: 10 });
+  });
+
+  it('leaves by the top when the other node is directly above', () => {
+    const b = box(0, 0, 100, 20);
+    expect(boundaryPoint(b, { x: 50, y: -500 })).toEqual({ x: 50, y: 0 });
+  });
+
+  it('leaves by the bottom when the other node is directly below', () => {
+    const b = box(0, 0, 100, 20);
+    expect(boundaryPoint(b, { x: 50, y: 500 })).toEqual({ x: 50, y: 20 });
+  });
+
+  it('always lands on the outline, never inside or beyond it', () => {
+    const b = box(0, 0, 184, 26);
+    for (let angle = 0; angle < Math.PI * 2; angle += Math.PI / 12) {
+      const target = { x: 92 + Math.cos(angle) * 1000, y: 13 + Math.sin(angle) * 1000 };
+      const p = boundaryPoint(b, target);
+      const onEdge =
+        Math.abs(p.x - b.x) < 0.001 ||
+        Math.abs(p.x - (b.x + b.width)) < 0.001 ||
+        Math.abs(p.y - b.y) < 0.001 ||
+        Math.abs(p.y - (b.y + b.height)) < 0.001;
+      expect(onEdge).toBe(true);
+      expect(inside(b, p.x, p.y)).toBe(false);
+    }
+  });
+
+  it('pushes the point clear of the outline by the padding', () => {
+    const b = box(0, 0, 100, 20);
+    expect(boundaryPoint(b, { x: 500, y: 10 }, 5)).toEqual({ x: 105, y: 10 });
+  });
+
+  it('returns the centre when there is no direction to leave in', () => {
+    const b = box(0, 0, 100, 20);
+    expect(boundaryPoint(b, { x: 50, y: 10 })).toEqual({ x: 50, y: 10 });
+  });
+});
+
+describe('floatingEnds', () => {
+  it('runs between the facing sides of two papers side by side', () => {
+    const ends = floatingEnds(box(0, 0, 100, 20), box(300, 0, 100, 20), 0);
+    expect(ends).toEqual({ sourceX: 100, sourceY: 10, targetX: 300, targetY: 10 });
+  });
+
+  it('points upwards when the cited paper sits above the citing one', () => {
+    // The case the fixed handles got wrong: the edge used to travel up through
+    // the target to reach its top edge.
+    const source = box(0, 500, 100, 20);
+    const target = box(0, 0, 100, 20);
+    const ends = floatingEnds(source, target, 0);
+    // Leaves the source by its top, arrives at the target's bottom.
+    expect(ends.sourceY).toBe(500);
+    expect(ends.targetY).toBe(20);
+  });
+
+  it('never places an endpoint inside either paper', () => {
+    const source = box(0, 0);
+    for (const target of [box(400, 0), box(-400, 0), box(0, 300), box(0, -300), box(250, -180)]) {
+      const ends = floatingEnds(source, target);
+      expect(inside(source, ends.sourceX, ends.sourceY)).toBe(false);
+      expect(inside(target, ends.targetX, ends.targetY)).toBe(false);
+      expect(inside(target, ends.sourceX, ends.sourceY)).toBe(false);
+      expect(inside(source, ends.targetX, ends.targetY)).toBe(false);
+    }
+  });
+
+  it('draws a segment that enters neither paper along its whole length', () => {
+    // Sampled rather than reasoned: this is the property a reader sees.
+    const source = box(0, 0);
+    const target = box(260, -200);
+    const ends = floatingEnds(source, target);
+    for (let t = 0; t <= 1; t += 0.02) {
+      const x = ends.sourceX + (ends.targetX - ends.sourceX) * t;
+      const y = ends.sourceY + (ends.targetY - ends.sourceY) * t;
+      expect(inside(source, x, y)).toBe(false);
+      expect(inside(target, x, y)).toBe(false);
+    }
+  });
+
+  it('leaves clearance at both ends so an arrowhead sits against the border', () => {
+    const ends = floatingEnds(box(0, 0, 100, 20), box(300, 0, 100, 20), 4);
+    expect(ends.sourceX).toBe(104);
+    expect(ends.targetX).toBe(296);
+  });
+});

--- a/web/lib/citations/edge-geometry.ts
+++ b/web/lib/citations/edge-geometry.ts
@@ -1,0 +1,114 @@
+/**
+ * Where a citation edge meets the papers at its ends.
+ *
+ * @remarks
+ * React Flow routes an edge between two handles, and a handle sits at a fixed
+ * side of its node. With a target handle at the top and a source handle at the
+ * bottom -- the arrangement a top-to-bottom flow chart wants -- every edge runs
+ * from the bottom of one paper to the *top* of another, whatever their actual
+ * positions. When the target happens to sit above the source, the line has to
+ * travel up through the target's body to reach its top edge, so it crosses the
+ * pill and the arrowhead lands somewhere inside it.
+ *
+ * A citation network has no such flow. Two papers are wherever the layout put
+ * them, and an edge should leave and arrive at whichever point on each node's
+ * outline faces the other one. That is what these compute, and it fixes both
+ * faults at once: nothing overshoots, because the endpoint is the boundary, and
+ * nothing crosses a node body, because the segment stops there.
+ *
+ * @packageDocumentation
+ */
+
+/** A node as the geometry needs it: where it is and how big it is drawn. */
+export interface NodeBox {
+  /** Left edge, in flow coordinates. */
+  readonly x: number;
+  /** Top edge, in flow coordinates. */
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/** A point in flow coordinates. */
+export interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * The centre of a node.
+ *
+ * @param box - The node
+ * @returns Its midpoint
+ *
+ * @public
+ */
+export function centreOf(box: NodeBox): Point {
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+/**
+ * Where the line towards a point leaves a node's outline.
+ *
+ * @param box - The node the line starts inside
+ * @param towards - The point it heads for
+ * @param padding - How far beyond the outline to sit, in pixels
+ * @returns The boundary point, pushed out by `padding`
+ *
+ * @remarks
+ * A ray from the centre towards `towards`, clipped to the rectangle: whichever
+ * of the vertical and horizontal sides it would reach first is the side it
+ * leaves by. The padding puts an arrowhead's tip against the border rather than
+ * under it.
+ *
+ * Two nodes at the same point have no direction between them, so the centre is
+ * returned unchanged rather than a division by zero.
+ *
+ * @public
+ */
+export function boundaryPoint(box: NodeBox, towards: Point, padding = 0): Point {
+  const centre = centreOf(box);
+  const dx = towards.x - centre.x;
+  const dy = towards.y - centre.y;
+  const distance = Math.hypot(dx, dy);
+  if (distance === 0) return centre;
+
+  const halfWidth = box.width / 2;
+  const halfHeight = box.height / 2;
+  const scaleX = dx === 0 ? Number.POSITIVE_INFINITY : halfWidth / Math.abs(dx);
+  const scaleY = dy === 0 ? Number.POSITIVE_INFINITY : halfHeight / Math.abs(dy);
+  const scale = Math.min(scaleX, scaleY);
+
+  return {
+    x: centre.x + dx * scale + (dx / distance) * padding,
+    y: centre.y + dy * scale + (dy / distance) * padding,
+  };
+}
+
+/** The two ends of an edge. */
+export interface EdgeEnds {
+  readonly sourceX: number;
+  readonly sourceY: number;
+  readonly targetX: number;
+  readonly targetY: number;
+}
+
+/**
+ * The endpoints of a citation, on the outlines of the two papers.
+ *
+ * @param source - The citing paper
+ * @param target - The cited paper
+ * @param padding - Clearance to leave at each end
+ * @returns Coordinates for a straight segment between the two outlines
+ *
+ * @remarks
+ * Each end faces the other node's centre, so the segment lies entirely between
+ * the two papers and touches neither.
+ *
+ * @public
+ */
+export function floatingEnds(source: NodeBox, target: NodeBox, padding = 3): EdgeEnds {
+  const from = boundaryPoint(source, centreOf(target), padding);
+  const to = boundaryPoint(target, centreOf(source), padding);
+  return { sourceX: from.x, sourceY: from.y, targetX: to.x, targetY: to.y };
+}

--- a/web/lib/citations/flow-graph.test.ts
+++ b/web/lib/citations/flow-graph.test.ts
@@ -13,7 +13,16 @@
 import { MarkerType } from '@xyflow/react';
 import { describe, expect, it } from 'vitest';
 
-import { buildFlowEdges, buildFlowNodes, neighbourhoodOf, nodeLabel } from './flow-graph';
+import {
+  buildFlowEdges,
+  buildFlowNodes,
+  DOT_SIZE,
+  neighbourhoodOf,
+  NODE_HEIGHT,
+  NODE_WIDTH,
+  nodeLabel,
+  sizeFor,
+} from './flow-graph';
 import { assignEdgeRoles, NETWORK_COLORS, type NetworkEdge } from './network-model';
 import type { CitedPaper } from './paper-label';
 
@@ -60,10 +69,25 @@ describe('buildFlowEdges', () => {
   it('fades the rest of the network back rather than hiding it', () => {
     const edges = buildFlowEdges(EDGES, assignEdgeRoles(EDGES, { focusUri: 'focus' }));
     const background = edges.find((edge) => edge.id === 'far->other');
-    expect(background?.style?.opacity).toBeLessThan(0.5);
+    expect(background?.style?.stroke).toContain('rgba');
     expect(background?.style?.strokeDasharray).toBe('4 4');
     // Still drawn: it is the context the focus sits in.
     expect(background?.markerEnd).toBeDefined();
+  });
+
+  it('never sets opacity, which would show the line through the arrowhead', () => {
+    // Element opacity applies to the path and the marker alike, so where the
+    // line runs under the arrowhead the two composite and the line shows
+    // through it as a darker streak. The fade goes in the colour instead.
+    for (const edge of buildFlowEdges(EDGES, assignEdgeRoles(EDGES, { focusUri: 'focus' }))) {
+      expect(edge.style?.opacity).toBeUndefined();
+    }
+  });
+
+  it('paints the arrowhead in exactly the colour of its line', () => {
+    for (const edge of buildFlowEdges(EDGES, assignEdgeRoles(EDGES, { focusUri: 'focus' }))) {
+      expect(edge.markerEnd).toMatchObject({ color: edge.style?.stroke });
+    }
   });
 
   it('paints lit edges above the background ones, by ordering', () => {
@@ -80,6 +104,14 @@ describe('buildFlowEdges', () => {
     const edges = buildFlowEdges(EDGES, assignEdgeRoles(EDGES, { focusUri: 'focus' }));
     for (const edge of edges) {
       expect(edge.zIndex).toBeUndefined();
+    }
+  });
+
+  it('routes every edge through the floating type, not a handle-bound one', () => {
+    // A handle is fixed to one side of a node, so a built-in edge whose target
+    // sat above its source ran up through the target's body to reach its top.
+    for (const edge of buildFlowEdges(EDGES, new Map())) {
+      expect(edge.type).toBe('floating');
     }
   });
 
@@ -113,8 +145,15 @@ describe('buildFlowNodes', () => {
   ]);
 
   it('places each paper where the layout put it', () => {
-    const nodes = buildFlowNodes(positions, papers, new Map());
-    expect(nodes.find((node) => node.id === 'ref')?.position).toEqual({ x: 100, y: 40 });
+    // A labelled node sits exactly where the layout put it; an unlabelled dot
+    // is centred on the same point, which is a smaller box at a shifted origin.
+    const roles = new Map([['ref', { relation: 'citer' as const, tier: 'primary' as const }]]);
+    expect(buildFlowNodes(positions, papers, roles).find((n) => n.id === 'ref')?.position).toEqual({
+      x: 100,
+      y: 40,
+    });
+    const dot = buildFlowNodes(positions, papers, new Map()).find((n) => n.id === 'ref');
+    expect(dot!.position.x + DOT_SIZE / 2).toBe(100 + NODE_WIDTH / 2);
   });
 
   it('carries the role through, so the node can paint itself', () => {
@@ -124,6 +163,27 @@ describe('buildFlowNodes', () => {
       relation: 'anchor',
       tier: 'primary',
     });
+  });
+
+  it('draws a labelled paper as a pill and a background one as a dot', () => {
+    // A few hundred labels is a wall of words; the names worth reading are the
+    // ones beside the paper in hand.
+    const roles = new Map([['focus', { relation: 'anchor' as const, tier: 'primary' as const }]]);
+    const nodes = buildFlowNodes(positions, papers, roles);
+    const focus = nodes.find((node) => node.id === 'focus');
+    const background = nodes.find((node) => node.id === 'ref');
+    expect(focus).toMatchObject({ width: NODE_WIDTH, height: NODE_HEIGHT });
+    expect(background).toMatchObject({ width: DOT_SIZE, height: DOT_SIZE });
+  });
+
+  it('centres a dot where its pill would have been', () => {
+    // Otherwise a paper jumps across the canvas when selecting something makes
+    // it grow a label.
+    const roles = new Map([['focus', { relation: 'anchor' as const, tier: 'primary' as const }]]);
+    const labelled = buildFlowNodes(positions, papers, roles).find((n) => n.id === 'focus');
+    const dot = buildFlowNodes(positions, papers, new Map()).find((n) => n.id === 'focus');
+    expect(labelled!.position.x + NODE_WIDTH / 2).toBe(dot!.position.x + DOT_SIZE / 2);
+    expect(labelled!.position.y + NODE_HEIGHT / 2).toBe(dot!.position.y + DOT_SIZE / 2);
   });
 
   it('treats a paper with no role as background rather than dropping it', () => {
@@ -175,5 +235,22 @@ describe('neighbourhoodOf', () => {
 
   it('returns the paper alone when nothing touches it', () => {
     expect(neighbourhoodOf('alone', EDGES)).toEqual(['alone']);
+  });
+});
+
+describe('sizeFor', () => {
+  it('gives a labelled paper the pill and everything else the dot', () => {
+    expect(sizeFor({ relation: 'anchor', tier: 'primary' })).toEqual({
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+    });
+    expect(sizeFor({ relation: 'citer', tier: 'secondary' })).toEqual({
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+    });
+    expect(sizeFor({ relation: 'none', tier: 'none' })).toEqual({
+      width: DOT_SIZE,
+      height: DOT_SIZE,
+    });
   });
 });

--- a/web/lib/citations/flow-graph.ts
+++ b/web/lib/citations/flow-graph.ts
@@ -15,7 +15,7 @@
 
 import { MarkerType, type Edge, type Node } from '@xyflow/react';
 
-import { edgeKey, roleStyle, type NetworkEdge, type NodeRole } from './network-model';
+import { edgeKey, roleStyle, withAlpha, type NetworkEdge, type NodeRole } from './network-model';
 import { formatAuthors, type CitedPaper } from './paper-label';
 
 /** What a network node carries. */
@@ -50,6 +50,34 @@ export const NODE_WIDTH = 184;
  * @public
  */
 export const NODE_HEIGHT = 26;
+
+/**
+ * The diameter of an unlabelled node.
+ *
+ * @remarks
+ * A paper more than one citation from whatever is being read against carries no
+ * text at all. A few dozen names is a network; a few hundred is a wall of
+ * words, and the names worth reading are the ones beside the paper in hand. The
+ * rest are the shape of the field around it, which a dot conveys and a label
+ * obscures.
+ *
+ * @public
+ */
+export const DOT_SIZE = 12;
+
+/**
+ * The size a node is drawn at, which depends on whether it is labelled.
+ *
+ * @param role - The node's place in the network
+ * @returns Its width and height
+ *
+ * @public
+ */
+export function sizeFor(role: NodeRole): { width: number; height: number } {
+  return role.tier === 'none'
+    ? { width: DOT_SIZE, height: DOT_SIZE }
+    : { width: NODE_WIDTH, height: NODE_HEIGHT };
+}
 
 /**
  * Names a paper the way it would be referred to in passing.
@@ -95,18 +123,24 @@ export function buildFlowNodes(
   papers: ReadonlyMap<string, CitedPaper>,
   roles: ReadonlyMap<string, NodeRole>
 ): Node<FlowNodeData>[] {
-  return [...positions.entries()].map(([uri, position]) => ({
-    id: uri,
-    type: 'paper',
-    position,
-    width: NODE_WIDTH,
-    height: NODE_HEIGHT,
-    data: {
-      label: nodeLabel(papers.get(uri), uri),
-      role: roles.get(uri) ?? UNRELATED,
-      uri,
-    },
-  }));
+  return [...positions.entries()].map(([uri, position]) => {
+    const role = roles.get(uri) ?? UNRELATED;
+    const size = sizeFor(role);
+    return {
+      id: uri,
+      type: 'paper',
+      // An unlabelled dot is centred where its pill would have been, so a paper
+      // does not jump across the canvas when selecting something makes it grow
+      // a label.
+      position: {
+        x: position.x + (NODE_WIDTH - size.width) / 2,
+        y: position.y + (NODE_HEIGHT - size.height) / 2,
+      },
+      width: size.width,
+      height: size.height,
+      data: { label: nodeLabel(papers.get(uri), uri), role, uri },
+    };
+  });
 }
 
 /**
@@ -138,23 +172,29 @@ export function buildFlowEdges(
     const style = roleStyle(role);
     const lit = role.tier !== 'none';
 
+    // The fade is carried in the colour rather than in `opacity`. Element
+    // opacity applies to the path and the arrowhead alike, so wherever the line
+    // runs under the marker the two composite together and the line shows
+    // through the arrowhead as a darker streak. One solid colour on both makes
+    // the overlap invisible.
+    const colour = lit ? style.stroke : withAlpha(style.stroke, 0.28);
+
     return {
       lit,
       edge: {
         id: key,
         source: citation.citingUri,
         target: citation.citedUri,
-        type: 'straight',
+        type: 'floating',
         markerEnd: {
           type: MarkerType.ArrowClosed,
           width: lit ? 18 : 14,
           height: lit ? 18 : 14,
-          color: style.stroke,
+          color: colour,
         },
         style: {
-          stroke: style.stroke,
+          stroke: colour,
           strokeWidth: lit ? 1.8 : 1,
-          opacity: lit ? 0.9 : 0.25,
           ...(lit ? {} : { strokeDasharray: '4 4' }),
         },
       } satisfies Edge,

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chive/web",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Three faults in the citation network, reported on the deployed 0.22.1.

**Arrows ran through the papers and overshot them.** The cause was routing, not stacking. React Flow routes an edge between handles, and a handle is fixed to one side of its node — my target handle sat at the top, so an edge whose cited paper was *above* its citing one had to travel up through that paper's body to reach its top edge. That put the line across the pill and the arrowhead inside it. Edges now compute their own endpoints from the two node outlines, meeting whichever point faces the other node. The `zIndex` change in 0.22.1 treated a symptom of this and did not fix it; that `zIndex` is gone.

**The line showed through the arrowhead.** The fade was element `opacity`, which applies to the path and the marker alike, so the two composited where they overlap. The fade lives in the stroke colour now and the arrowhead takes exactly that colour.

**Papers beyond one citation were labelled.** This was in the original brief and I missed it. A paper more than one citation from the focus or the current selection is drawn as a 12px dot with no text; it grows into a labelled pill the moment it attaches to either. Hovering still names any paper in full.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## How Has This Been Tested?

Verified in a browser against live production data before deploying, by measurement rather than by eye — the previous attempt was signed off on a screenshot I read wrongly.

Programmatic checks on the rendered graph, both with and without a paper selected:

- **Overshoot**: 3,800 points sampled along all 190 edges; **0** fell inside the box of either node at that edge's own ends.
- **Stacking**: every point where an edge crosses a third node, resolved with `elementFromPoint` — 72 crossings, **node painted on top in all of them, edge in none**.
- **Labels**: 53 papers, 4 labelled with no selection and 11 with one (4 primary, 7 secondary); **0** unlabelled dots carried any text; dot diameter 12px.
- Arrowheads inspected at magnification: solid, no line visible through them.

Unit coverage: 13 new geometry tests, including that an endpoint always lands on the outline and never inside it, and that a sampled segment between two papers enters neither. Plus tests that no edge sets `opacity`, that every arrowhead matches its line's colour, that every edge uses the floating type, and that a background node renders no text.

Full frontend suite 3015 green. `pnpm typecheck` (both projects), `pnpm format:check`, `pnpm lint` (0 errors) and the OpenAPI check all clean.

## Screenshots

Compared against the reported view at the same zoom and the same selected node.

## Checklist

### General

- [x] I have performed a self-review of my code
- [x] Code follows style guide (`npm run lint` passes)
- [x] Tests added/updated for changes
- [x] All new and existing tests pass (`npm test`)
- [x] Documentation updated (if applicable)

### ATProto Compliance (required for data flow changes)

- [x] Compliance tests pass (`npm run test:compliance` — 100% required)
- [x] No writes to user PDSes
- [x] BlobRef storage only (never blob data)
- [x] Indexes can be rebuilt from firehose
- [x] PDS source is tracked for staleness detection

Presentation only; no data flow touched.

### Breaking Changes

- [x] N/A — no breaking changes
- [ ] Migration path documented